### PR TITLE
Feat: bowser closing — delete draft, reopen with config gate

### DIFF
--- a/controllers/bowser-controller.js
+++ b/controllers/bowser-controller.js
@@ -1,6 +1,7 @@
 'use strict';
-const BowserDao = require('../dao/bowser-dao');
-const utils = require('../utils/app-utils');
+const BowserDao      = require('../dao/bowser-dao');
+const utils          = require('../utils/app-utils');
+const locationConfig = require('../utils/location-config');
 
 module.exports = {
 
@@ -111,9 +112,10 @@ module.exports = {
             const locationCode = req.user.location_code;
             const toDate   = req.query.toDate   || utils.currentDate();
             const fromDate = req.query.fromDate  || utils.currentDate();
-            const [closings, bowsers] = await Promise.all([
+            const [closings, bowsers, allowBowserReopen] = await Promise.all([
                 BowserDao.getBowserClosings(locationCode, fromDate, toDate),
-                BowserDao.getActiveBowsersByLocation(locationCode)
+                BowserDao.getActiveBowsersByLocation(locationCode),
+                locationConfig.getLocationConfigValue(locationCode, 'ALLOW_BOWSER_REOPEN', 'N')
             ]);
             res.render('bowser/bowser-closing-list', {
                 title: 'Bowser Closings',
@@ -121,7 +123,8 @@ module.exports = {
                 closings,
                 bowsers,
                 fromDate,
-                toDate
+                toDate,
+                allowBowserReopen
             });
         } catch (err) {
             console.error('getClosingList error:', err);
@@ -136,10 +139,11 @@ module.exports = {
             const locationCode = req.user.location_code;
             const bowserClosingId = req.params.id || null;
 
-            const [bowsers, customers, digitalVendors] = await Promise.all([
+            const [bowsers, customers, digitalVendors, allowBowserReopen] = await Promise.all([
                 BowserDao.getActiveBowsersByLocation(locationCode),
                 BowserDao.getCreditCustomers(locationCode),
-                BowserDao.getDigitalVendors(locationCode)
+                BowserDao.getDigitalVendors(locationCode),
+                locationConfig.getLocationConfigValue(locationCode, 'ALLOW_BOWSER_REOPEN', 'N')
             ]);
 
             let closing = null, creditItems = [], digitalItems = [], cashItems = [];
@@ -164,6 +168,7 @@ module.exports = {
                 bowsers,
                 customers,
                 digitalVendors,
+                allowBowserReopen,
                 currentDate: utils.currentDate()
             });
         } catch (err) {
@@ -207,14 +212,14 @@ module.exports = {
                 });
                 res.json({ success: true, bowser_closing_id, message: 'Readings saved.' });
             } else {
-                const [, meta] = await BowserDao.createBowserClosing({
+                const [insertId] = await BowserDao.createBowserClosing({
                     bowserId: bowser_id, locationCode, closingDate: closing_date,
                     openingMeter: opening_meter, closingMeter: closing_meter,
                     rate: rate || 0,
                     fillsReceived: fills_received, openingStock: opening_stock,
                     createdBy
                 });
-                res.json({ success: true, bowser_closing_id: meta, message: 'Bowser closing created.' });
+                res.json({ success: true, bowser_closing_id: insertId, message: 'Bowser closing created.' });
             }
         } catch (err) {
             console.error('saveDraft error:', err);
@@ -267,11 +272,34 @@ module.exports = {
 
     reopenClosing: async (req, res) => {
         try {
+            const locationCode = req.user.location_code;
+            const userRole     = req.user.Role;
+
+            let hasPermission = userRole === 'SuperUser';
+            if (!hasPermission && userRole === 'Admin') {
+                const allow = await locationConfig.getLocationConfigValue(locationCode, 'ALLOW_BOWSER_REOPEN', 'N');
+                hasPermission = allow === 'Y';
+            }
+            if (!hasPermission) {
+                return res.status(403).json({ success: false, error: 'You do not have permission to reopen bowser closings.' });
+            }
+
             await BowserDao.reopenBowserClosing(req.params.id, String(req.user.Person_id));
             res.json({ success: true, message: 'Bowser closing reopened.' });
         } catch (err) {
             console.error('reopenClosing error:', err);
             res.status(500).json({ success: false, error: err.message });
+        }
+    },
+
+    deleteClosing: async (req, res) => {
+        try {
+            await BowserDao.deleteBowserClosing(req.params.id);
+            res.json({ success: true, message: 'Bowser closing deleted.' });
+        } catch (err) {
+            const status = err.statusCode || 500;
+            console.error('deleteClosing error:', err);
+            res.status(status).json({ success: false, error: err.message });
         }
     }
 };

--- a/dao/bowser-dao.js
+++ b/dao/bowser-dao.js
@@ -205,9 +205,24 @@ module.exports = {
     reopenBowserClosing: (bowserClosingId, updatedBy) => {
         return db.sequelize.query(`
             UPDATE t_bowser_closing
-            SET status = 'DRAFT', updated_by = :updatedBy, updation_date = NOW()
+            SET status = 'DRAFT', ex_shortage = NULL, updated_by = :updatedBy, updation_date = NOW()
             WHERE bowser_closing_id = :bowserClosingId AND status = 'CLOSED'
         `, { replacements: { bowserClosingId, updatedBy }, type: db.Sequelize.QueryTypes.UPDATE });
+    },
+
+    deleteBowserClosing: async (bowserClosingId) => {
+        // Guard: only DRAFT may be deleted
+        const [closing] = await db.sequelize.query(
+            `SELECT status FROM t_bowser_closing WHERE bowser_closing_id = :bowserClosingId`,
+            { replacements: { bowserClosingId }, type: db.Sequelize.QueryTypes.SELECT }
+        );
+        if (!closing) throw Object.assign(new Error('Bowser closing not found.'), { statusCode: 404 });
+        if (closing.status !== 'DRAFT') throw Object.assign(new Error('Only DRAFT closings can be deleted.'), { statusCode: 400 });
+
+        await db.sequelize.query(`DELETE FROM t_bowser_credits       WHERE bowser_closing_id = :bowserClosingId`, { replacements: { bowserClosingId }, type: db.Sequelize.QueryTypes.DELETE });
+        await db.sequelize.query(`DELETE FROM t_bowser_digital_sales  WHERE bowser_closing_id = :bowserClosingId`, { replacements: { bowserClosingId }, type: db.Sequelize.QueryTypes.DELETE });
+        await db.sequelize.query(`DELETE FROM t_bowser_cashsales      WHERE bowser_closing_id = :bowserClosingId`, { replacements: { bowserClosingId }, type: db.Sequelize.QueryTypes.DELETE });
+        await db.sequelize.query(`DELETE FROM t_bowser_closing        WHERE bowser_closing_id = :bowserClosingId AND status = 'DRAFT'`, { replacements: { bowserClosingId }, type: db.Sequelize.QueryTypes.DELETE });
     },
 
     // ── Delivery Items ────────────────────────────────────────

--- a/routes/bowser-routes.js
+++ b/routes/bowser-routes.js
@@ -74,6 +74,10 @@ router.post('/closing/:id/reopen',
     [ensureLoggedIn, security.hasPermission('MANAGE_BOWSER_CLOSING')],
     bowserController.reopenClosing);
 
+router.delete('/closing/:id',
+    [ensureLoggedIn, security.hasPermission('MANAGE_BOWSER_CLOSING')],
+    bowserController.deleteClosing);
+
 router.post('/closing/items',
     [ensureLoggedIn, security.hasPermission('MANAGE_BOWSER_CLOSING')],
     bowserController.saveDeliveryItems);

--- a/views/bowser/bowser-closing-list.pug
+++ b/views/bowser/bowser-closing-list.pug
@@ -52,7 +52,35 @@ block content
                                     else
                                         span.badge.badge-warning Draft
                                 td
-                                    a.btn.btn-sm.btn-outline-secondary(href=`/bowser/closing/${c.bowser_closing_id}`)
-                                        | View
+                                    a.btn.btn-sm.btn-outline-secondary.mr-1(href=`/bowser/closing/${c.bowser_closing_id}`) View
+                                    if c.status === 'DRAFT'
+                                        button.btn.btn-sm.btn-outline-danger(onclick=`deleteBowserClosing(${c.bowser_closing_id})`) Delete
+                                    else if c.status === 'CLOSED'
+                                        - const canReopen = (user.Role === 'SuperUser') || (user.Role === 'Admin' && allowBowserReopen === 'Y')
+                                        if canReopen
+                                            button.btn.btn-sm.btn-outline-warning.ml-1(onclick=`reopenBowserClosing(${c.bowser_closing_id})`) Reopen
         else
             .alert.alert-info No bowser closings found for the selected period.
+
+    script.
+        function deleteBowserClosing(id) {
+            if (!confirm('Delete this draft bowser closing? This cannot be undone.')) return;
+            fetch(`/bowser/closing/${id}`, { method: 'DELETE' })
+                .then(r => r.json())
+                .then(data => {
+                    if (data.success) location.reload();
+                    else alert(data.error || 'Error deleting closing.');
+                })
+                .catch(() => alert('Network error.'));
+        }
+
+        function reopenBowserClosing(id) {
+            if (!confirm('Reopen this bowser closing? Status will change back to Draft.')) return;
+            fetch(`/bowser/closing/${id}/reopen`, { method: 'POST' })
+                .then(r => r.json())
+                .then(data => {
+                    if (data.success) location.reload();
+                    else alert(data.error || 'Error reopening closing.');
+                })
+                .catch(() => alert('Network error.'));
+        }

--- a/views/bowser/bowser-closing.pug
+++ b/views/bowser/bowser-closing.pug
@@ -366,9 +366,11 @@ block content
                             div.col(align='right')
                                 button.btn.btn-dark(type='button' onclick='finalizeClosing()') Close Bowser &raquo;
                     else
-                        div.row.mt-3
-                            div.col(align='right')
-                                button.btn.btn-outline-warning(type='button' onclick='reopenClosing()') Reopen
+                        - const canReopen = (user.Role === 'SuperUser') || (user.Role === 'Admin' && allowBowserReopen === 'Y')
+                        if canReopen
+                            div.row.mt-3
+                                div.col(align='right')
+                                    button.btn.btn-outline-warning(type='button' onclick='reopenClosing()') Reopen
 
     script.
         // ── Page data ──────────────────────────────────────────────────────────


### PR DESCRIPTION
- DELETE /bowser/closing/:id — cascades across all 3 delivery tables, DRAFT only
- Reopen gated by ALLOW_BOWSER_REOPEN location config (SuperUser always allowed)
- List page: Delete button for DRAFT, Reopen button for CLOSED (when permitted)
- Closing form: Reopen button hidden unless user has permission
- reopenBowserClosing clears stored ex_shortage on reopen
- Also fix insertId bug: use correct index from Sequelize INSERT result

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>