### PR TITLE
Feat: bowser closing — rate column, amount-based excess/shortage

### DIFF
--- a/controllers/bowser-controller.js
+++ b/controllers/bowser-controller.js
@@ -194,13 +194,14 @@ module.exports = {
     saveDraft: async (req, res) => {
         try {
             const { bowser_closing_id, bowser_id, closing_date,
-                    opening_meter, closing_meter, fills_received, opening_stock } = req.body;
+                    opening_meter, closing_meter, rate, fills_received, opening_stock } = req.body;
             const locationCode = req.user.location_code;
             const createdBy = String(req.user.Person_id);
 
             if (bowser_closing_id) {
                 await BowserDao.updateBowserClosing(bowser_closing_id, {
                     openingMeter: opening_meter, closingMeter: closing_meter,
+                    rate: rate || 0,
                     fillsReceived: fills_received, openingStock: opening_stock,
                     updatedBy: createdBy
                 });
@@ -209,6 +210,7 @@ module.exports = {
                 const [, meta] = await BowserDao.createBowserClosing({
                     bowserId: bowser_id, locationCode, closingDate: closing_date,
                     openingMeter: opening_meter, closingMeter: closing_meter,
+                    rate: rate || 0,
                     fillsReceived: fills_received, openingStock: opening_stock,
                     createdBy
                 });
@@ -216,6 +218,16 @@ module.exports = {
             }
         } catch (err) {
             console.error('saveDraft error:', err);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    },
+
+    getExShortage: async (req, res) => {
+        try {
+            const result = await BowserDao.getExShortage(req.params.id);
+            res.json({ success: true, ...result });
+        } catch (err) {
+            console.error('getExShortage error:', err);
             res.status(500).json({ success: false, error: err.message });
         }
     },

--- a/dao/bowser-dao.js
+++ b/dao/bowser-dao.js
@@ -169,9 +169,9 @@ module.exports = {
     createBowserClosing: (data) => {
         return db.sequelize.query(`
             INSERT INTO t_bowser_closing
-                (bowser_id, location_code, closing_date, opening_meter, closing_meter,
+                (bowser_id, location_code, closing_date, opening_meter, closing_meter, rate,
                  fills_received, opening_stock, status, created_by)
-            VALUES (:bowserId, :locationCode, :closingDate, :openingMeter, :closingMeter,
+            VALUES (:bowserId, :locationCode, :closingDate, :openingMeter, :closingMeter, :rate,
                     :fillsReceived, :openingStock, 'DRAFT', :createdBy)
         `, { replacements: data, type: db.Sequelize.QueryTypes.INSERT });
     },
@@ -181,6 +181,7 @@ module.exports = {
             UPDATE t_bowser_closing
             SET opening_meter  = :openingMeter,
                 closing_meter  = :closingMeter,
+                rate           = :rate,
                 fills_received = :fillsReceived,
                 opening_stock  = :openingStock,
                 updated_by     = :updatedBy,
@@ -313,6 +314,37 @@ module.exports = {
             });
         }
         return { inserted: items.length };
+    },
+
+    // ── Excess / Shortage ─────────────────────────────────────
+
+    getExShortage: (bowserClosingId) => {
+        return db.sequelize.query(`
+            SELECT
+                (bc.closing_meter - bc.opening_meter) * bc.rate          AS reading_amount,
+                COALESCE(SUM(cr.amount), 0)                              AS credit_amount,
+                COALESCE((SELECT SUM(amount) FROM t_bowser_digital_sales WHERE bowser_closing_id = :bowserClosingId), 0) AS digital_amount,
+                COALESCE((SELECT SUM(amount) FROM t_bowser_cashsales     WHERE bowser_closing_id = :bowserClosingId), 0) AS cash_amount
+            FROM t_bowser_closing bc
+            LEFT JOIN t_bowser_credits cr ON cr.bowser_closing_id = bc.bowser_closing_id
+            WHERE bc.bowser_closing_id = :bowserClosingId
+            GROUP BY bc.bowser_closing_id, bc.closing_meter, bc.opening_meter, bc.rate
+        `, { replacements: { bowserClosingId }, type: db.Sequelize.QueryTypes.SELECT })
+        .then(rows => {
+            if (!rows[0]) return { reading_amount: 0, credit_amount: 0, digital_amount: 0, cash_amount: 0, ex_shortage: 0 };
+            const r = rows[0];
+            const reading  = Number(r.reading_amount)  || 0;
+            const credit   = Number(r.credit_amount)   || 0;
+            const digital  = Number(r.digital_amount)  || 0;
+            const cash     = Number(r.cash_amount)     || 0;
+            return {
+                reading_amount:  reading,
+                credit_amount:   credit,
+                digital_amount:  digital,
+                cash_amount:     cash,
+                ex_shortage:     reading - credit - digital - cash
+            };
+        });
     },
 
     // ── Products for dropdown ─────────────────────────────────

--- a/db/migrations/bowser-add-rate-column.sql
+++ b/db/migrations/bowser-add-rate-column.sql
@@ -1,0 +1,5 @@
+-- Add rate column to t_bowser_closing
+-- Rate is used to calculate reading amount (meter_diff * rate) for excess/shortage
+
+ALTER TABLE t_bowser_closing
+    ADD COLUMN rate DECIMAL(10,4) NOT NULL DEFAULT 0 AFTER closing_meter;

--- a/routes/bowser-routes.js
+++ b/routes/bowser-routes.js
@@ -37,6 +37,10 @@ router.get('/api/fills-received',
     [ensureLoggedIn],
     bowserController.getFillsSuggestion);
 
+router.get('/api/ex-shortage/:id',
+    [ensureLoggedIn],
+    bowserController.getExShortage);
+
 router.get('/api/vehicles/:creditlistId',
     [ensureLoggedIn],
     bowserController.getVehiclesByCustomer);

--- a/views/bowser/bowser-closing.pug
+++ b/views/bowser/bowser-closing.pug
@@ -311,7 +311,7 @@ block content
                 div.container-fluid.mt-3
 
                     div.row
-                        div.col-md-4
+                        div.col-md-5
                             h6.sub-header Readings
                             table.table.table-sm.table-borderless
                                 tbody
@@ -325,24 +325,16 @@ block content
                                         th Meter Diff (L)
                                         td#sum_meter_diff —
                                     tr
-                                        th Fills Received (L)
-                                        td#sum_fills —
-                                    tr
-                                        th Opening Stock (L)
-                                        td#sum_opening_stock —
-                                    tr
-                                        th Closing Stock (L)
-                                        td#sum_closing_stock —
+                                        th Credit Qty (L)
+                                        td#sum_credit_qty —
 
-                        div.col-md-8
-                            h6.sub-header Deliveries by Type
-                            table.table.table-sm
-                                thead.thead-light
-                                    tr
-                                        th Type
-                                        th Qty (L)
-                                        th Amount (₹)
-                                tbody#sum_type_rows
+                    div.row.mt-2
+                        div.col
+                            div.table-success.row.py-2(align='center')
+                                div.col
+                                    span Excess / Shortage:&nbsp;
+                                    span#sum_ex_shortage_color
+                                        b#sum_ex_shortage —
 
                     div.row.mt-3
                         div.col-md-12
@@ -470,6 +462,7 @@ block content
                 body:    JSON.stringify({
                     bowser_id:      bowserId,
                     closing_date:   date,
+                    rate:           parseFloat(document.getElementById('bc_rate')?.value) || 0,
                     opening_meter:  0,
                     closing_meter:  0,
                     fills_received: 0,
@@ -521,6 +514,7 @@ block content
                     bowser_closing_id: hiddenId,
                     opening_meter:     document.getElementById('bc_opening_meter').value,
                     closing_meter:     document.getElementById('bc_closing_meter').value,
+                    rate:              parseFloat(document.getElementById('bc_rate')?.value) || 0,
                     fills_received:    document.getElementById('bc_fills_received').value,
                     opening_stock:     document.getElementById('bc_opening_stock').value
                 })
@@ -709,14 +703,8 @@ block content
                     ? (bowserEl.options[bowserEl.selectedIndex]?.text || '—')
                     : (bowserEl?.value || '—');
 
-            const diff    = parseFloat(document.getElementById('bc_meter_diff').value)    || 0;
-            const fills   = parseFloat(document.getElementById('bc_fills_received').value) || 0;
-            const opening = parseFloat(document.getElementById('bc_opening_stock').value)  || 0;
-            const stock   = parseFloat(document.getElementById('bc_closing_stock').value)  || 0;
-            document.getElementById('sum_meter_diff').innerText    = diff.toFixed(3)    + ' L';
-            document.getElementById('sum_fills').innerText         = fills.toFixed(3)   + ' L';
-            document.getElementById('sum_opening_stock').innerText = opening.toFixed(3) + ' L';
-            document.getElementById('sum_closing_stock').innerText = stock.toFixed(3)   + ' L';
+            const diff = parseFloat(document.getElementById('bc_meter_diff').value) || 0;
+            document.getElementById('sum_meter_diff').innerText = diff.toFixed(3) + ' L';
 
             function readAmt(row, inputClass, dataKey) {
                 const input = row.querySelector(`.${inputClass}`);
@@ -756,11 +744,23 @@ block content
                 lineRows.push(`<tr><td>CASH</td><td>—</td><td>—</td><td>—</td><td>${amt.toFixed(2)}</td><td>—</td></tr>`);
             });
 
-            document.getElementById('sum_type_rows').innerHTML = [
-                `<tr><td><strong>CREDIT</strong></td><td>${totals.CREDIT.qty.toFixed(3)}</td><td>${totals.CREDIT.amt.toFixed(2)}</td></tr>`,
-                `<tr><td><strong>DIGITAL</strong></td><td>—</td><td>${totals.DIGITAL.amt.toFixed(2)}</td></tr>`,
-                `<tr><td><strong>CASH</strong></td><td>—</td><td>${totals.CASH.amt.toFixed(2)}</td></tr>`
-            ].join('');
+            const credQty = totals.CREDIT.qty;
+            document.getElementById('sum_credit_qty').innerText = credQty.toFixed(3) + ' L';
+
+            // Fetch ex/shortage from server (amount-based: reading_amount - credit - digital - cash)
+            const closingId = document.getElementById('bowser_closing_id_hidden').value;
+            if (closingId) {
+                fetch(`/bowser/api/ex-shortage/${closingId}`)
+                    .then(r => r.json())
+                    .then(data => {
+                        if (!data.success) return;
+                        const exEl      = document.getElementById('sum_ex_shortage');
+                        const exColorEl = document.getElementById('sum_ex_shortage_color');
+                        const val       = Number(data.ex_shortage) || 0;
+                        exEl.innerText        = (val >= 0 ? '+' : '') + val.toFixed(2);
+                        exColorEl.style.color = val >= 0 ? 'green' : 'red';
+                    });
+            }
 
             document.getElementById('sum_lines_tbody').innerHTML =
                 lineRows.join('') || '<tr><td colspan="6" class="text-muted text-center">No deliveries</td></tr>';


### PR DESCRIPTION
- Add rate column to t_bowser_closing (migration)
- Save rate from closing tab in both create and update paths
- Add getExShortage DAO/controller/route: reading_amount - credit - digital - cash
- Summary tab: fetch ex/shortage from server, display in ₹ with green/red styling
- Remove client-side ex/shortage calc; use server-side API instead

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>