### PR TITLE
Fix: intercompany tab — auto-save on tab switch, cache bust, entry lo…

### DIFF
--- a/public/javascripts/draft-edit-scripts.js
+++ b/public/javascripts/draft-edit-scripts.js
@@ -262,7 +262,7 @@ function getSaveFunction(clickedTab) {
                 saveFunctionName = 'saveAttendance';   // dummy value
                 break;
             case 'intercompany_tab':
-                saveFunctionName = 'NoSaveClick';   // user saves explicitly via Save button
+                saveFunctionName = 'saveIntercompany';
                 break;
         }
     }

--- a/views/edit-draft-closing.pug
+++ b/views/edit-draft-closing.pug
@@ -560,7 +560,7 @@ block content
                         script.
                             window.bowserIntercompanyData     = !{JSON.stringify(bowserValues)};
                             window.existingIntercompanyEntries = !{JSON.stringify(t_intercompany || [])};
-                        script(src="/javascripts/bowser-intercompany.js")
+                        script(src=`/javascripts/bowser-intercompany.js?v=${CACHE_BUST}`)
 
                 // ----------------------- Summary ----------------------------
                 if(user.isAdmin)

--- a/views/new-closing.pug
+++ b/views/new-closing.pug
@@ -523,7 +523,7 @@ block content
                                 button.btn.btn-primary(type="button" onclick="saveAndNextIntercompany()") Next &raquo;
                         script.
                             window.bowserIntercompanyData = !{JSON.stringify(bowserValues)};
-                        script(src="/javascripts/bowser-intercompany.js")
+                        script(src=`/javascripts/bowser-intercompany.js?v=${CACHE_BUST}`)
 
                 // ----------------------- Summary ----------------------------
                 div.tab-pane.fade#summary


### PR DESCRIPTION
…ading

- Map intercompany_tab to saveIntercompany in getSaveFunction so tabbing away triggers a save
- Add cache bust query param to bowser-intercompany.js in both new and edit closing views
- Use window.existingIntercompanyEntries for reliable entry loading (no DOMContentLoaded race)