### PR TITLE
Fix: shift closing summary — intercompany placement and data loading

### DIFF
--- a/public/javascripts/bowser-intercompany.js
+++ b/public/javascripts/bowser-intercompany.js
@@ -119,30 +119,33 @@
     // ── Summary section population ────────────────────────────────
 
     window.populateIntercompanySummary = function () {
-        const tbody = document.getElementById('summary-intercompany-tbody');
-        const totalEl = document.getElementById('val-intercompany-total');
-        if (!tbody || !totalEl) return;
+        const summaryTbody = document.getElementById('summary-intercompany-tbody');
+        const totalEl      = document.getElementById('val-intercompany-total');
+        if (!summaryTbody || !totalEl) return;
 
-        const rows = document.querySelectorAll('#intercompany-tbody tr');
+        // Query by class inside the whole table to avoid nested-tbody DOM issues
+        const qtyInputs = document.querySelectorAll('#intercompany-table .ic-qty');
         let totalQty = 0;
         const summaryRows = [];
 
-        rows.forEach(row => {
+        qtyInputs.forEach(qtyEl => {
+            const row = qtyEl.closest('tr');
+            if (!row) return;
+
             const bowserSel  = row.querySelector('.ic-bowser');
             const productEl  = row.querySelector('.ic-product-name');
-            const qtyEl      = row.querySelector('.ic-qty');
-            if (!bowserSel || !qtyEl) return;
-
-            const qty = parseFloat(qtyEl.value) || 0;
+            const qty        = parseFloat(qtyEl.value) || 0;
             if (qty <= 0) return;
 
-            const bowserName  = bowserSel.options[bowserSel.selectedIndex]?.text || '—';
+            const bowserName  = bowserSel
+                ? (bowserSel.options[bowserSel.selectedIndex]?.text || '—')
+                : '—';
             const productName = productEl ? (productEl.value || '—') : '—';
             totalQty += qty;
             summaryRows.push(`<tr><td>${bowserName}</td><td>${productName}</td><td>${qty.toFixed(3)}</td></tr>`);
         });
 
-        tbody.innerHTML = summaryRows.join('');
+        summaryTbody.innerHTML = summaryRows.join('');
         totalEl.textContent = totalQty.toFixed(3);
     };
 
@@ -174,5 +177,15 @@
             alert(msg);
         }
     }
+
+    // ── Auto-load existing entries set by the Pug template ───────
+    // window.existingIntercompanyEntries is set before this script runs,
+    // so we can read it directly here without waiting for DOMContentLoaded.
+    (function autoLoad() {
+        const entries = window.existingIntercompanyEntries;
+        if (entries && entries.length > 0) {
+            window.loadIntercompanyEntries(entries);
+        }
+    })();
 
 })();

--- a/views/edit-draft-closing.pug
+++ b/views/edit-draft-closing.pug
@@ -558,12 +558,8 @@ block content
                                 div.col
                                     button.btn.btn-primary(type="button" onclick="saveAndNextIntercompany()") Next &raquo;
                         script.
-                            window.bowserIntercompanyData = !{JSON.stringify(bowserValues)};
-                            document.addEventListener('DOMContentLoaded', function() {
-                                if (window.loadIntercompanyEntries && !{JSON.stringify(t_intercompany || [])}.length > 0) {
-                                    loadIntercompanyEntries(!{JSON.stringify(t_intercompany || [])});
-                                }
-                            });
+                            window.bowserIntercompanyData     = !{JSON.stringify(bowserValues)};
+                            window.existingIntercompanyEntries = !{JSON.stringify(t_intercompany || [])};
                         script(src="/javascripts/bowser-intercompany.js")
 
                 // ----------------------- Summary ----------------------------
@@ -676,24 +672,24 @@ block content
                                                                 span
                                                                     b#val-digital-sales-total= 0
                                                             td
-                                    if bowserValues && bowserValues.length > 0
-                                        div.col-6#v-intercompany
-                                            h6.sub-header Intercompany Fills
-                                            div.table-responsive
-                                                table.table.table-sm#summary-intercompany-table
-                                                    thead.thead-light
+                                        if bowserValues && bowserValues.length > 0
+                                            div.col-6#v-intercompany
+                                                h6.sub-header Intercompany Fills
+                                                div.table-responsive
+                                                    table.table.table-sm#summary-intercompany-table
+                                                        thead.thead-light
+                                                            tr
+                                                                th(scope="col") Bowser
+                                                                th(scope="col") Product
+                                                                th(scope="col") Qty (L)
+                                                        tbody#summary-intercompany-tbody
                                                         tr
-                                                            th(scope="col") Bowser
-                                                            th(scope="col") Product
-                                                            th(scope="col") Qty (L)
-                                                    tbody#summary-intercompany-tbody
-                                                    tr
-                                                        td(colspan=2)
-                                                            b Total
-                                                        td
-                                                            b#val-intercompany-total 0.000
-                                    else
-                                        div.col-6
+                                                            td(colspan=2)
+                                                                b Total
+                                                            td
+                                                                b#val-intercompany-total 0.000
+                                        else
+                                            div.col-6
                                 div.row
                                     if show2TSalesTab
                                         // 2T loose details


### PR DESCRIPTION
- Indent intercompany section inside the digital sales row so it renders side-by-side
- Replace DOMContentLoaded approach with window.existingIntercompanyEntries variable so entries load reliably when bowser-intercompany.js script executes