### PR TITLE
Feat: bowser closing — ex/shortage sign fix, stored on close, UI cleanup

### DIFF
--- a/dao/bowser-dao.js
+++ b/dao/bowser-dao.js
@@ -126,12 +126,8 @@ module.exports = {
             SELECT bc.bowser_closing_id, bc.closing_date, bc.status,
                    bc.opening_meter, bc.closing_meter,
                    (bc.closing_meter - bc.opening_meter) AS meter_diff,
-                   bc.fills_received, bc.opening_stock,
-                   (bc.opening_stock + bc.fills_received - (bc.closing_meter - bc.opening_meter)) AS closing_stock,
-                   b.bowser_name, b.capacity_litres,
-                   COALESCE(
-                       (SELECT SUM(quantity) FROM t_bowser_credits WHERE bowser_closing_id = bc.bowser_closing_id), 0)
-                   AS total_delivered
+                   bc.rate, bc.ex_shortage,
+                   b.bowser_name, b.capacity_litres
             FROM t_bowser_closing bc
             JOIN m_bowser b ON b.bowser_id = bc.bowser_id
             WHERE bc.location_code = :locationCode
@@ -193,7 +189,15 @@ module.exports = {
     finalizeBowserClosing: (bowserClosingId, updatedBy) => {
         return db.sequelize.query(`
             UPDATE t_bowser_closing
-            SET status = 'CLOSED', updated_by = :updatedBy, updation_date = NOW()
+            SET status     = 'CLOSED',
+                ex_shortage = (
+                    COALESCE((SELECT SUM(amount) FROM t_bowser_credits       WHERE bowser_closing_id = :bowserClosingId), 0) +
+                    COALESCE((SELECT SUM(amount) FROM t_bowser_digital_sales  WHERE bowser_closing_id = :bowserClosingId), 0) +
+                    COALESCE((SELECT SUM(amount) FROM t_bowser_cashsales      WHERE bowser_closing_id = :bowserClosingId), 0) -
+                    (closing_meter - opening_meter) * rate
+                ),
+                updated_by  = :updatedBy,
+                updation_date = NOW()
             WHERE bowser_closing_id = :bowserClosingId AND status = 'DRAFT'
         `, { replacements: { bowserClosingId, updatedBy }, type: db.Sequelize.QueryTypes.UPDATE });
     },
@@ -342,7 +346,7 @@ module.exports = {
                 credit_amount:   credit,
                 digital_amount:  digital,
                 cash_amount:     cash,
-                ex_shortage:     reading - credit - digital - cash
+                ex_shortage:     credit + digital + cash - reading
             };
         });
     },

--- a/db/migrations/bowser-add-ex-shortage-column.sql
+++ b/db/migrations/bowser-add-ex-shortage-column.sql
@@ -1,0 +1,5 @@
+-- Add ex_shortage column to t_bowser_closing
+-- Stored when closing is finalized: (credit + digital + cash) - reading_amount
+
+ALTER TABLE t_bowser_closing
+    ADD COLUMN ex_shortage DECIMAL(10,2) NULL AFTER rate;

--- a/views/bowser/bowser-closing-list.pug
+++ b/views/bowser/bowser-closing-list.pug
@@ -28,25 +28,24 @@ block content
                             th Bowser
                             th Open Meter
                             th Close Meter
-                            th Meter Diff (L)
-                            th Fills Rec. (L)
-                            th Delivered (L)
-                            th Close Stock (L)
+                            th Bowser Sales (L)
+                            th Rate (₹/L)
+                            th Ex / Shortage (₹)
                             th Status
                             th
                     tbody
                         each c in closings
                             - const meterDiff = (parseFloat(c.closing_meter) - parseFloat(c.opening_meter)).toFixed(3)
-                            - const closeStock = (parseFloat(c.opening_stock) + parseFloat(c.fills_received) - parseFloat(meterDiff)).toFixed(3)
+                            - const exShortage = c.ex_shortage != null ? parseFloat(c.ex_shortage).toFixed(2) : '—'
+                            - const exClass = c.ex_shortage != null ? (parseFloat(c.ex_shortage) >= 0 ? 'text-danger' : 'text-success') : ''
                             tr
                                 td= new Date(c.closing_date).toLocaleDateString('en-IN', {day:'2-digit', month:'short', year:'numeric'})
                                 td= c.bowser_name
                                 td= parseFloat(c.opening_meter).toFixed(3)
                                 td= parseFloat(c.closing_meter).toFixed(3)
                                 td= meterDiff
-                                td= parseFloat(c.fills_received).toFixed(3)
-                                td= parseFloat(c.total_delivered).toFixed(3)
-                                td= closeStock
+                                td= c.rate ? parseFloat(c.rate).toFixed(4) : '—'
+                                td(class=exClass)= exShortage
                                 td
                                     if c.status === 'CLOSED'
                                         span.badge.badge-success Closed

--- a/views/bowser/bowser-closing.pug
+++ b/views/bowser/bowser-closing.pug
@@ -182,7 +182,7 @@ block content
                                                         input.form-control.form-control-sm.cred-rate(
                                                             type='number' min='0' step='0.0001'
                                                             value=item.rate
-                                                            oninput='computeDeliveryRow(this,"cred")'
+                                                            readonly
                                                         )
                                                 td
                                                     if isClosed
@@ -322,11 +322,14 @@ block content
                                         th Bowser
                                         td#sum_bowser —
                                     tr
-                                        th Meter Diff (L)
+                                        th Bowser Sales (L)
                                         td#sum_meter_diff —
                                     tr
-                                        th Credit Qty (L)
-                                        td#sum_credit_qty —
+                                        th Rate (₹/L)
+                                        td#sum_rate —
+                                    tr
+                                        th Reading Amount (₹)
+                                        td#sum_reading_amount —
 
                     div.row.mt-2
                         div.col
@@ -549,7 +552,7 @@ block content
                     </select>
                 </td>
                 <td><input class="form-control form-control-sm cred-qty" type="number" min="0" step="0.001" oninput="computeDeliveryRow(this,'cred'); updateAllTotals()"></td>
-                <td><input class="form-control form-control-sm cred-rate" type="number" min="0" step="0.0001" value="${rate}" oninput="computeDeliveryRow(this,'cred')"></td>
+                <td><input class="form-control form-control-sm cred-rate" type="number" min="0" step="0.0001" value="${rate}" readonly></td>
                 <td><input class="form-control form-control-sm cred-amount" type="text" readonly></td>
                 <td><button class="btn btn-sm btn-outline-danger" type="button" onclick="removeDeliveryRow(this)">&times;</button></td>
             `;
@@ -744,16 +747,17 @@ block content
                 lineRows.push(`<tr><td>CASH</td><td>—</td><td>—</td><td>—</td><td>${amt.toFixed(2)}</td><td>—</td></tr>`);
             });
 
-            const credQty = totals.CREDIT.qty;
-            document.getElementById('sum_credit_qty').innerText = credQty.toFixed(3) + ' L';
-
-            // Fetch ex/shortage from server (amount-based: reading_amount - credit - digital - cash)
+            // Fetch rate, reading amount and ex/shortage from server
             const closingId = document.getElementById('bowser_closing_id_hidden').value;
             if (closingId) {
                 fetch(`/bowser/api/ex-shortage/${closingId}`)
                     .then(r => r.json())
                     .then(data => {
                         if (!data.success) return;
+                        document.getElementById('sum_rate').innerText =
+                            parseFloat(document.getElementById('bc_rate')?.value || 0).toFixed(4);
+                        document.getElementById('sum_reading_amount').innerText =
+                            Number(data.reading_amount).toFixed(2);
                         const exEl      = document.getElementById('sum_ex_shortage');
                         const exColorEl = document.getElementById('sum_ex_shortage_color');
                         const val       = Number(data.ex_shortage) || 0;


### PR DESCRIPTION
- Fix ex/shortage formula: (credit+digital+cash) - reading_amount
- Save ex_shortage to t_bowser_closing on finalize (SQL subquery)
- Add ex_shortage column migration
- Summary tab: replace Credit Qty with Rate and Reading Amount rows
- List page: remove fills/delivered/closing stock, add rate and ex/shortage columns
- Credit rate input set to readonly (driven from closing tab rate)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>