### PR TITLE
Feat: bowser intercompany adjustments — summary, ex/shortage, cashflo…

### DIFF
--- a/db/migrations/bowser-intercompany-adjustments.sql
+++ b/db/migrations/bowser-intercompany-adjustments.sql
@@ -1,0 +1,584 @@
+-- ============================================================
+-- Bowser Intercompany Adjustments
+-- Updates CALCULATE_EXSHORTAGE and generate_cashflow to
+-- account for bowser fill quantities (t_closing_intercompany).
+--
+-- The intercompany fill goes through the SFS nozzle, so it
+-- appears in t_reading (adds to revenue). But the SFS cashier
+-- does NOT collect cash for it — it is an intercompany transfer.
+-- These adjustments prevent the bowser fill from creating a
+-- false shortage in ex/shortage and from inflating the
+-- cashflow collection amount.
+--
+-- Safe to re-run: uses DROP FUNCTION/PROCEDURE IF EXISTS.
+-- ============================================================
+
+
+-- ── 1. CALCULATE_EXSHORTAGE ───────────────────────────────────────────────────
+
+DROP FUNCTION IF EXISTS `CALCULATE_EXSHORTAGE`;
+
+DELIMITER ;;
+
+CREATE DEFINER=`petromath_prod`@`%` FUNCTION `CALCULATE_EXSHORTAGE`(p_closing_id INT) RETURNS decimal(10,2)
+BEGIN
+    DECLARE amt              DECIMAL(10,2);
+    DECLARE creditamt        DECIMAL(10,2);
+    DECLARE cashasaleamt     DECIMAL(10,2);
+    DECLARE pumpdiscountamt  DECIMAL(10,2);
+    DECLARE digitalsaleamt   DECIMAL(10,2);
+    DECLARE twotoilamt       DECIMAL(10,2);
+    DECLARE expenseamt       DECIMAL(10,2);
+    DECLARE denomamt         DECIMAL(10,2);
+    DECLARE closingcashgiven DECIMAL(10,2);
+    DECLARE intercompanyamt  DECIMAL(10,2);
+    DECLARE ex_short_amt     DECIMAL(10,2);
+
+    -- Reading amount
+    SELECT COALESCE(SUM((closing_reading - opening_reading - testing) * price), 0)
+    INTO amt
+    FROM t_reading
+    WHERE closing_id = p_closing_id;
+
+    -- Credit amount for pump products in this closing
+    SELECT COALESCE(SUM(tc.price * tc.qty), 0) INTO creditamt
+    FROM t_credits tc
+    INNER JOIN m_product mp ON tc.product_id = mp.product_id
+    INNER JOIN (
+        SELECT DISTINCT mp2.product_code
+        FROM t_reading tr
+        INNER JOIN m_pump mp2 ON tr.pump_id = mp2.pump_id
+        WHERE tr.closing_id = p_closing_id
+    ) pump_products ON mp.product_name = pump_products.product_code
+    WHERE tc.closing_id = p_closing_id;
+
+    -- Cash sales for NON-PUMP products in this closing
+    SELECT COALESCE(SUM((cs.price - cs.price_discount) * cs.qty), 0) INTO cashasaleamt
+    FROM t_cashsales cs
+    INNER JOIN m_product mp ON cs.product_id = mp.product_id
+    WHERE cs.closing_id = p_closing_id
+      AND mp.product_name NOT IN (
+          SELECT DISTINCT mp2.product_code
+          FROM t_reading tr
+          INNER JOIN m_pump mp2 ON tr.pump_id = mp2.pump_id
+          WHERE tr.closing_id = p_closing_id
+      );
+
+    -- Discount amount for PUMP products in this closing
+    SELECT COALESCE(SUM(cs.price_discount * cs.qty), 0) INTO pumpdiscountamt
+    FROM t_cashsales cs
+    INNER JOIN m_product mp ON cs.product_id = mp.product_id
+    WHERE cs.closing_id = p_closing_id
+      AND mp.product_name IN (
+          SELECT DISTINCT mp2.product_code
+          FROM t_reading tr
+          INNER JOIN m_pump mp2 ON tr.pump_id = mp2.pump_id
+          WHERE tr.closing_id = p_closing_id
+      );
+
+    SELECT COALESCE(SUM(price * (given_qty - returned_qty)), 0) INTO twotoilamt
+    FROM t_2toil WHERE closing_id = p_closing_id;
+
+    SELECT COALESCE(SUM(amount), 0) INTO expenseamt
+    FROM t_expense WHERE closing_id = p_closing_id;
+
+    SELECT COALESCE(SUM(IF(denomination = '0', 1, denomination) * denomcount), 0) INTO denomamt
+    FROM t_denomination WHERE closing_id = p_closing_id;
+
+    SELECT COALESCE(cash, 0) INTO closingcashgiven
+    FROM t_closing WHERE closing_id = p_closing_id;
+
+    SELECT COALESCE(SUM(amount), 0) INTO digitalsaleamt
+    FROM t_digital_sales WHERE closing_id = p_closing_id;
+
+    -- Intercompany (bowser fill) amount for this closing
+    -- Valued at the weighted-average nozzle price for each product
+    SELECT COALESCE(SUM(
+        tci.quantity * (
+            SELECT AVG(tr.price)
+            FROM t_reading tr
+            JOIN m_pump mp ON tr.pump_id = mp.pump_id
+            JOIN m_product mp2 ON mp.product_code = mp2.product_name
+            WHERE tr.closing_id = p_closing_id
+              AND mp2.product_id = tci.product_id
+        )
+    ), 0) INTO intercompanyamt
+    FROM t_closing_intercompany tci
+    WHERE tci.closing_id = p_closing_id;
+
+    SET ex_short_amt = COALESCE(expenseamt, 0) + COALESCE(denomamt, 0) + COALESCE(creditamt, 0)
+                     + COALESCE(digitalsaleamt, 0) + COALESCE(pumpdiscountamt, 0)
+                     + COALESCE(intercompanyamt, 0)         -- bowser fill is "accounted for" like credit
+                     - COALESCE(amt, 0) - COALESCE(twotoilamt, 0) - COALESCE(cashasaleamt, 0)
+                     - COALESCE(closingcashgiven, 0);
+
+    RETURN ex_short_amt;
+END ;;
+
+DELIMITER ;
+
+
+-- ── 2. generate_cashflow ──────────────────────────────────────────────────────
+--
+-- Only the Collection calculation block is changed:
+-- subtract intercompany fill value from the collection amount so the
+-- bowser-nozzle throughput does not inflate the SFS cashflow collection.
+--
+-- Full procedure redefine (same pattern as the dump).
+-- NOTE: This intentionally redefines the full procedure so the file is
+-- self-contained and safe to re-run.
+
+DROP PROCEDURE IF EXISTS `generate_cashflow`;
+
+DELIMITER ;;
+
+CREATE DEFINER=`petromath_prod`@`%` PROCEDURE `generate_cashflow`(IN p_cashflow_id INT)
+BEGIN
+
+    DECLARE creditamount INT DEFAULT 0;
+    DECLARE totalamount INT DEFAULT 0;
+    DECLARE CashSaleamount INT DEFAULT 0;
+    DECLARE l_pump_discount DECIMAL(20,2) DEFAULT 0;
+    DECLARE diaryclosecnt INT DEFAULT 0;
+    DECLARE l_location_code VARCHAR(50);
+    DECLARE d_cashflow_date DATE;
+    DECLARE l_closing_id INT;
+    DECLARE exit_loop BOOLEAN;
+    DECLARE l_tran_type, l_remarks VARCHAR(500);
+    DECLARE l_amount DECIMAL(20,2);
+    DECLARE l_digital_amount DECIMAL(20,2);
+    DECLARE l_intercompany_amount DECIMAL(20,2) DEFAULT 0;
+    DECLARE l_oil_amount, l_given_qty, l_cash_bf, l_credits, l_debits DECIMAL(20,2);
+    DECLARE l_session_id VARCHAR(50);
+    DECLARE l_prev_cashflow_date DATE;
+    DECLARE l_collection_desc VARCHAR(200);
+    DECLARE l_min_date, l_max_date DATE;
+
+    -- Cursors
+    DECLARE cur_closing_id CURSOR FOR
+        SELECT closing_id
+        FROM t_closing
+        WHERE location_code = l_location_code
+          AND closing_status = 'CLOSED'
+          AND (cashflow_id IS NULL OR cashflow_id = p_cashflow_id)
+          AND DATE(closing_date) >= DATE_SUB(d_cashflow_date, INTERVAL 1 DAY)
+          AND DATE(closing_date) <= d_cashflow_date;
+
+    DECLARE cur_cash_receipts CURSOR FOR
+        SELECT tr.amount,
+               CONCAT(COALESCE(mcl.short_name, mcl.company_name), ' - Receipt No: ', tr.receipt_no) AS remarks
+        FROM t_receipts tr
+        JOIN m_credit_list mcl ON tr.creditlist_id = mcl.creditlist_id
+        WHERE tr.receipt_type = 'Cash'
+          AND tr.location_code = l_location_code
+          AND tr.cashflow_date IS NULL
+          AND (
+              tr.pending_cashflow_id IS NULL
+              OR NOT EXISTS (
+                  SELECT 1 FROM t_cashflow_closing tcc
+                  WHERE tcc.cashflow_id = tr.pending_cashflow_id
+              )
+          )
+          AND DATE(tr.receipt_date) <= d_cashflow_date;
+
+    DECLARE cur_cash_expense CURSOR FOR
+        SELECT CONCAT(me.expense_name,'  ',te.notes) AS remarks,
+               SUM(te.amount) AS amount
+        FROM t_expense te
+        JOIN m_expense me ON te.expense_id = me.expense_id
+        JOIN t_closing tc ON tc.closing_id = te.closing_id
+        WHERE tc.location_code = l_location_code
+          AND tc.closing_id IN (SELECT closing_id
+                                FROM t_cashflow_generation_temp
+                                WHERE session_id = l_session_id)
+          AND tc.closing_status = 'CLOSED'
+        GROUP BY me.expense_name, te.notes;
+
+    DECLARE cur_tt_expense CURSOR FOR
+        SELECT CONCAT(tte.truck_number,'---',tte.expense,'---',tte.qty) AS remarks,
+               tte.amount
+        FROM t_truckexpense_v tte
+        WHERE tte.location_code = l_location_code
+          AND DATE(tte.expense_date) = d_cashflow_date
+          AND tte.payment_name = 'Cash';
+
+    DECLARE cur_salary_payout CURSOR FOR
+        SELECT CONCAT(emp.name, ' (', ep.txn_type, ')') AS remarks,
+               ep.amount
+        FROM t_employee_payable ep
+        JOIN m_employee emp ON ep.employee_id = emp.employee_id
+        WHERE ep.location_code = l_location_code
+          AND ep.cashflow_date IS NULL
+          AND (
+              ep.pending_cashflow_id IS NULL
+              OR NOT EXISTS (
+                  SELECT 1 FROM t_cashflow_closing tcc
+                  WHERE tcc.cashflow_id = ep.pending_cashflow_id
+              )
+          )
+          AND DATE(ep.txn_date) <= d_cashflow_date
+          AND ep.txn_type       IN ('ADVANCE', 'PAYMENT')
+          AND ep.deleted_flag   = 'N';
+
+    DECLARE cur_salary_recovery CURSOR FOR
+        SELECT CONCAT(emp.name, ' - Recovery') AS remarks,
+               ep.amount
+        FROM t_employee_payable ep
+        JOIN m_employee emp ON ep.employee_id = emp.employee_id
+        WHERE ep.location_code = l_location_code
+          AND ep.cashflow_date IS NULL
+          AND (
+              ep.pending_cashflow_id IS NULL
+              OR NOT EXISTS (
+                  SELECT 1 FROM t_cashflow_closing tcc
+                  WHERE tcc.cashflow_id = ep.pending_cashflow_id
+              )
+          )
+          AND DATE(ep.txn_date) <= d_cashflow_date
+          AND ep.txn_type       = 'ADVANCE_RECOVERY'
+          AND ep.deleted_flag   = 'N';
+
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET exit_loop = TRUE;
+
+    SET l_session_id = CONCAT(CONNECTION_ID(), '_', p_cashflow_id, '_', NOW());
+
+    DELETE FROM t_cashflow_generation_temp WHERE session_id = l_session_id;
+    DELETE FROM t_debug_msg;
+    DELETE FROM t_cashflow_transaction
+     WHERE cashflow_id = p_cashflow_id AND calc_flag = 'Y';
+    UPDATE t_receipts SET pending_cashflow_id = NULL
+    WHERE pending_cashflow_id = p_cashflow_id;
+    UPDATE t_employee_payable SET pending_cashflow_id = NULL
+    WHERE pending_cashflow_id = p_cashflow_id;
+
+    SELECT location_code, cashflow_date
+    INTO l_location_code, d_cashflow_date
+    FROM t_cashflow_closing
+    WHERE cashflow_id = p_cashflow_id;
+
+    SET exit_loop = FALSE;
+    OPEN cur_closing_id;
+    build_closing_list: LOOP
+        FETCH cur_closing_id INTO l_closing_id;
+        IF exit_loop THEN
+            CLOSE cur_closing_id;
+            LEAVE build_closing_list;
+        END IF;
+        INSERT INTO t_cashflow_generation_temp (session_id, closing_id)
+        VALUES (l_session_id, l_closing_id);
+    END LOOP build_closing_list;
+
+    -- Previous cashflow balance
+    SELECT prev_date,
+           COALESCE(credits, 0) - COALESCE(debits, 0) AS balance_bf
+    INTO l_prev_cashflow_date, l_cash_bf
+    FROM (
+        SELECT MAX(tcc.cashflow_date) AS prev_date,
+               (SELECT COALESCE(SUM(tct.amount), 0)
+                FROM t_cashflow_transaction tct
+                JOIN m_lookup ml ON ml.lookup_type = 'CashFlow'
+                                AND ml.description = tct.type
+                                AND ml.tag = 'IN'
+                                AND ml.location_code = l_location_code
+                JOIN t_cashflow_closing tcc2 ON tct.cashflow_id = tcc2.cashflow_id
+                                           AND tcc2.location_code = l_location_code
+                WHERE tcc2.cashflow_date = MAX(tcc.cashflow_date)
+               ) AS credits,
+               (SELECT COALESCE(SUM(tct.amount), 0)
+                FROM t_cashflow_transaction tct
+                JOIN m_lookup ml ON ml.lookup_type = 'CashFlow'
+                                AND ml.description = tct.type
+                                AND ml.tag = 'OUT'
+                                AND ml.location_code = l_location_code
+                JOIN t_cashflow_closing tcc2 ON tct.cashflow_id = tcc2.cashflow_id
+                                           AND tcc2.location_code = l_location_code
+                WHERE tcc2.cashflow_date = MAX(tcc.cashflow_date)
+               ) AS debits
+        FROM t_cashflow_closing tcc
+        WHERE tcc.location_code = l_location_code
+          AND tcc.cashflow_date < d_cashflow_date
+          AND tcc.cashflow_id != p_cashflow_id
+    ) prev_data;
+
+    IF l_prev_cashflow_date IS NOT NULL THEN
+        SET l_remarks = CONCAT('From Day Close Dated:  ', DATE_FORMAT(l_prev_cashflow_date, '%d/%m/%Y'));
+    ELSE
+        SET l_remarks = 'Opening Balance - No previous cashflow';
+        SET l_cash_bf = 0;
+    END IF;
+
+    INSERT INTO t_cashflow_transaction(cashflow_id, description, type, amount, calc_flag)
+    VALUES(p_cashflow_id, l_remarks, 'Balance B/F', l_cash_bf, 'Y');
+
+    IF(l_location_code <> 'MCA') THEN
+
+        -- Collection: total nozzle sale minus credit
+        SELECT SUM(totalsalamt) - SUM(COALESCE(crsaleamtwithoutdisc,0))
+        INTO l_amount
+        FROM (
+            SELECT product_code,
+                   SUM(ROUND(total_amt,2)) AS totalsalamt,
+                   (SELECT SUM(ROUND(tcr.qty * tcr.price,2))
+                    FROM t_credits tcr
+                    JOIN m_product mp ON tcr.product_id = mp.product_id
+                    JOIN t_closing tc ON tcr.closing_id = tc.closing_id
+                    WHERE tc.location_code = l_location_code
+                      AND tc.closing_id IN (SELECT closing_id
+                                            FROM t_cashflow_generation_temp
+                                            WHERE session_id = l_session_id)
+                      AND tc.closing_status = 'CLOSED'
+                      AND mp.product_name = a.product_code
+                    GROUP BY mp.product_name) AS crsaleamtwithoutdisc
+            FROM (
+                SELECT mp.pump_code,
+                       mp.product_code,
+                       SUM((tr.closing_reading - tr.opening_reading - tr.testing) * price) AS total_amt
+                FROM t_reading tr
+                JOIN m_pump mp ON tr.pump_id = mp.pump_id
+                JOIN t_closing tc ON tr.closing_id = tc.closing_id
+                WHERE tc.location_code = l_location_code
+                  AND tc.closing_id IN (SELECT closing_id
+                                        FROM t_cashflow_generation_temp
+                                        WHERE session_id = l_session_id)
+                  AND tc.closing_status = 'CLOSED'
+                GROUP BY mp.pump_code, mp.product_code
+            ) a
+            GROUP BY product_code
+        ) c;
+
+        -- Oil amount (2T Loose / Pouch + non-pump cash sales)
+        SELECT ROUND(SUM(a.cash_amt),2) INTO l_oil_amount
+        FROM (
+            SELECT (given_qty - returned_qty) *
+                   CASE
+                     WHEN l_location_code IN ('MC','MUE','MC2','MME')
+                       THEN (SELECT price
+                               FROM m_product
+                               WHERE product_name = 'DSR - OIL'
+                                 AND location_code = l_location_code)
+                     ELSE tc.price
+                   END AS cash_amt
+            FROM t_2toil tc
+            JOIN m_product mp ON tc.product_id = mp.product_id
+            JOIN t_closing tcl ON tc.closing_id = tcl.closing_id
+            WHERE UPPER(mp.product_name) = '2T LOOSE'
+              AND tcl.location_code = l_location_code
+              AND tcl.closing_id IN (SELECT closing_id
+                                     FROM t_cashflow_generation_temp
+                                     WHERE session_id = l_session_id)
+              AND tcl.closing_status = 'CLOSED'
+
+            UNION ALL
+            SELECT (given_qty - returned_qty) * mp.price
+            FROM t_2toil tc
+            JOIN m_product mp ON tc.product_id = mp.product_id
+            JOIN t_closing tcl ON tc.closing_id = tcl.closing_id
+            WHERE UPPER(mp.product_name) = '2T POUCH'
+              AND tcl.location_code = l_location_code
+              AND tcl.closing_id IN (SELECT closing_id
+                                     FROM t_cashflow_generation_temp
+                                     WHERE session_id = l_session_id)
+              AND tcl.closing_status = 'CLOSED'
+
+            UNION ALL
+            SELECT tc.amount
+            FROM t_cashsales tc
+            JOIN m_product mp ON tc.product_id = mp.product_id
+            JOIN t_closing tcl ON tc.closing_id = tcl.closing_id
+            WHERE mp.product_name NOT IN (
+                      SELECT DISTINCT mp2.product_code
+                      FROM t_reading tr
+                      JOIN m_pump mp2 ON tr.pump_id = mp2.pump_id
+                      WHERE tr.closing_id = tcl.closing_id
+                  )
+              AND tcl.location_code = l_location_code
+              AND tcl.closing_id IN (SELECT closing_id
+                                     FROM t_cashflow_generation_temp
+                                     WHERE session_id = l_session_id)
+              AND tcl.closing_status = 'CLOSED'
+        ) a;
+
+        -- Digital sales
+        SELECT COALESCE(SUM(tds.amount), 0)
+        INTO l_digital_amount
+        FROM t_digital_sales tds
+        JOIN t_closing tc ON tds.closing_id = tc.closing_id
+        WHERE tc.location_code = l_location_code
+          AND tc.closing_id IN (SELECT closing_id
+                                FROM t_cashflow_generation_temp
+                                WHERE session_id = l_session_id)
+          AND tc.closing_status = 'CLOSED';
+
+        -- Intercompany (bowser fills) — deducted from collection
+        -- Valued at weighted-average nozzle price per product per closing
+        SELECT COALESCE(SUM(
+            tci.quantity * (
+                SELECT AVG(tr.price)
+                FROM t_reading tr
+                JOIN m_pump mp ON tr.pump_id = mp.pump_id
+                JOIN m_product mp2 ON mp.product_code = mp2.product_name
+                WHERE tr.closing_id = tci.closing_id
+                  AND mp2.product_id = tci.product_id
+            )
+        ), 0)
+        INTO l_intercompany_amount
+        FROM t_closing_intercompany tci
+        JOIN t_closing tc ON tci.closing_id = tc.closing_id
+        WHERE tc.location_code = l_location_code
+          AND tc.closing_id IN (SELECT closing_id
+                                FROM t_cashflow_generation_temp
+                                WHERE session_id = l_session_id)
+          AND tc.closing_status = 'CLOSED';
+
+        SET l_amount = COALESCE(l_amount,0)
+                     + COALESCE(l_oil_amount,0)
+                     - COALESCE(l_digital_amount,0)
+                     - COALESCE(l_intercompany_amount,0);
+
+        SELECT MIN(DATE(tc.closing_date)), MAX(DATE(tc.closing_date))
+        INTO l_min_date, l_max_date
+        FROM t_closing tc
+        WHERE tc.closing_id IN (SELECT closing_id
+                                FROM t_cashflow_generation_temp
+                                WHERE session_id = l_session_id);
+
+        IF l_min_date = l_max_date THEN
+            SET l_collection_desc = CONCAT('From Closing: ', DATE_FORMAT(l_min_date, '%d/%m/%Y'));
+        ELSE
+            SET l_collection_desc = CONCAT('From Closings: ', DATE_FORMAT(l_min_date, '%d/%m/%Y'),
+                                           ' to ', DATE_FORMAT(l_max_date, '%d/%m/%Y'));
+        END IF;
+
+        INSERT INTO t_cashflow_transaction(cashflow_id, description, type, amount, calc_flag)
+        VALUES(p_cashflow_id, l_collection_desc, 'Collection', l_amount, 'Y');
+
+        INSERT INTO t_debug_msg(creation_date, module, msg)
+        VALUES(NOW(),'Generate Cashflow collection', l_amount);
+
+        -- 2T Oil adjustment (only for specific locations)
+        IF l_location_code IN ('MC2','MME','MC','MUE') THEN
+            SELECT SUM(tt.given_qty - tt.returned_qty),
+                   SUM(tt.given_qty - tt.returned_qty) *
+                       (MAX(mp.price) - (SELECT mp2.price
+                                         FROM m_product mp2
+                                         WHERE mp2.product_name = 'DSR - OIL'
+                                           AND mp2.location_code = l_location_code))
+            INTO l_remarks, l_oil_amount
+            FROM t_2toil tt
+            JOIN t_closing tc ON tc.closing_id = tt.closing_id
+            JOIN m_product mp ON tt.product_id = mp.product_id
+            WHERE tc.location_code = l_location_code
+              AND tc.closing_id IN (SELECT closing_id
+                                    FROM t_cashflow_generation_temp
+                                    WHERE session_id = l_session_id)
+              AND tc.closing_status = 'CLOSED'
+              AND mp.product_name = '2T LOOSE';
+
+            IF COALESCE(l_oil_amount, 0) <> 0 THEN
+                INSERT INTO t_cashflow_transaction(cashflow_id, description, type, amount, calc_flag)
+                VALUES(p_cashflow_id,
+                       CONCAT('2T Loose Qty:', COALESCE(l_remarks,'0')),
+                       '2T Loose Adjustment', l_oil_amount, 'Y');
+            END IF;
+        END IF;
+
+    END IF; -- end IF(l_location_code <> 'MCA')
+
+    -- Cash receipts
+    SET exit_loop = FALSE;
+    OPEN cur_cash_receipts;
+    cash_receipts_loop: LOOP
+        FETCH cur_cash_receipts INTO l_amount, l_remarks;
+        IF exit_loop THEN
+            CLOSE cur_cash_receipts;
+            LEAVE cash_receipts_loop;
+        END IF;
+        INSERT INTO t_cashflow_transaction(cashflow_id, description, type, amount, calc_flag)
+        VALUES(p_cashflow_id, l_remarks, 'Receipt', l_amount, 'Y');
+        UPDATE t_receipts SET pending_cashflow_id = p_cashflow_id
+        WHERE receipt_type = 'Cash'
+          AND location_code = l_location_code
+          AND cashflow_date IS NULL
+          AND (pending_cashflow_id IS NULL
+               OR NOT EXISTS (SELECT 1 FROM t_cashflow_closing tcc WHERE tcc.cashflow_id = pending_cashflow_id))
+          AND DATE(receipt_date) <= d_cashflow_date
+          AND CONCAT(COALESCE((SELECT short_name FROM m_credit_list WHERE creditlist_id = creditlist_id),''),
+                     (SELECT company_name FROM m_credit_list WHERE creditlist_id = creditlist_id),
+                     ' - Receipt No: ', receipt_no) = l_remarks;
+    END LOOP cash_receipts_loop;
+
+    -- Cash expenses
+    SET exit_loop = FALSE;
+    OPEN cur_cash_expense;
+    cash_expense_loop: LOOP
+        FETCH cur_cash_expense INTO l_remarks, l_amount;
+        IF exit_loop THEN
+            CLOSE cur_cash_expense;
+            LEAVE cash_expense_loop;
+        END IF;
+        INSERT INTO t_cashflow_transaction(cashflow_id, description, type, amount, calc_flag)
+        VALUES(p_cashflow_id, l_remarks, 'Expense', l_amount, 'Y');
+    END LOOP cash_expense_loop;
+
+    -- Truck expenses
+    SET exit_loop = FALSE;
+    OPEN cur_tt_expense;
+    tt_expense_loop: LOOP
+        FETCH cur_tt_expense INTO l_remarks, l_amount;
+        IF exit_loop THEN
+            CLOSE cur_tt_expense;
+            LEAVE tt_expense_loop;
+        END IF;
+        INSERT INTO t_cashflow_transaction(cashflow_id, description, type, amount, calc_flag)
+        VALUES(p_cashflow_id, l_remarks, 'TT Expense', l_amount, 'Y');
+    END LOOP tt_expense_loop;
+
+    -- Salary payouts
+    SET exit_loop = FALSE;
+    OPEN cur_salary_payout;
+    salary_payout_loop: LOOP
+        FETCH cur_salary_payout INTO l_remarks, l_amount;
+        IF exit_loop THEN
+            CLOSE cur_salary_payout;
+            LEAVE salary_payout_loop;
+        END IF;
+        INSERT INTO t_cashflow_transaction(cashflow_id, description, type, amount, calc_flag)
+        VALUES(p_cashflow_id, l_remarks, 'Salary', l_amount, 'Y');
+        UPDATE t_employee_payable SET pending_cashflow_id = p_cashflow_id
+        WHERE location_code = l_location_code
+          AND cashflow_date IS NULL
+          AND (pending_cashflow_id IS NULL
+               OR NOT EXISTS (SELECT 1 FROM t_cashflow_closing tcc WHERE tcc.cashflow_id = pending_cashflow_id))
+          AND DATE(txn_date) <= d_cashflow_date
+          AND txn_type IN ('ADVANCE','PAYMENT')
+          AND deleted_flag = 'N';
+    END LOOP salary_payout_loop;
+
+    -- Salary recoveries
+    SET exit_loop = FALSE;
+    OPEN cur_salary_recovery;
+    salary_recovery_loop: LOOP
+        FETCH cur_salary_recovery INTO l_remarks, l_amount;
+        IF exit_loop THEN
+            CLOSE cur_salary_recovery;
+            LEAVE salary_recovery_loop;
+        END IF;
+        INSERT INTO t_cashflow_transaction(cashflow_id, description, type, amount, calc_flag)
+        VALUES(p_cashflow_id, l_remarks, 'Salary Recovery', l_amount, 'Y');
+        UPDATE t_employee_payable SET pending_cashflow_id = p_cashflow_id
+        WHERE location_code = l_location_code
+          AND cashflow_date IS NULL
+          AND (pending_cashflow_id IS NULL
+               OR NOT EXISTS (SELECT 1 FROM t_cashflow_closing tcc WHERE tcc.cashflow_id = pending_cashflow_id))
+          AND DATE(txn_date) <= d_cashflow_date
+          AND txn_type = 'ADVANCE_RECOVERY'
+          AND deleted_flag = 'N';
+    END LOOP salary_recovery_loop;
+
+    DELETE FROM t_cashflow_generation_temp WHERE session_id = l_session_id;
+
+END ;;
+
+DELIMITER ;
+
+SELECT 'Bowser intercompany adjustments applied: CALCULATE_EXSHORTAGE and generate_cashflow updated.' AS status;

--- a/db/migrations/generate-day-bill-procedure.sql
+++ b/db/migrations/generate-day-bill-procedure.sql
@@ -21,6 +21,11 @@ generate_day_bill_sp: BEGIN
     DECLARE v_pump_count        INT           DEFAULT 0;
     DECLARE v_oil_count         INT           DEFAULT 0;
 
+    -- Consolidation threshold (read from config; default 20000)
+    DECLARE v_threshold         DECIMAL(15,2) DEFAULT 20000;
+    DECLARE v_primary_vendor_id INT           DEFAULT NULL;
+    DECLARE v_is_consolidated   TINYINT(1)    DEFAULT 0;
+
     -- Cursor variables for digital vendor loop
     DECLARE v_vendor_id         INT;
     DECLARE v_vendor_name       VARCHAR(255);
@@ -36,10 +41,14 @@ generate_day_bill_sp: BEGIN
     DROP TEMPORARY TABLE IF EXISTS tmp_db_pump;
     DROP TEMPORARY TABLE IF EXISTS tmp_db_oil;
     DROP TEMPORARY TABLE IF EXISTS tmp_db_cashsale;
+    DROP TEMPORARY TABLE IF EXISTS tmp_db_intercompany;
     DROP TEMPORARY TABLE IF EXISTS tmp_db_credit;
     DROP TEMPORARY TABLE IF EXISTS tmp_db_digital;
     DROP TEMPORARY TABLE IF EXISTS tmp_db_dig_items;
     DROP TEMPORARY TABLE IF EXISTS tmp_db_bill_numbers;
+    DROP TEMPORARY TABLE IF EXISTS tmp_db_cons_dominant;
+    DROP TEMPORARY TABLE IF EXISTS tmp_db_cons_assign;
+    DROP TEMPORARY TABLE IF EXISTS tmp_db_primary_items;
 
     -- ── 1. Reading-product pump quantities for the day ───────────────────────
     --    Weighted-average price across all shifts closed on p_bill_date.
@@ -131,11 +140,29 @@ generate_day_bill_sp: BEGIN
       AND cs.product_id IN (SELECT product_id FROM tmp_db_pump)
     GROUP BY cs.product_id;
 
-    -- ── 5. Compute net_qty = pumped - cashsales (floor at 0) ─────────────────
+    -- ── 4b. Intercompany fill quantities (bowser fills — excluded from billable qty) ──
+    --     Bowser fills at the SFS nozzle appear in pumped_qty but are NOT
+    --     sold to any retail customer; they must be subtracted like cashsales.
+    CREATE TEMPORARY TABLE tmp_db_intercompany
+    SELECT
+        tci.product_id,
+        CAST(SUM(tci.quantity) AS DECIMAL(12,3)) AS intercompany_qty
+    FROM t_closing_intercompany tci
+    JOIN t_closing c ON tci.closing_id = c.closing_id
+    WHERE c.location_code = p_location_code
+      AND DATE(c.closing_date) = p_bill_date
+      AND c.closing_status = 'CLOSED'
+      AND tci.product_id IN (SELECT product_id FROM tmp_db_pump)
+    GROUP BY tci.product_id;
+
+    -- ── 5. Compute net_qty = pumped - cashsales - intercompany (floor at 0) ─────
     UPDATE tmp_db_pump p
-    LEFT  JOIN tmp_db_cashsale cs ON p.product_id = cs.product_id
+    LEFT  JOIN tmp_db_cashsale cs     ON p.product_id = cs.product_id
+    LEFT  JOIN tmp_db_intercompany ic ON p.product_id = ic.product_id
     SET   p.cashsale_qty = COALESCE(cs.cashsale_qty, 0),
-          p.net_qty      = GREATEST(0, p.pumped_qty - COALESCE(cs.cashsale_qty, 0));
+          p.net_qty      = GREATEST(0, p.pumped_qty
+                                       - COALESCE(cs.cashsale_qty, 0)
+                                       - COALESCE(ic.intercompany_qty, 0));
 
     -- ── 6. Total net revenue (denominator for digital split) ─────────────────
     SELECT COALESCE(SUM(net_qty * price), 0)
@@ -156,6 +183,25 @@ generate_day_bill_sp: BEGIN
       AND DATE(c.closing_date) = p_bill_date
       AND c.closing_status = 'CLOSED'
     GROUP BY ds.vendor_id, cl.Company_Name;
+
+    -- ── 7b. Read consolidation threshold from location config ─────────────────
+    --    DAY_BILL_CONSOLIDATE_THRESHOLD: vendors at or below this amount get a
+    --    single-product (dominant product) bill. Default 20000.
+    SELECT CAST(setting_value AS DECIMAL(15,2)) INTO v_threshold
+    FROM m_location_config
+    WHERE setting_name = 'DAY_BILL_CONSOLIDATE_THRESHOLD'
+      AND location_code IN (p_location_code, '*')
+      AND CURDATE() BETWEEN effective_start_date AND effective_end_date
+    ORDER BY CASE WHEN location_code = p_location_code THEN 0 ELSE 1 END
+    LIMIT 1;
+
+    -- Primary vendor: largest above threshold; if none above threshold, just the largest.
+    -- Primary gets the full multi-product breakdown and absorbs redistribution.
+    SELECT vendor_id INTO v_primary_vendor_id
+    FROM tmp_db_digital
+    ORDER BY CASE WHEN digital_amount > v_threshold THEN 0 ELSE 1 END ASC,
+             digital_amount DESC
+    LIMIT 1;
 
     -- ── 8. Credit quantities for the day ────────────────────────────────────
     CREATE TEMPORARY TABLE tmp_db_credit
@@ -184,6 +230,58 @@ generate_day_bill_sp: BEGIN
         AS DECIMAL(12,6)) AS digital_qty
     FROM tmp_db_digital  d
     CROSS JOIN tmp_db_pump p;
+
+    -- ── 9b. Build consolidated-vendor tables ─────────────────────────────────
+    --    For each vendor ≤ threshold (and not the primary), find their dominant
+    --    product (highest proportionate value) — they will be billed on that
+    --    product only.
+    CREATE TEMPORARY TABLE tmp_db_cons_dominant
+    SELECT ranked.vendor_id, ranked.product_id AS dom_product_id, ranked.price AS dom_price
+    FROM (
+        SELECT
+            di.vendor_id,
+            di.product_id,
+            p.price,
+            ROW_NUMBER() OVER (PARTITION BY di.vendor_id
+                               ORDER BY (di.digital_qty * p.price) DESC) AS rn
+        FROM tmp_db_dig_items di
+        JOIN tmp_db_pump p     ON di.product_id = p.product_id
+        JOIN tmp_db_digital d  ON di.vendor_id  = d.vendor_id
+        WHERE d.digital_amount <= v_threshold
+          AND di.vendor_id <> v_primary_vendor_id
+    ) ranked
+    WHERE rn = 1;
+
+    -- Single-product assignment for each consolidated vendor:
+    --   qty = vendor_amount / dominant_price  (so qty × price = vendor_amount exactly)
+    CREATE TEMPORARY TABLE tmp_db_cons_assign
+    SELECT
+        cd.vendor_id,
+        cd.dom_product_id AS product_id,
+        CAST(d.digital_amount / cd.dom_price AS DECIMAL(12,6)) AS qty
+    FROM tmp_db_cons_dominant cd
+    JOIN tmp_db_digital d ON cd.vendor_id = d.vendor_id;
+
+    -- Pre-calculate primary vendor adjusted quantities.
+    -- MySQL cannot open the same temp table twice in one query (error 1137),
+    -- so we materialise the result here before the vendor loop.
+    CREATE TEMPORARY TABLE tmp_db_primary_items
+    SELECT
+        p2.product_id,
+        p2.price,
+        p2.cgst_rate,
+        p2.sgst_rate,
+        GREATEST(0,
+            COALESCE(SUM(CASE WHEN di.vendor_id = v_primary_vendor_id THEN di.digital_qty ELSE 0 END), 0)
+            + COALESCE(SUM(CASE WHEN di.vendor_id IN (SELECT vendor_id FROM tmp_db_cons_dominant)
+                                THEN di.digital_qty ELSE 0 END), 0)
+            - COALESCE(
+                (SELECT SUM(ca.qty) FROM tmp_db_cons_assign ca WHERE ca.product_id = p2.product_id),
+                0)
+        ) AS adjusted_qty
+    FROM tmp_db_pump p2
+    LEFT JOIN tmp_db_dig_items di ON di.product_id = p2.product_id
+    GROUP BY p2.product_id, p2.price, p2.cgst_rate, p2.sgst_rate;
 
     -- ── 10. Upsert t_day_bill parent row ────────────────────────────────────
     INSERT INTO t_day_bill (location_code, bill_date, status,
@@ -291,10 +389,20 @@ generate_day_bill_sp: BEGIN
     WHERE  header_id = v_header_id;
 
     -- ── 17. DIGITAL headers + items (one per vendor) ─────────────────────────
+    --
+    --  Three cases per vendor:
+    --    A. Consolidated (≤ threshold, not primary): single dominant-product line,
+    --       qty = vendor_amount / dom_price, total = vendor_amount (exact).
+    --    B. Primary (largest / highest above threshold): absorbs residual quantities
+    --       from consolidated vendors while keeping all products.
+    --    C. Normal above-threshold (not primary): unchanged proportionate split.
+    --
     OPEN cur_vendors;
     vendor_loop: LOOP
         FETCH cur_vendors INTO v_vendor_id, v_vendor_name, v_digital_amount;
         IF v_done THEN LEAVE vendor_loop; END IF;
+
+        SET v_is_consolidated = IF(v_digital_amount <= v_threshold AND v_vendor_id <> v_primary_vendor_id, 1, 0);
 
         INSERT INTO t_day_bill_header (day_bill_id, bill_type, vendor_id, bill_number,
                                        total_amount, created_by, creation_date, updated_by, updation_date)
@@ -305,33 +413,98 @@ generate_day_bill_sp: BEGIN
 
         SET v_dig_header_id = LAST_INSERT_ID();
 
-        INSERT INTO t_day_bill_items (header_id, product_id, quantity, rate,
-                                      taxable_amount, cgst_rate, cgst_amount,
-                                      sgst_rate, sgst_amount, total_amount)
-        SELECT
-            v_dig_header_id,
-            di.product_id,
-            ROUND(di.digital_qty, 3),
-            ROUND(p.price, 3),
-            ROUND(
-                CASE WHEN (p.cgst_rate + p.sgst_rate) > 0
-                     THEN di.digital_qty * p.price / (1 + (p.cgst_rate + p.sgst_rate) / 100)
-                     ELSE di.digital_qty * p.price END, 3),
-            p.cgst_rate,
-            ROUND(
-                CASE WHEN (p.cgst_rate + p.sgst_rate) > 0
-                     THEN (di.digital_qty * p.price / (1 + (p.cgst_rate + p.sgst_rate) / 100)) * p.cgst_rate / 100
-                     ELSE 0 END, 3),
-            p.sgst_rate,
-            ROUND(
-                CASE WHEN (p.cgst_rate + p.sgst_rate) > 0
-                     THEN (di.digital_qty * p.price / (1 + (p.cgst_rate + p.sgst_rate) / 100)) * p.sgst_rate / 100
-                     ELSE 0 END, 3),
-            ROUND(di.digital_qty * p.price, 3)
-        FROM tmp_db_dig_items di
-        JOIN tmp_db_pump p ON di.product_id = p.product_id
-        WHERE di.vendor_id  = v_vendor_id
-          AND di.digital_qty > 0;
+        IF v_is_consolidated THEN
+            -- ── A. Consolidated: single dominant-product line ────────────────
+            INSERT INTO t_day_bill_items (header_id, product_id, quantity, rate,
+                                          taxable_amount, cgst_rate, cgst_amount,
+                                          sgst_rate, sgst_amount, total_amount)
+            SELECT
+                v_dig_header_id,
+                ca.product_id,
+                ROUND(ca.qty, 3)                                                             AS quantity,
+                ROUND(p.price, 3)                                                            AS rate,
+                ROUND(
+                    CASE WHEN (p.cgst_rate + p.sgst_rate) > 0
+                         THEN v_digital_amount / (1 + (p.cgst_rate + p.sgst_rate) / 100)
+                         ELSE v_digital_amount END, 3)                                       AS taxable_amount,
+                p.cgst_rate,
+                ROUND(
+                    CASE WHEN (p.cgst_rate + p.sgst_rate) > 0
+                         THEN (v_digital_amount / (1 + (p.cgst_rate + p.sgst_rate) / 100)) * p.cgst_rate / 100
+                         ELSE 0 END, 3)                                                      AS cgst_amount,
+                p.sgst_rate,
+                ROUND(
+                    CASE WHEN (p.cgst_rate + p.sgst_rate) > 0
+                         THEN (v_digital_amount / (1 + (p.cgst_rate + p.sgst_rate) / 100)) * p.sgst_rate / 100
+                         ELSE 0 END, 3)                                                      AS sgst_amount,
+                ROUND(v_digital_amount, 3)                                                   AS total_amount
+            FROM tmp_db_cons_assign ca
+            JOIN tmp_db_pump p ON ca.product_id = p.product_id
+            WHERE ca.vendor_id = v_vendor_id;
+
+        ELSEIF v_vendor_id = v_primary_vendor_id THEN
+            -- ── B. Primary: adjusted quantities absorbing consolidated residuals ──
+            --    adjusted_qty[P] = primary_proportionate[P]
+            --                    + consolidated_proportionate[P]   (what they would have got)
+            --                    - consolidated_actual[P]          (what they actually get)
+            --    Uses pre-calculated tmp_db_primary_items (avoids MySQL 1137 temp-table reopen error)
+            INSERT INTO t_day_bill_items (header_id, product_id, quantity, rate,
+                                          taxable_amount, cgst_rate, cgst_amount,
+                                          sgst_rate, sgst_amount, total_amount)
+            SELECT
+                v_dig_header_id,
+                pi.product_id,
+                ROUND(pi.adjusted_qty, 3),
+                ROUND(pi.price, 3),
+                ROUND(
+                    CASE WHEN (pi.cgst_rate + pi.sgst_rate) > 0
+                         THEN pi.adjusted_qty * pi.price / (1 + (pi.cgst_rate + pi.sgst_rate) / 100)
+                         ELSE pi.adjusted_qty * pi.price END, 3),
+                pi.cgst_rate,
+                ROUND(
+                    CASE WHEN (pi.cgst_rate + pi.sgst_rate) > 0
+                         THEN (pi.adjusted_qty * pi.price / (1 + (pi.cgst_rate + pi.sgst_rate) / 100)) * pi.cgst_rate / 100
+                         ELSE 0 END, 3),
+                pi.sgst_rate,
+                ROUND(
+                    CASE WHEN (pi.cgst_rate + pi.sgst_rate) > 0
+                         THEN (pi.adjusted_qty * pi.price / (1 + (pi.cgst_rate + pi.sgst_rate) / 100)) * pi.sgst_rate / 100
+                         ELSE 0 END, 3),
+                ROUND(pi.adjusted_qty * pi.price, 3)
+            FROM tmp_db_primary_items pi
+            WHERE pi.adjusted_qty > 0;
+
+        ELSE
+            -- ── C. Normal above-threshold vendor: unchanged proportionate split ──
+            INSERT INTO t_day_bill_items (header_id, product_id, quantity, rate,
+                                          taxable_amount, cgst_rate, cgst_amount,
+                                          sgst_rate, sgst_amount, total_amount)
+            SELECT
+                v_dig_header_id,
+                di.product_id,
+                ROUND(di.digital_qty, 3),
+                ROUND(p.price, 3),
+                ROUND(
+                    CASE WHEN (p.cgst_rate + p.sgst_rate) > 0
+                         THEN di.digital_qty * p.price / (1 + (p.cgst_rate + p.sgst_rate) / 100)
+                         ELSE di.digital_qty * p.price END, 3),
+                p.cgst_rate,
+                ROUND(
+                    CASE WHEN (p.cgst_rate + p.sgst_rate) > 0
+                         THEN (di.digital_qty * p.price / (1 + (p.cgst_rate + p.sgst_rate) / 100)) * p.cgst_rate / 100
+                         ELSE 0 END, 3),
+                p.sgst_rate,
+                ROUND(
+                    CASE WHEN (p.cgst_rate + p.sgst_rate) > 0
+                         THEN (di.digital_qty * p.price / (1 + (p.cgst_rate + p.sgst_rate) / 100)) * p.sgst_rate / 100
+                         ELSE 0 END, 3),
+                ROUND(di.digital_qty * p.price, 3)
+            FROM tmp_db_dig_items di
+            JOIN tmp_db_pump p ON di.product_id = p.product_id
+            WHERE di.vendor_id  = v_vendor_id
+              AND di.digital_qty > 0;
+
+        END IF;
 
         UPDATE t_day_bill_header
         SET    total_amount = (SELECT COALESCE(SUM(total_amount), 0)
@@ -346,10 +519,14 @@ generate_day_bill_sp: BEGIN
     DROP TEMPORARY TABLE IF EXISTS tmp_db_pump;
     DROP TEMPORARY TABLE IF EXISTS tmp_db_oil;
     DROP TEMPORARY TABLE IF EXISTS tmp_db_cashsale;
+    DROP TEMPORARY TABLE IF EXISTS tmp_db_intercompany;
     DROP TEMPORARY TABLE IF EXISTS tmp_db_credit;
     DROP TEMPORARY TABLE IF EXISTS tmp_db_digital;
     DROP TEMPORARY TABLE IF EXISTS tmp_db_dig_items;
     DROP TEMPORARY TABLE IF EXISTS tmp_db_bill_numbers;
+    DROP TEMPORARY TABLE IF EXISTS tmp_db_cons_dominant;
+    DROP TEMPORARY TABLE IF EXISTS tmp_db_cons_assign;
+    DROP TEMPORARY TABLE IF EXISTS tmp_db_primary_items;
 
 END generate_day_bill_sp //
 

--- a/public/javascripts/app-scripts.js
+++ b/public/javascripts/app-scripts.js
@@ -884,6 +884,11 @@ function populateSummary(obj) {
         } else {
             console.warn('loadShiftProducts function not available');
         }
+
+        // Populate intercompany summary section (only present on SFS with bowsers)
+        if (typeof populateIntercompanySummary === 'function') {
+            populateIntercompanySummary();
+        }
     });
 }
 

--- a/public/javascripts/bowser-intercompany.js
+++ b/public/javascripts/bowser-intercompany.js
@@ -116,6 +116,36 @@
         });
     };
 
+    // ── Summary section population ────────────────────────────────
+
+    window.populateIntercompanySummary = function () {
+        const tbody = document.getElementById('summary-intercompany-tbody');
+        const totalEl = document.getElementById('val-intercompany-total');
+        if (!tbody || !totalEl) return;
+
+        const rows = document.querySelectorAll('#intercompany-tbody tr');
+        let totalQty = 0;
+        const summaryRows = [];
+
+        rows.forEach(row => {
+            const bowserSel  = row.querySelector('.ic-bowser');
+            const productEl  = row.querySelector('.ic-product-name');
+            const qtyEl      = row.querySelector('.ic-qty');
+            if (!bowserSel || !qtyEl) return;
+
+            const qty = parseFloat(qtyEl.value) || 0;
+            if (qty <= 0) return;
+
+            const bowserName  = bowserSel.options[bowserSel.selectedIndex]?.text || '—';
+            const productName = productEl ? (productEl.value || '—') : '—';
+            totalQty += qty;
+            summaryRows.push(`<tr><td>${bowserName}</td><td>${productName}</td><td>${qty.toFixed(3)}</td></tr>`);
+        });
+
+        tbody.innerHTML = summaryRows.join('');
+        totalEl.textContent = totalQty.toFixed(3);
+    };
+
     // ── Load existing entries (edit screen) ───────────────────────
 
     window.loadIntercompanyEntries = function (entries) {

--- a/views/bowser/bowser-closing.pug
+++ b/views/bowser/bowser-closing.pug
@@ -3,255 +3,306 @@ extends ../layout
 block content
     - const isNew    = !closing
     - const isClosed = closing && closing.status === 'CLOSED'
-    - const disabledAttr = isClosed ? 'disabled' : ''
 
-    .container-fluid.mt-3
-
-        .row.mb-2.align-items-center
-            .col
-                h4= title
-                if closing
-                    span.badge.badge-pill(class= isClosed ? 'badge-success' : 'badge-warning')= closing.status
-            .col-auto
-                a.btn.btn-outline-secondary.btn-sm(href='/bowser/closing') &laquo; Back
-
+    div
         input(type='hidden' id='bowser_closing_id_hidden' value= closing ? closing.bowser_closing_id : '')
 
-        ul.nav.nav-tabs.mt-2
+        //- ── Tab navigation ──────────────────────────────────────────────────
+        ul.nav.nav-tabs
             li.nav-item
-                a.nav-link.active(data-toggle='tab' href='#tab-readings') Readings
+                a.nav-link.active#readings_tab(data-toggle='tab' href='#tab-readings') Readings
             li.nav-item
-                a.nav-link(data-toggle='tab' href='#tab-deliveries') Deliveries
+                a.nav-link#deliveries_tab(data-toggle='tab' href='#tab-deliveries') Deliveries
             li.nav-item
-                a.nav-link(data-toggle='tab' href='#tab-summary' onclick='refreshSummary()') Summary
+                a.nav-link#summary_tab(data-toggle='tab' href='#tab-summary' onclick='refreshSummary()') Summary
 
-        .tab-content.border.border-top-0.p-3
+        div.tab-content
 
-            //- ── TAB 1: READINGS ─────────────────────────────────────────
-            #tab-readings.tab-pane.active
-                .row.mt-3
-                    .col-md-4
-                        .form-group
-                            label Date
-                            input#bc_date.form-control(
-                                type='date'
-                                value= closing ? closing.closing_date : currentDate
-                                max=currentDate
-                                onchange='suggestFills()'
-                                disabled= (!isNew || isClosed) ? true : false
-                            )
-                        .form-group
-                            label Bowser
-                            if isNew
-                                select#bc_bowser_id.form-control(onchange='suggestFills()')
-                                    option(value='') -- Select --
-                                    each b in bowsers
-                                        option(value=b.bowser_id data-product_id=b.product_id data-product_name=b.product_name)= b.bowser_name
-                            else
-                                input.form-control(type='text' value=closing.bowser_name disabled)
-                                input(type='hidden' id='bc_bowser_id' value=closing.bowser_id)
-                        .form-group
-                            label Opening Meter (L)
-                            input#bc_opening_meter.form-control(
-                                type='number' min='0' step='0.001'
-                                value= closing ? closing.opening_meter : ''
-                                disabled= isClosed ? true : false
-                            )
-                        .form-group
-                            label Closing Meter (L)
-                            input#bc_closing_meter.form-control(
-                                type='number' min='0' step='0.001'
-                                value= closing ? closing.closing_meter : ''
-                                oninput='computeMeterDiff()'
-                                disabled= isClosed ? true : false
-                            )
-                        .form-group
-                            label Meter Difference (L)
-                            input#bc_meter_diff.form-control(type='text' readonly)
-                        .form-group
-                            label
-                                | Fills Received (L)
-                                small.text-muted.ml-2#fills_suggestion
-                            input#bc_fills_received.form-control(
-                                type='number' min='0' step='0.001'
-                                value= closing ? closing.fills_received : '0'
-                                disabled= isClosed ? true : false
-                            )
-                        .form-group
-                            label Opening Stock (L)
-                            input#bc_opening_stock.form-control(
-                                type='number' min='0' step='0.001'
-                                value= closing ? closing.opening_stock : '0'
-                                oninput='computeClosingStock()'
-                                disabled= isClosed ? true : false
-                            )
-                        .form-group
-                            label Closing Stock (L)
-                            input#bc_closing_stock.form-control(type='text' readonly)
+            //- ── TAB 1: READINGS ─────────────────────────────────────────────
+            div.tab-pane.fade.show.active#tab-readings
+                div
+                    div.container-fluid
+                        div.row.mt-3
+                            div.col-md-4
+
+                                //- Header info row
+                                div.row.mb-3.align-items-center
+                                    div.col
+                                        h5= title
+                                        if closing
+                                            span.badge.badge-pill(class= isClosed ? 'badge-success' : 'badge-warning')= closing.status
+                                    div.col-auto
+                                        a.btn.btn-outline-secondary.btn-sm(href='/bowser/closing') &laquo; Back
+
+                                div.form-group
+                                    label Date
+                                    input#bc_date.form-control(
+                                        type='date'
+                                        value= closing ? closing.closing_date : currentDate
+                                        max=currentDate
+                                        onchange='suggestFills()'
+                                        disabled= (!isNew || isClosed) ? true : false
+                                    )
+                                div.form-group
+                                    label Bowser
+                                    if isNew
+                                        select#bc_bowser_id.form-control(onchange='suggestFills()')
+                                            option(value='') -- Select --
+                                            each b in bowsers
+                                                option(value=b.bowser_id data-product_id=b.product_id data-product_name=b.product_name)= b.bowser_name
+                                    else
+                                        input.form-control(type='text' value=closing.bowser_name disabled)
+                                        input(type='hidden' id='bc_bowser_id' value=closing.bowser_id)
+
+                                h6.sub-header Meter Readings
+
+                                div.form-group
+                                    label Opening Meter (L)
+                                    input#bc_opening_meter.form-control(
+                                        type='number' min='0' step='0.001'
+                                        value= closing ? closing.opening_meter : ''
+                                        disabled= isClosed ? true : false
+                                    )
+                                div.form-group
+                                    label Closing Meter (L)
+                                    input#bc_closing_meter.form-control(
+                                        type='number' min='0' step='0.001'
+                                        value= closing ? closing.closing_meter : ''
+                                        oninput='computeMeterDiff()'
+                                        disabled= isClosed ? true : false
+                                    )
+                                div.form-group
+                                    label Meter Difference (L)
+                                    input#bc_meter_diff.form-control(type='text' readonly)
+
+                                h6.sub-header Stock
+
+                                div.form-group
+                                    label
+                                        | Fills Received (L)
+                                        small.text-muted.ml-2#fills_suggestion
+                                    input#bc_fills_received.form-control(
+                                        type='number' min='0' step='0.001'
+                                        value= closing ? closing.fills_received : '0'
+                                        oninput='computeClosingStock()'
+                                        disabled= isClosed ? true : false
+                                    )
+                                div.form-group
+                                    label Opening Stock (L)
+                                    input#bc_opening_stock.form-control(
+                                        type='number' min='0' step='0.001'
+                                        value= closing ? closing.opening_stock : '0'
+                                        oninput='computeClosingStock()'
+                                        disabled= isClosed ? true : false
+                                    )
+                                div.form-group
+                                    label Closing Stock (L)
+                                    input#bc_closing_stock.form-control(type='text' readonly)
 
                 if !isClosed
-                    .row.mt-3
-                        .col(align='right')
-                            button.btn.btn-dark(type='button' onclick='saveReadings()') Save Readings &raquo;
+                    div.row.mt-3
+                        div.col(align='right')
+                            button.btn.btn-primary(type='button' onclick='saveReadingsAndNext()') Save &amp; Next &raquo;
 
-            //- ── TAB 2: DELIVERIES ───────────────────────────────────────
-            #tab-deliveries.tab-pane.fade
-                .row.mt-2.mb-2.align-items-center
-                    .col
-                        span.text-muted Meter Diff:&nbsp;
-                        strong#del_meter_diff_display —
-                        span.text-muted.ml-3 Total Accounted:&nbsp;
-                        strong#del_total_accounted 0.000
-                        span.ml-3(id='del_reconcile_msg')
+            //- ── TAB 2: DELIVERIES ───────────────────────────────────────────
+            div.tab-pane.fade#tab-deliveries
+                div
+                    div.container-fluid.mt-3
 
-                .table-responsive
-                    table.table.table-sm.table-bordered#deliveries-table
-                        thead.thead-dark
-                            tr
-                                th Type
-                                th Customer / Vendor
-                                th Vehicle
-                                th Qty (L)
-                                th Rate
-                                th Amount
-                                th Ref #
-                                if !isClosed
-                                    th
+                        //- Reconciliation header
+                        div.row.mb-2.align-items-center
+                            div.col
+                                span.text-muted Meter Diff:&nbsp;
+                                strong#del_meter_diff_display —
+                                span.text-muted.ml-3 Total Accounted:&nbsp;
+                                strong#del_total_accounted 0.000
+                                span.ml-3(id='del_reconcile_msg')
 
-                        tbody#deliveries-tbody
-                            if deliveryItems && deliveryItems.length > 0
-                                each item in deliveryItems
-                                    tr(data-item_id=item.item_id)
-                                        td
-                                            if isClosed
-                                                span= item.sale_type
-                                            else
-                                                select.form-control.form-control-sm.del-type(onchange='onTypeChange(this)')
-                                                    option(value='CREDIT'   selected= item.sale_type==='CREDIT')   CREDIT
-                                                    option(value='DIGITAL'  selected= item.sale_type==='DIGITAL')  DIGITAL
-                                                    option(value='CASH'     selected= item.sale_type==='CASH')     CASH
-                                        td
-                                            if isClosed
-                                                span= item.sale_type === 'CREDIT' ? (item.customer_name || '—') : (item.digital_vendor_name || '—')
-                                            else
-                                                select.form-control.form-control-sm.del-customer(
-                                                    style= item.sale_type !== 'CREDIT' ? 'display:none' : ''
-                                                    onchange='loadVehicles(this)'
-                                                )
-                                                    option(value='') -- Customer --
-                                                    each c in customers
-                                                        option(value=c.creditlist_id selected= c.creditlist_id===item.creditlist_id)= c.customer_name
-                                                select.form-control.form-control-sm.del-digital-vendor(
-                                                    style= item.sale_type !== 'DIGITAL' ? 'display:none' : ''
-                                                )
-                                                    option(value='') -- Vendor --
-                                                    each dv in digitalVendors
-                                                        option(value=dv.creditlist_id selected= dv.creditlist_id===item.digital_vendor_id)= dv.vendor_name
-                                        td
-                                            if isClosed
-                                                span= item.vehicle_number || '—'
-                                            else
-                                                select.form-control.form-control-sm.del-vehicle(
-                                                    style= item.sale_type !== 'CREDIT' ? 'display:none' : ''
-                                                )
-                                                    option(value='') -- Vehicle --
-                                                    if item.vehicle_id
-                                                        option(value=item.vehicle_id selected)= item.vehicle_number
-                                        td
-                                            if isClosed
-                                                span= item.quantity
-                                            else
-                                                input.form-control.form-control-sm.del-qty(
-                                                    type='number' min='0' step='0.001'
-                                                    value=item.quantity
-                                                    oninput='computeRow(this); updateTotals()'
-                                                )
-                                        td
-                                            if isClosed
-                                                span= item.rate
-                                            else
-                                                input.form-control.form-control-sm.del-rate(
-                                                    type='number' min='0' step='0.0001'
-                                                    value=item.rate
-                                                    oninput='computeRow(this)'
-                                                )
-                                        td
-                                            if isClosed
-                                                span= item.amount
-                                            else
-                                                input.form-control.form-control-sm.del-amount(type='text' readonly value=item.amount)
-                                        td
-                                            if isClosed
-                                                span= item.digital_ref || '—'
-                                            else
-                                                input.form-control.form-control-sm.del-ref(
-                                                    type='text' placeholder='UPI/ref'
-                                                    style= item.sale_type !== 'DIGITAL' ? 'display:none' : ''
-                                                    value= item.digital_ref || ''
-                                                )
-                                        if !isClosed
-                                            td
-                                                button.btn.btn-sm.btn-outline-danger(type='button' onclick='removeRow(this)') &times;
+                        div.row
+                            div.col-16
+                                div.table-responsive
+                                    table.table.table-sm#deliveries-table
+                                        thead.thead-light
+                                            tr
+                                                th Type
+                                                th Customer / Vendor
+                                                th Vehicle
+                                                th(scope="col") Qty (L)
+                                                th Rate
+                                                th Amount
+                                                th Ref #
+                                                if !isClosed
+                                                    th
 
-                if !isClosed
-                    .row.mt-2
-                        .col
-                            button.btn.btn-sm.btn-outline-secondary(type='button' onclick='addDeliveryRow()') + Add Row
-                        .col(align='right')
-                            button.btn.btn-dark(type='button' onclick='saveDeliveries()') Save Deliveries
+                                        tbody#deliveries-tbody.w-100
+                                            if deliveryItems && deliveryItems.length > 0
+                                                each item in deliveryItems
+                                                    tr(data-item_id=item.item_id)
+                                                        td
+                                                            if isClosed
+                                                                span= item.sale_type
+                                                            else
+                                                                select.form-control.form-control-sm.del-type(onchange='onTypeChange(this)')
+                                                                    option(value='CREDIT'  selected= item.sale_type==='CREDIT')  CREDIT
+                                                                    option(value='DIGITAL' selected= item.sale_type==='DIGITAL') DIGITAL
+                                                                    option(value='CASH'    selected= item.sale_type==='CASH')    CASH
+                                                        td
+                                                            if isClosed
+                                                                span= item.sale_type === 'CREDIT' ? (item.customer_name || '—') : (item.digital_vendor_name || '—')
+                                                            else
+                                                                select.form-control.form-control-sm.del-customer(
+                                                                    style= item.sale_type !== 'CREDIT' ? 'display:none' : ''
+                                                                    onchange='loadVehicles(this)'
+                                                                )
+                                                                    option(value='') -- Customer --
+                                                                    each c in customers
+                                                                        option(value=c.creditlist_id selected= c.creditlist_id===item.creditlist_id)= c.customer_name
+                                                                select.form-control.form-control-sm.del-digital-vendor(
+                                                                    style= item.sale_type !== 'DIGITAL' ? 'display:none' : ''
+                                                                )
+                                                                    option(value='') -- Vendor --
+                                                                    each dv in digitalVendors
+                                                                        option(value=dv.creditlist_id selected= dv.creditlist_id===item.digital_vendor_id)= dv.vendor_name
+                                                        td
+                                                            if isClosed
+                                                                span= item.vehicle_number || '—'
+                                                            else
+                                                                select.form-control.form-control-sm.del-vehicle(
+                                                                    style= item.sale_type !== 'CREDIT' ? 'display:none' : ''
+                                                                )
+                                                                    option(value='') -- Vehicle --
+                                                                    if item.vehicle_id
+                                                                        option(value=item.vehicle_id selected)= item.vehicle_number
+                                                        td
+                                                            if isClosed
+                                                                span= item.quantity
+                                                            else
+                                                                input.form-control.form-control-sm.del-qty(
+                                                                    type='number' min='0' step='0.001'
+                                                                    value=item.quantity
+                                                                    oninput='computeRow(this); updateTotals()'
+                                                                )
+                                                        td
+                                                            if isClosed
+                                                                span= item.rate
+                                                            else
+                                                                input.form-control.form-control-sm.del-rate(
+                                                                    type='number' min='0' step='0.0001'
+                                                                    value=item.rate
+                                                                    oninput='computeRow(this)'
+                                                                )
+                                                        td
+                                                            if isClosed
+                                                                span= item.amount
+                                                            else
+                                                                input.form-control.form-control-sm.del-amount(type='text' readonly value=item.amount)
+                                                        td
+                                                            if isClosed
+                                                                span= item.digital_ref || '—'
+                                                            else
+                                                                input.form-control.form-control-sm.del-ref(
+                                                                    type='text' placeholder='UPI/ref'
+                                                                    style= item.sale_type !== 'DIGITAL' ? 'display:none' : ''
+                                                                    value= item.digital_ref || ''
+                                                                )
+                                                        if !isClosed
+                                                            td
+                                                                button.btn.btn-sm.btn-outline-danger(type='button' onclick='removeRow(this)') &times;
 
-            //- ── TAB 3: SUMMARY ──────────────────────────────────────────
-            #tab-summary.tab-pane.fade
-                .row.mt-3
-                    .col-md-5
-                        table.table.table-sm.table-borderless
-                            tbody
-                                tr
-                                    th(width='50%') Meter Diff
-                                    td#sum_meter_diff —
-                                tr
-                                    th Fills Received
-                                    td#sum_fills —
-                                tr
-                                    th Opening Stock
-                                    td#sum_opening_stock —
-                                tr
-                                    th Closing Stock
-                                    td#sum_closing_stock —
-                        hr
-                        table.table.table-sm
-                            thead.thead-light
-                                tr
-                                    th Type
-                                    th Qty (L)
-                                    th Amount
-                            tbody#sum_type_rows
+                        if !isClosed
+                            div.row.mt-2
+                                div.col
+                                    button.btn.btn-info.btn-sm(type='button' onclick='addDeliveryRow()') + Add Row
+                                div.col(align='right')
+                                    button.btn.btn-primary(type='button' onclick='saveDeliveriesAndNext()') Save &amp; Next &raquo;
 
-                if !isClosed
-                    .row.mt-3
-                        .col(align='right')
-                            button.btn.btn-success(type='button' onclick='finalizeClosing()') Close Bowser &raquo;
-                else
-                    .row.mt-3
-                        .col(align='right')
-                            button.btn.btn-outline-warning(type='button' onclick='reopenClosing()') Reopen
+            //- ── TAB 3: SUMMARY ──────────────────────────────────────────────
+            div.tab-pane.fade#tab-summary
+                div
+                    div.container-fluid.mt-3
+
+                        div.row
+                            //- Readings summary
+                            div.col-md-4
+                                h6.sub-header Readings
+                                table.table.table-sm.table-borderless
+                                    tbody
+                                        tr
+                                            th(width='55%') Date
+                                            td#sum_date —
+                                        tr
+                                            th Bowser
+                                            td#sum_bowser —
+                                        tr
+                                            th Meter Diff (L)
+                                            td#sum_meter_diff —
+                                        tr
+                                            th Fills Received (L)
+                                            td#sum_fills —
+                                        tr
+                                            th Opening Stock (L)
+                                            td#sum_opening_stock —
+                                        tr
+                                            th Closing Stock (L)
+                                            td#sum_closing_stock —
+
+                            //- Deliveries summary by type
+                            div.col-md-8
+                                h6.sub-header Deliveries
+                                table.table.table-sm
+                                    thead.thead-light
+                                        tr
+                                            th Type
+                                            th Qty (L)
+                                            th Amount
+                                    tbody#sum_type_rows
+
+                        div.row.mt-3
+                            div.col-md-12
+                                h6.sub-header Delivery Lines
+                                div.table-responsive
+                                    table.table.table-sm#sum_lines_table
+                                        thead.thead-light
+                                            tr
+                                                th Type
+                                                th Customer / Vendor
+                                                th Vehicle
+                                                th Qty (L)
+                                                th Rate
+                                                th Amount
+                                                th Ref #
+                                        tbody#sum_lines_tbody
+
+                        if !isClosed
+                            div.row.mt-3
+                                div.col(align='right')
+                                    button.btn.btn-dark(type='button' onclick='finalizeClosing()') Close Bowser &raquo;
+                        else
+                            div.row.mt-3
+                                div.col(align='right')
+                                    button.btn.btn-outline-warning(type='button' onclick='reopenClosing()') Reopen
 
     script.
-        // ── Init ─────────────────────────────────────────────────────
+        // ── Page data ─────────────────────────────────────────────────────────
+        const bc_customers      = !{JSON.stringify(customers.map(c => ({ id: c.creditlist_id, name: c.customer_name })))};
+        const bc_digitalVendors = !{JSON.stringify(digitalVendors.map(d => ({ id: d.creditlist_id, name: d.vendor_name })))};
+        const bc_productId      = !{JSON.stringify(closing ? closing.product_id : (bowsers[0] ? bowsers[0].product_id : 0))};
+
+        // ── Init ──────────────────────────────────────────────────────────────
         window.addEventListener('DOMContentLoaded', () => {
             computeMeterDiff();
             computeClosingStock();
             updateTotals();
         });
 
-        // ── Readings tab helpers ──────────────────────────────────────
+        // ── Readings tab ──────────────────────────────────────────────────────
         function computeMeterDiff() {
             const open  = parseFloat(document.getElementById('bc_opening_meter').value) || 0;
             const close = parseFloat(document.getElementById('bc_closing_meter').value) || 0;
             const diff  = Math.max(0, close - open);
             document.getElementById('bc_meter_diff').value = diff.toFixed(3);
-            document.getElementById('del_meter_diff_display').innerText = diff.toFixed(3) + ' L';
-            document.getElementById('sum_meter_diff').innerText = diff.toFixed(3) + ' L';
+            const dispEl = document.getElementById('del_meter_diff_display');
+            if (dispEl) dispEl.innerText = diff.toFixed(3) + ' L';
             computeClosingStock();
         }
 
@@ -261,9 +312,6 @@ block content
             const diff    = parseFloat(document.getElementById('bc_meter_diff').value) || 0;
             const stock   = opening + fills - diff;
             document.getElementById('bc_closing_stock').value = stock.toFixed(3);
-            document.getElementById('sum_fills').innerText         = fills.toFixed(3) + ' L';
-            document.getElementById('sum_opening_stock').innerText = opening.toFixed(3) + ' L';
-            document.getElementById('sum_closing_stock').innerText = stock.toFixed(3) + ' L';
         }
 
         function suggestFills() {
@@ -274,7 +322,8 @@ block content
                 .then(r => r.json())
                 .then(data => {
                     if (data.success) {
-                        document.getElementById('fills_suggestion').innerText = `(SFS fills: ${data.total_fills} L)`;
+                        document.getElementById('fills_suggestion').innerText =
+                            data.total_fills > 0 ? `(SFS fills: ${data.total_fills} L)` : '';
                     }
                 });
         }
@@ -282,10 +331,10 @@ block content
         function saveReadings() {
             const bowserId = document.getElementById('bc_bowser_id').value;
             const date     = document.getElementById('bc_date').value;
-            if (!bowserId || !date) { alert('Select a bowser and date.'); return; }
+            if (!bowserId || !date) { alert('Select a bowser and date.'); return Promise.resolve(false); }
 
             const hiddenId = document.getElementById('bowser_closing_id_hidden').value;
-            const payload = {
+            const payload  = {
                 bowser_closing_id: hiddenId || null,
                 bowser_id:      bowserId,
                 closing_date:   date,
@@ -298,7 +347,7 @@ block content
             const method = hiddenId ? 'PUT' : 'POST';
             const url    = hiddenId ? `/bowser/closing/${hiddenId}` : '/bowser/closing';
 
-            fetch(url, {
+            return fetch(url, {
                 method,
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload)
@@ -308,20 +357,29 @@ block content
                 if (data.success) {
                     document.getElementById('bowser_closing_id_hidden').value = data.bowser_closing_id;
                     if (!hiddenId) window.history.replaceState({}, '', `/bowser/closing/${data.bowser_closing_id}`);
-                    alert(data.message);
+                    if (typeof showSnackbar === 'function') showSnackbar(data.message, 'success');
+                    return true;
                 } else {
                     alert(data.error || 'Error saving readings.');
+                    return false;
                 }
+            })
+            .catch(() => { alert('Network error saving readings.'); return false; });
+        }
+
+        function saveReadingsAndNext() {
+            ajaxLoading('d-md-block');
+            saveReadings().then(ok => {
+                ajaxLoading('d-md-none');
+                if (ok) activateBowserTab('deliveries_tab');
             });
         }
 
-        // ── Deliveries tab helpers ────────────────────────────────────
+        // ── Deliveries tab ────────────────────────────────────────────────────
         function addDeliveryRow() {
-            const tbody = document.getElementById('deliveries-tbody');
-            const customers       = !{JSON.stringify(customers.map(c => ({ id: c.creditlist_id, name: c.customer_name })))};
-            const digitalVendors  = !{JSON.stringify(digitalVendors.map(d => ({ id: d.creditlist_id, name: d.vendor_name })))};
-            const custOptions = customers.map(c => `<option value="${c.id}">${c.name}</option>`).join('');
-            const vendorOptions   = digitalVendors.map(d => `<option value="${d.id}">${d.name}</option>`).join('');
+            const tbody       = document.getElementById('deliveries-tbody');
+            const custOptions = bc_customers.map(c => `<option value="${c.id}">${c.name}</option>`).join('');
+            const vendOptions = bc_digitalVendors.map(d => `<option value="${d.id}">${d.name}</option>`).join('');
 
             const tr = document.createElement('tr');
             tr.innerHTML = `
@@ -337,7 +395,7 @@ block content
                         <option value="">-- Customer --</option>${custOptions}
                     </select>
                     <select class="form-control form-control-sm del-digital-vendor" style="display:none">
-                        <option value="">-- Vendor --</option>${vendorOptions}
+                        <option value="">-- Vendor --</option>${vendOptions}
                     </select>
                 </td>
                 <td>
@@ -363,10 +421,10 @@ block content
             const row       = sel.closest('tr');
             const isCredit  = sel.value === 'CREDIT';
             const isDigital = sel.value === 'DIGITAL';
-            row.querySelector('.del-customer').style.display        = isCredit  ? '' : 'none';
-            row.querySelector('.del-digital-vendor').style.display  = isDigital ? '' : 'none';
-            row.querySelector('.del-vehicle').style.display         = isCredit  ? '' : 'none';
-            row.querySelector('.del-ref').style.display             = isDigital ? '' : 'none';
+            row.querySelector('.del-customer').style.display       = isCredit  ? '' : 'none';
+            row.querySelector('.del-digital-vendor').style.display = isDigital ? '' : 'none';
+            row.querySelector('.del-vehicle').style.display        = isCredit  ? '' : 'none';
+            row.querySelector('.del-ref').style.display            = isDigital ? '' : 'none';
         }
 
         function loadVehicles(sel) {
@@ -385,10 +443,10 @@ block content
         }
 
         function computeRow(el) {
-            const row    = el.closest('tr');
-            const qty    = parseFloat(row.querySelector('.del-qty')?.value) || 0;
-            const rate   = parseFloat(row.querySelector('.del-rate')?.value) || 0;
-            const amtEl  = row.querySelector('.del-amount');
+            const row   = el.closest('tr');
+            const qty   = parseFloat(row.querySelector('.del-qty')?.value)  || 0;
+            const rate  = parseFloat(row.querySelector('.del-rate')?.value) || 0;
+            const amtEl = row.querySelector('.del-amount');
             if (amtEl) amtEl.value = (qty * rate).toFixed(2);
         }
 
@@ -402,13 +460,13 @@ block content
             if (Math.abs(gap) < 0.001) {
                 msg.innerHTML = '<span class="badge badge-success">Reconciled</span>';
             } else {
-                msg.innerHTML = `<span class="badge badge-danger">Gap: ${gap.toFixed(3)} L</span>`;
+                msg.innerHTML = `<span class="badge badge-warning">Gap: ${gap.toFixed(3)} L</span>`;
             }
         }
 
         function saveDeliveries() {
             const closingId = document.getElementById('bowser_closing_id_hidden').value;
-            if (!closingId) { alert('Save readings first.'); return; }
+            if (!closingId) { alert('Save readings first.'); return Promise.resolve(false); }
 
             const rows  = document.querySelectorAll('#deliveries-tbody tr');
             const items = [];
@@ -417,54 +475,126 @@ block content
                 if (qty <= 0) return;
                 items.push({
                     sale_type:         row.querySelector('.del-type')?.value,
-                    creditlist_id:     row.querySelector('.del-customer')?.value || null,
-                    vehicle_id:        row.querySelector('.del-vehicle')?.value || null,
+                    creditlist_id:     row.querySelector('.del-customer')?.value    || null,
+                    vehicle_id:        row.querySelector('.del-vehicle')?.value     || null,
                     digital_vendor_id: row.querySelector('.del-digital-vendor')?.value || null,
-                    digital_ref:       row.querySelector('.del-ref')?.value || null,
-                    product_id:        !{JSON.stringify(closing ? closing.product_id : (bowsers[0] ? bowsers[0].product_id : 0))},
+                    digital_ref:       row.querySelector('.del-ref')?.value         || null,
+                    product_id:        bc_productId,
                     quantity:          qty,
-                    rate:              parseFloat(row.querySelector('.del-rate')?.value) || 0,
+                    rate:              parseFloat(row.querySelector('.del-rate')?.value)   || 0,
                     amount:            parseFloat(row.querySelector('.del-amount')?.value) || 0
                 });
             });
 
-            fetch('/bowser/closing/items', {
+            return fetch('/bowser/closing/items', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ bowser_closing_id: closingId, items })
             })
             .then(r => r.json())
             .then(data => {
-                if (data.success) alert(data.message);
-                else alert(data.error || 'Error saving deliveries.');
+                if (data.success) {
+                    if (typeof showSnackbar === 'function') showSnackbar(data.message, 'success');
+                    return true;
+                } else {
+                    alert(data.error || 'Error saving deliveries.');
+                    return false;
+                }
+            })
+            .catch(() => { alert('Network error saving deliveries.'); return false; });
+        }
+
+        function saveDeliveriesAndNext() {
+            ajaxLoading('d-md-block');
+            saveDeliveries().then(ok => {
+                ajaxLoading('d-md-none');
+                if (ok) {
+                    refreshSummary();
+                    activateBowserTab('summary_tab');
+                }
             });
         }
 
-        // ── Summary tab ───────────────────────────────────────────────
+        // ── Summary tab ───────────────────────────────────────────────────────
         function refreshSummary() {
             computeMeterDiff();
             computeClosingStock();
 
+            // Header info
+            const dateEl   = document.getElementById('bc_date');
+            const bowserEl = document.getElementById('bc_bowser_id');
+            document.getElementById('sum_date').innerText =
+                dateEl ? dateEl.value : '—';
+            document.getElementById('sum_bowser').innerText =
+                bowserEl?.options[bowserEl.selectedIndex]?.text || (document.querySelector('input[id="bc_bowser_id"]')?.value ? '—' : '—');
+
+            const diff    = parseFloat(document.getElementById('bc_meter_diff').value)    || 0;
+            const fills   = parseFloat(document.getElementById('bc_fills_received').value) || 0;
+            const opening = parseFloat(document.getElementById('bc_opening_stock').value)  || 0;
+            const stock   = parseFloat(document.getElementById('bc_closing_stock').value)  || 0;
+            document.getElementById('sum_meter_diff').innerText    = diff.toFixed(3)    + ' L';
+            document.getElementById('sum_fills').innerText         = fills.toFixed(3)   + ' L';
+            document.getElementById('sum_opening_stock').innerText = opening.toFixed(3) + ' L';
+            document.getElementById('sum_closing_stock').innerText = stock.toFixed(3)   + ' L';
+
+            // Totals by type
             const rows   = document.querySelectorAll('#deliveries-tbody tr');
             const totals = { CREDIT: { qty: 0, amt: 0 }, DIGITAL: { qty: 0, amt: 0 }, CASH: { qty: 0, amt: 0 } };
             rows.forEach(row => {
-                const type = row.querySelector('.del-type')?.value || row.querySelector('td:first-child span')?.innerText;
-                const qty  = parseFloat(row.querySelector('.del-qty')?.value || row.querySelector('.del-qty + *')?.innerText) || 0;
-                const amt  = parseFloat(row.querySelector('.del-amount')?.value || row.querySelector('.del-amount + *')?.innerText) || 0;
+                const typeSel = row.querySelector('.del-type');
+                const type    = typeSel ? typeSel.value
+                                        : (row.querySelector('td:first-child span')?.innerText || '');
+                const qty  = parseFloat(row.querySelector('.del-qty')?.value)    || 0;
+                const amt  = parseFloat(row.querySelector('.del-amount')?.value) || 0;
                 if (totals[type]) { totals[type].qty += qty; totals[type].amt += amt; }
             });
 
-            const tbody = document.getElementById('sum_type_rows');
-            tbody.innerHTML = Object.entries(totals).map(([type, v]) =>
-                `<tr><td>${type}</td><td>${v.qty.toFixed(3)}</td><td>${v.amt.toFixed(2)}</td></tr>`
-            ).join('');
+            document.getElementById('sum_type_rows').innerHTML =
+                Object.entries(totals)
+                    .map(([type, v]) => `<tr><td><strong>${type}</strong></td><td>${v.qty.toFixed(3)}</td><td>${v.amt.toFixed(2)}</td></tr>`)
+                    .join('');
+
+            // Detail lines
+            const linesTbody = document.getElementById('sum_lines_tbody');
+            const lineRows = [];
+            rows.forEach(row => {
+                const typeSel   = row.querySelector('.del-type');
+                const type      = typeSel ? typeSel.value : (row.querySelector('td:first-child span')?.innerText || '');
+                const custSel   = row.querySelector('.del-customer');
+                const vendSel   = row.querySelector('.del-digital-vendor');
+                const vehSel    = row.querySelector('.del-vehicle');
+                const qty       = row.querySelector('.del-qty')?.value    || row.querySelectorAll('td')[3]?.innerText || '—';
+                const rate      = row.querySelector('.del-rate')?.value   || row.querySelectorAll('td')[4]?.innerText || '—';
+                const amount    = row.querySelector('.del-amount')?.value || row.querySelectorAll('td')[5]?.innerText || '—';
+                const ref       = row.querySelector('.del-ref')?.value    || row.querySelectorAll('td')[6]?.innerText || '—';
+
+                let partyName = '—';
+                if (type === 'CREDIT' && custSel) {
+                    partyName = custSel.options[custSel.selectedIndex]?.text || '—';
+                } else if (type === 'DIGITAL' && vendSel) {
+                    partyName = vendSel.options[vendSel.selectedIndex]?.text || '—';
+                }
+                const vehName = (type === 'CREDIT' && vehSel)
+                    ? (vehSel.options[vehSel.selectedIndex]?.text || '—') : '—';
+
+                lineRows.push(`<tr>
+                    <td>${type}</td>
+                    <td>${partyName}</td>
+                    <td>${vehName}</td>
+                    <td>${parseFloat(qty).toFixed(3)}</td>
+                    <td>${parseFloat(rate).toFixed(4)}</td>
+                    <td>${parseFloat(amount).toFixed(2)}</td>
+                    <td>${ref !== '—' && ref ? ref : '—'}</td>
+                </tr>`);
+            });
+            linesTbody.innerHTML = lineRows.join('') || '<tr><td colspan="7" class="text-muted text-center">No deliveries</td></tr>';
         }
 
-        // ── Finalize / Reopen ─────────────────────────────────────────
+        // ── Finalize / Reopen ─────────────────────────────────────────────────
         function finalizeClosing() {
             const id = document.getElementById('bowser_closing_id_hidden').value;
             if (!id) { alert('Save readings first.'); return; }
-            if (!confirm('Close this bowser closing? This cannot be undone easily.')) return;
+            if (!confirm('Close this bowser closing? Delivery entries will be locked.')) return;
             fetch(`/bowser/closing/${id}/finalize`, { method: 'POST' })
                 .then(r => r.json())
                 .then(data => { if (data.success) location.reload(); else alert(data.error); });
@@ -476,4 +606,12 @@ block content
             fetch(`/bowser/closing/${id}/reopen`, { method: 'POST' })
                 .then(r => r.json())
                 .then(data => { if (data.success) location.reload(); else alert(data.error); });
+        }
+
+        // ── Tab navigation helper ─────────────────────────────────────────────
+        function activateBowserTab(tabId) {
+            const tabEl = document.getElementById(tabId);
+            if (!tabEl) return;
+            // Bootstrap 4 tab activation
+            $(tabEl).tab('show');
         }

--- a/views/edit-draft-closing.pug
+++ b/views/edit-draft-closing.pug
@@ -675,7 +675,24 @@ block content
                                                             td
                                                                 span
                                                                     b#val-digital-sales-total= 0
-                                                            td                                           
+                                                            td
+                                    if bowserValues && bowserValues.length > 0
+                                        div.col-6#v-intercompany
+                                            h6.sub-header Intercompany Fills
+                                            div.table-responsive
+                                                table.table.table-sm#summary-intercompany-table
+                                                    thead.thead-light
+                                                        tr
+                                                            th(scope="col") Bowser
+                                                            th(scope="col") Product
+                                                            th(scope="col") Qty (L)
+                                                    tbody#summary-intercompany-tbody
+                                                    tr
+                                                        td(colspan=2)
+                                                            b Total
+                                                        td
+                                                            b#val-intercompany-total 0.000
+                                    else
                                         div.col-6
                                 div.row
                                     if show2TSalesTab

--- a/views/new-closing.pug
+++ b/views/new-closing.pug
@@ -634,8 +634,25 @@ block content
                                                         td
                                                             span
                                                                 b#val-digital-sales-total= 0
-                                                        td                                           
-                                    div.col-6
+                                                        td
+                                    if bowserValues && bowserValues.length > 0
+                                        div.col-6#v-intercompany
+                                            h6.sub-header Intercompany Fills
+                                            div.table-responsive
+                                                table.table.table-sm#summary-intercompany-table
+                                                    thead.thead-light
+                                                        tr
+                                                            th(scope="col") Bowser
+                                                            th(scope="col") Product
+                                                            th(scope="col") Qty (L)
+                                                    tbody#summary-intercompany-tbody
+                                                    tr
+                                                        td(colspan=2)
+                                                            b Total
+                                                        td
+                                                            b#val-intercompany-total 0.000
+                                    else
+                                        div.col-6
                                 div.row
                                     if show2TSalesTab
                                         // 2T loose details


### PR DESCRIPTION
…w, day bill

- SFS shift closing summary now shows Intercompany Fills section (conditional on bowsers)
- CALCULATE_EXSHORTAGE: exclude intercompany fill value from shortage calculation
- generate_cashflow: deduct intercompany fill value from Collection amount
- generate_day_bill: exclude intercompany qty from net billable quantity (step 4b)
- Bowser closing page redesigned to match new-closing.pug (sub-headers, Save & Next buttons, detail lines in summary)