### PR TITLE
Feat: bowser closing — delete draft, reopen with config gate

### DIFF
--- a/controllers/account-heads-controller.js
+++ b/controllers/account-heads-controller.js
@@ -121,6 +121,7 @@ module.exports = {
                 max_amount:           req.body.max_amount            || null,
                 effective_start_date: req.body.effective_start_date  || null,
                 effective_end_date:   req.body.effective_end_date    || null,
+                allow_split_flag:     req.body.allow_split_flag      === 'Y' ? 'Y' : 'N',
                 created_by:           req.user.username || req.user.Person_id
             };
 
@@ -149,6 +150,7 @@ module.exports = {
                 max_amount:           req.body.max_amount            || null,
                 effective_start_date: req.body.effective_start_date  || null,
                 effective_end_date:   req.body.effective_end_date    || null,
+                allow_split_flag:     req.body.allow_split_flag      === 'Y' ? 'Y' : 'N',
                 updated_by:           req.user.username || req.user.Person_id
             };
 
@@ -173,6 +175,24 @@ module.exports = {
         } catch (err) {
             console.error("Error deleting ledger rule:", err);
             req.flash("error", "Error deleting ledger rule");
+            res.redirect("/account-heads?tab=rules");
+        }
+    },
+
+    // ── Allow Split flag — all rule types ────────────────────────────────
+
+    updateSplitFlag: async (req, res, next) => {
+        try {
+            await LedgerRulesDao.updateSplitFlag({
+                rule_id:         req.params.id,
+                allow_split_flag: req.body.allow_split_flag === 'Y' ? 'Y' : 'N',
+                updated_by:      req.user.username || req.user.Person_id
+            });
+            req.flash("success", "Split flag updated");
+            res.redirect("/account-heads?tab=rules");
+        } catch (err) {
+            console.error("Error updating split flag:", err);
+            req.flash("error", "Error updating split flag");
             res.redirect("/account-heads?tab=rules");
         }
     },

--- a/controllers/bank-statement-controller.js
+++ b/controllers/bank-statement-controller.js
@@ -14,12 +14,15 @@ module.exports = {
             let bankId = req.query.bank_id || 0;
 
             // Get configuration for manual transactions (default: true if not configured)
-            const [allowManualSetting, allowReclassifySetting] = await Promise.all([
+            const [allowManualSetting, allowReclassifySetting, allowSplitSetting] = await Promise.all([
                 locationConfigDao.getSetting(locationCode, 'ALLOW_MANUAL_BANK_TRANSACTIONS'),
-                locationConfigDao.getSetting(locationCode, 'ALLOW_BANK_RECLASSIFY')
+                locationConfigDao.getSetting(locationCode, 'ALLOW_BANK_RECLASSIFY'),
+                locationConfigDao.getSetting(locationCode, 'ALLOW_BANK_SPLIT')
             ]);
             const allowManual = allowManualSetting === null || allowManualSetting === undefined ? 'true' : allowManualSetting;
             const allowReclassify = allowReclassifySetting === null || allowReclassifySetting === undefined ? 'true' : allowReclassifySetting;
+            // Split is disabled by default — must be explicitly enabled per location
+            const allowSplit = allowSplitSetting === 'true' ? 'true' : 'false';
 
             const [accountList, locationData, transactionList, transactionTypes, accountingTypes, ledgerList] = await Promise.all([
                 BankStatementDao.getBankAccounts(locationCode),
@@ -36,6 +39,7 @@ module.exports = {
                 config: config.APP_CONFIGS,
                 allowManualBankTransactions: allowManual,
                 allowBankReclassify: allowReclassify,
+                allowBankSplit: allowSplit,
                 fromDate: fromDate,
                 toDate: toDate,
                 bankId: bankId,
@@ -159,7 +163,13 @@ module.exports = {
             // Block if the transaction already has downstream dependencies:
             //   'Credit'   → auto-receipt created; would leave dangling receipt
             //   'Supplier' → supplier reconciliation may reference external_id
+            //   is_split   → allocations live in splits table; use DELETE /splits then re-split
             const txn = await BankStatementDao.getTransactionById(tBankId);
+            if (txn && txn.is_split === 'Y') {
+                return res.status(400).json({
+                    error: 'Cannot reclassify: this transaction has been split. Remove the split first, then reclassify.'
+                });
+            }
             if (txn && ['Credit', 'Supplier'].includes(txn.external_source)) {
                 return res.status(400).json({
                     error: `Cannot reclassify: this transaction is already linked to a ${txn.external_source} ledger with downstream records. Delete and re-enter it with the correct ledger.`
@@ -284,6 +294,94 @@ module.exports = {
         } catch (error) {
             console.error('Error bulk reclassifying transactions:', error);
             res.status(500).json({ error: 'Failed to bulk reclassify transactions.' });
+        }
+    },
+
+    // ── Split transaction handlers ─────────────────────────────────────────────
+
+    // GET /bank-statement/:id/splits
+    // Returns split-eligible ledgers for this transaction AND any existing splits.
+    getSplits: async (req, res, next) => {
+        try {
+            const tBankId     = req.params.id;
+            const locationCode = req.user.location_code;
+
+            const txn = await BankStatementDao.getTransactionById(tBankId);
+            if (!txn) return res.status(404).json({ error: 'Transaction not found.' });
+
+            const entryType = parseFloat(txn.credit_amount) > 0 ? 'CREDIT' : 'DEBIT';
+
+            const [eligibleLedgers, existingSplits] = await Promise.all([
+                BankStatementDao.getSplitEligibleLedgers(txn.bank_id, locationCode, entryType),
+                BankStatementDao.getSplitsForTransaction(tBankId)
+            ]);
+
+            res.status(200).json({
+                success: true,
+                transaction: {
+                    t_bank_id:     txn.t_bank_id,
+                    trans_date:    txn.trans_date,
+                    credit_amount: txn.credit_amount,
+                    debit_amount:  txn.debit_amount,
+                    remarks:       txn.remarks,
+                    is_split:      txn.is_split
+                },
+                eligible_ledgers: eligibleLedgers,
+                existing_splits:  existingSplits
+            });
+        } catch (error) {
+            console.error('Error fetching splits:', error);
+            res.status(500).json({ error: 'Failed to fetch splits.' });
+        }
+    },
+
+    // POST /bank-statement/:id/splits
+    // Body: { splits: [{ ledger_name, external_id, external_source, amount, remarks }] }
+    // Replaces any prior split for this transaction (idempotent re-split).
+    saveSplits: async (req, res, next) => {
+        try {
+            const tBankId      = req.params.id;
+            const locationCode  = req.user.location_code;
+            const createdBy     = req.user.Person_id || req.user.username;
+            const { splits }    = req.body;
+
+            if (!Array.isArray(splits) || splits.length === 0) {
+                return res.status(400).json({ error: 'splits array is required and must not be empty.' });
+            }
+
+            const txn = await BankStatementDao.getTransactionById(tBankId);
+            if (!txn) return res.status(404).json({ error: 'Transaction not found.' });
+
+            await BankStatementDao.saveSplits(tBankId, splits, txn.bank_id, locationCode, createdBy);
+
+            res.status(200).json({ success: true, split_count: splits.length });
+        } catch (error) {
+            console.error('Error saving splits:', error);
+            // Expose validation errors (amount mismatch, ineligible ledger) as 400
+            const isValidationError = error.message &&
+                (error.message.includes('does not match') || error.message.includes('not eligible'));
+            res.status(isValidationError ? 400 : 500).json({ error: error.message || 'Failed to save splits.' });
+        }
+    },
+
+    // DELETE /bank-statement/:id/splits
+    // Removes all splits and resets the transaction to unclassified.
+    deleteSplits: async (req, res, next) => {
+        try {
+            const tBankId = req.params.id;
+
+            const txn = await BankStatementDao.getTransactionById(tBankId);
+            if (!txn) return res.status(404).json({ error: 'Transaction not found.' });
+            if (txn.is_split !== 'Y') {
+                return res.status(400).json({ error: 'Transaction is not split.' });
+            }
+
+            await BankStatementDao.deleteSplits(tBankId);
+
+            res.status(200).json({ success: true });
+        } catch (error) {
+            console.error('Error deleting splits:', error);
+            res.status(500).json({ error: 'Failed to delete splits.' });
         }
     },
 

--- a/controllers/bowser-controller.js
+++ b/controllers/bowser-controller.js
@@ -256,6 +256,14 @@ module.exports = {
                 await BowserDao.syncDraftCreditRates(bowser_closing_id, parsedRate);
                 res.json({ success: true, bowser_closing_id, message: 'Readings saved.' });
             } else {
+                // Check for an existing record for same bowser+date before inserting
+                const existingDraft = await BowserDao.getDraftByBowserAndDate(bowser_id, closing_date);
+                if (existingDraft) {
+                    return res.status(409).json({
+                        success: false,
+                        error: `A closing already exists for this bowser on ${closing_date}. Please open the existing record from the list instead of creating a new one.`
+                    });
+                }
                 const [insertId] = await BowserDao.createBowserClosing({
                     bowserId: bowser_id, locationCode, closingDate: closing_date,
                     openingMeter: opening_meter, closingMeter: closing_meter,

--- a/dao/bank-statement-dao.js
+++ b/dao/bank-statement-dao.js
@@ -79,6 +79,8 @@ module.exports = {
                 tbt.accounting_type,
                 tbt.transaction_type,
                 tbt.external_source,
+                tbt.is_split,
+                (SELECT COUNT(*) FROM t_bank_transaction_splits s WHERE s.t_bank_id = tbt.t_bank_id) AS split_count,
                 mb.account_nickname,
                 mb.bank_name
             FROM t_bank_transaction tbt
@@ -303,30 +305,47 @@ saveTransaction: async (transactionData) => {
                 tbt.external_source,
                 tbt.credit_amount,
                 tbt.debit_amount,
-                tbt.remarks
+                tbt.remarks,
+                tbt.is_split
             FROM t_bank_transaction tbt
             WHERE tbt.t_bank_id = :tBankId
         `;
-        
+
         const result = await db.sequelize.query(query, {
             replacements: { tBankId },
             type: QueryTypes.SELECT
         });
-        
+
         return result[0];
     },
 
-    // Delete transaction
+    // Delete transaction — also cleans up splits and their auto-receipts when is_split = 'Y'
     deleteTransaction: async (tBankId) => {
-        const query = `
-            DELETE FROM t_bank_transaction
-            WHERE t_bank_id = :tBankId
-        `;
-        
-        return await db.sequelize.query(query, {
-            replacements: { tBankId },
-            type: QueryTypes.DELETE
-        });
+        const t = await db.sequelize.transaction();
+        try {
+            // Delete receipts linked to this transaction (covers both direct and split-created receipts)
+            await db.sequelize.query(
+                `DELETE FROM t_receipts WHERE source_txn_id = :tBankId`,
+                { replacements: { tBankId }, type: QueryTypes.DELETE, transaction: t }
+            );
+
+            // Splits are removed by ON DELETE CASCADE on the FK, but explicit delete
+            // here keeps the intent clear and guards against engines without FK enforcement.
+            await db.sequelize.query(
+                `DELETE FROM t_bank_transaction_splits WHERE t_bank_id = :tBankId`,
+                { replacements: { tBankId }, type: QueryTypes.DELETE, transaction: t }
+            );
+
+            await db.sequelize.query(
+                `DELETE FROM t_bank_transaction WHERE t_bank_id = :tBankId`,
+                { replacements: { tBankId }, type: QueryTypes.DELETE, transaction: t }
+            );
+
+            await t.commit();
+        } catch (error) {
+            await t.rollback();
+            throw error;
+        }
     },
 
     // Get transaction types (from lookup table)
@@ -462,9 +481,280 @@ saveTransaction: async (transactionData) => {
             AND attribute1 IS NOT NULL
             ORDER BY attribute1
         `;
-        
+
         return await db.sequelize.query(query, {
             type: QueryTypes.SELECT
         });
+    },
+
+    // ── Split transaction support ─────────────────────────────────────────────
+
+    // Get ledgers eligible to be used in a split (allow_split_flag = 'Y').
+    // The entry_type param ('CREDIT' or 'DEBIT') narrows to relevant direction.
+    getSplitEligibleLedgers: async (bankId, locationCode, entryType) => {
+        const query = `
+            SELECT
+                rule_id,
+                source_type,
+                external_id,
+                ledger_name,
+                ledger_display_name,
+                allowed_entry_type,
+                notes_required_flag,
+                max_amount
+            FROM m_bank_allowed_ledgers_v
+            WHERE bank_id        = :bankId
+              AND (location_code = :locationCode OR location_code IS NULL)
+              AND allow_split_flag = 'Y'
+              AND (allowed_entry_type = 'BOTH' OR allowed_entry_type = :entryType)
+            ORDER BY source_type, ledger_display_name
+        `;
+        return await db.sequelize.query(query, {
+            replacements: { bankId, locationCode, entryType },
+            type: QueryTypes.SELECT
+        });
+    },
+
+    // Fetch existing splits for a transaction.
+    getSplitsForTransaction: async (tBankId) => {
+        const query = `
+            SELECT
+                split_id,
+                t_bank_id,
+                amount,
+                ledger_name,
+                external_id,
+                external_source,
+                remarks,
+                created_by,
+                creation_date
+            FROM t_bank_transaction_splits
+            WHERE t_bank_id = :tBankId
+            ORDER BY split_id
+        `;
+        return await db.sequelize.query(query, {
+            replacements: { tBankId },
+            type: QueryTypes.SELECT
+        });
+    },
+
+    // Save splits for a transaction.
+    //   splits: [{ ledger_name, external_id, external_source, amount, remarks }]
+    //
+    //   Validates:
+    //     • each ledger has allow_split_flag = 'Y'
+    //     • split amounts sum to the parent's credit/debit amount
+    //
+    //   Receipt creation strategy mirrors the existing non-split pattern:
+    //     • Non-cashflow location: receipts created immediately here (same as
+    //       saveTransaction does for manually-entered Credit transactions).
+    //       source_split_id is set for precise per-split dedup.
+    //     • Cashflow-enabled location: receipts are NOT created here.
+    //       The after_cashflow_close trigger creates them at cashflow close,
+    //       reading from t_bank_transaction_splits. parent closed_flag stays 'N'
+    //       so the trigger's bulk UPDATE closes it alongside everything else.
+    saveSplits: async (tBankId, splits, bankId, locationCode, createdBy) => {
+        if (!Array.isArray(splits) || splits.length === 0) {
+            throw new Error('At least one split allocation is required.');
+        }
+
+        const t = await db.sequelize.transaction();
+        try {
+            // Fetch parent
+            const [parent] = await db.sequelize.query(
+                `SELECT t_bank_id, credit_amount, debit_amount, trans_date, bank_id
+                 FROM t_bank_transaction WHERE t_bank_id = :tBankId`,
+                { replacements: { tBankId }, type: QueryTypes.SELECT, transaction: t }
+            );
+            if (!parent) throw new Error(`Transaction ${tBankId} not found.`);
+
+            const parentAmount = parseFloat(parent.credit_amount || parent.debit_amount || 0);
+            const splitTotal   = splits.reduce((s, r) => s + parseFloat(r.amount || 0), 0);
+
+            if (Math.abs(splitTotal - parentAmount) > 0.01) {
+                throw new Error(
+                    `Split total ${splitTotal.toFixed(2)} does not match transaction amount ${parentAmount.toFixed(2)}.`
+                );
+            }
+
+            // Validate each ledger is split-eligible
+            for (const split of splits) {
+                const [eligible] = await db.sequelize.query(
+                    `SELECT allow_split_flag
+                     FROM m_bank_allowed_ledgers_v
+                     WHERE bank_id        = :bankId
+                       AND (location_code = :locationCode OR location_code IS NULL)
+                       AND external_id   = :externalId
+                       AND allow_split_flag = 'Y'
+                     LIMIT 1`,
+                    {
+                        replacements: { bankId, locationCode, externalId: split.external_id },
+                        type: QueryTypes.SELECT,
+                        transaction: t
+                    }
+                );
+                if (!eligible) {
+                    throw new Error(`Ledger "${split.ledger_name}" is not eligible for split allocation.`);
+                }
+            }
+
+            // Check whether this location uses cashflow
+            const [cfRow] = await db.sequelize.query(
+                `SELECT config_value
+                 FROM m_location_config
+                 WHERE (location_code = :locationCode OR location_code = '*')
+                   AND config_name = 'CASHFLOW_ENABLED'
+                 ORDER BY CASE WHEN location_code = :locationCode THEN 0 ELSE 1 END
+                 LIMIT 1`,
+                { replacements: { locationCode }, type: QueryTypes.SELECT, transaction: t }
+            );
+            const cashflowEnabled = !cfRow || String(cfRow.config_value).toLowerCase() !== 'false';
+
+            // Remove prior splits and their receipts (re-split replaces previous)
+            await db.sequelize.query(
+                `DELETE FROM t_receipts WHERE source_split_id IN
+                    (SELECT split_id FROM t_bank_transaction_splits WHERE t_bank_id = :tBankId)`,
+                { replacements: { tBankId }, type: QueryTypes.DELETE, transaction: t }
+            );
+            await db.sequelize.query(
+                `DELETE FROM t_bank_transaction_splits WHERE t_bank_id = :tBankId`,
+                { replacements: { tBankId }, type: QueryTypes.DELETE, transaction: t }
+            );
+
+            // Insert each split row; for non-cashflow Credit splits, create receipt immediately
+            for (const split of splits) {
+                const [splitInsertResult] = await db.sequelize.query(
+                    `INSERT INTO t_bank_transaction_splits
+                        (t_bank_id, amount, ledger_name, external_id, external_source, remarks, created_by, creation_date)
+                     VALUES
+                        (:tBankId, :amount, :ledger_name, :external_id, :external_source, :remarks, :createdBy, NOW())`,
+                    {
+                        replacements: {
+                            tBankId,
+                            amount:          split.amount,
+                            ledger_name:     split.ledger_name,
+                            external_id:     split.external_id    || null,
+                            external_source: split.external_source || null,
+                            remarks:         split.remarks         || null,
+                            createdBy
+                        },
+                        type: QueryTypes.INSERT,
+                        transaction: t
+                    }
+                );
+                const splitId = splitInsertResult; // LAST_INSERT_ID
+
+                // Non-cashflow only: create receipt immediately (same as saveTransaction)
+                if (
+                    !cashflowEnabled &&
+                    split.external_source &&
+                    split.external_source.toUpperCase() === 'CREDIT' &&
+                    parseFloat(split.amount) > 0 &&
+                    split.external_id
+                ) {
+                    const [receiptMax] = await db.sequelize.query(
+                        `SELECT COALESCE(MAX(receipt_no), 0) AS max_no
+                         FROM t_receipts WHERE location_code = :locationCode`,
+                        { replacements: { locationCode }, type: QueryTypes.SELECT, transaction: t }
+                    );
+                    const nextReceiptNo = parseInt(receiptMax.max_no) + 1;
+
+                    await db.sequelize.query(
+                        `INSERT INTO t_receipts (
+                            receipt_no, creditlist_id, amount, receipt_date, receipt_type,
+                            location_code, cashflow_date, notes,
+                            created_by, updated_by, creation_date, updation_date,
+                            source_txn_id, source_split_id
+                         ) VALUES (
+                            :receipt_no, :creditlist_id, :amount, :receipt_date, 'Bank Deposit',
+                            :location_code, CURDATE(), :notes,
+                            :created_by, :created_by, NOW(), NOW(),
+                            :source_txn_id, :source_split_id
+                         )`,
+                        {
+                            replacements: {
+                                receipt_no:      nextReceiptNo,
+                                creditlist_id:   split.external_id,
+                                amount:          split.amount,
+                                receipt_date:    parent.trans_date,
+                                location_code:   locationCode,
+                                notes:           split.remarks
+                                                     ? `Split from Bank - ${split.remarks}`
+                                                     : 'Split from Bank',
+                                created_by:      createdBy,
+                                source_txn_id:   tBankId,
+                                source_split_id: splitId
+                            },
+                            type: QueryTypes.INSERT,
+                            transaction: t
+                        }
+                    );
+                }
+            }
+
+            // Mark parent as split.
+            // For cashflow locations: leave closed_flag = 'N' — the trigger closes it.
+            // For non-cashflow locations: close it now (no trigger will run).
+            if (cashflowEnabled) {
+                await db.sequelize.query(
+                    `UPDATE t_bank_transaction SET is_split = 'Y' WHERE t_bank_id = :tBankId`,
+                    { replacements: { tBankId }, type: QueryTypes.UPDATE, transaction: t }
+                );
+            } else {
+                await db.sequelize.query(
+                    `UPDATE t_bank_transaction
+                     SET is_split = 'Y', closed_flag = 'Y', closed_date = CURDATE()
+                     WHERE t_bank_id = :tBankId`,
+                    { replacements: { tBankId }, type: QueryTypes.UPDATE, transaction: t }
+                );
+            }
+
+            await t.commit();
+        } catch (error) {
+            await t.rollback();
+            throw error;
+        }
+    },
+
+    // Remove all splits for a transaction and reset it to unclassified.
+    // Deletes only receipts that carry a source_split_id (i.e. created by saveSplits
+    // for non-cashflow locations). For cashflow locations the trigger creates receipts
+    // at cashflow close; those will have source_split_id set too, so they are removed
+    // here as well — callers should guard against deleting splits after cashflow close.
+    deleteSplits: async (tBankId) => {
+        const t = await db.sequelize.transaction();
+        try {
+            // Remove only split-created receipts (identified by source_split_id)
+            await db.sequelize.query(
+                `DELETE FROM t_receipts
+                 WHERE source_split_id IN (
+                     SELECT split_id FROM t_bank_transaction_splits WHERE t_bank_id = :tBankId
+                 )`,
+                { replacements: { tBankId }, type: QueryTypes.DELETE, transaction: t }
+            );
+
+            await db.sequelize.query(
+                `DELETE FROM t_bank_transaction_splits WHERE t_bank_id = :tBankId`,
+                { replacements: { tBankId }, type: QueryTypes.DELETE, transaction: t }
+            );
+
+            // Revert parent to unclassified / unsplit state
+            await db.sequelize.query(
+                `UPDATE t_bank_transaction
+                 SET is_split        = 'N',
+                     closed_flag     = 'N',
+                     closed_date     = NULL,
+                     ledger_name     = NULL,
+                     external_id     = NULL,
+                     external_source = NULL
+                 WHERE t_bank_id = :tBankId`,
+                { replacements: { tBankId }, type: QueryTypes.UPDATE, transaction: t }
+            );
+
+            await t.commit();
+        } catch (error) {
+            await t.rollback();
+            throw error;
+        }
     }
 };

--- a/dao/bowser-dao.js
+++ b/dao/bowser-dao.js
@@ -161,6 +161,16 @@ module.exports = {
         .then(rows => (rows[0]?.closing_meter != null ? rows[0] : null));
     },
 
+    getDraftByBowserAndDate: (bowserId, closingDate) => {
+        return db.sequelize.query(`
+            SELECT bowser_closing_id
+            FROM t_bowser_closing
+            WHERE bowser_id = :bowserId AND closing_date = :closingDate AND status = 'DRAFT'
+            LIMIT 1
+        `, { replacements: { bowserId, closingDate }, type: db.Sequelize.QueryTypes.SELECT })
+        .then(rows => rows[0] || null);
+    },
+
     createBowserClosing: (data) => {
         return db.sequelize.query(`
             INSERT INTO t_bowser_closing

--- a/dao/ledger-rules-dao.js
+++ b/dao/ledger-rules-dao.js
@@ -33,6 +33,7 @@ module.exports = {
                 r.max_amount,
                 r.effective_start_date,
                 r.effective_end_date,
+                r.allow_split_flag,
                 r.created_by,
                 r.updated_by
             FROM m_ledger_rules r
@@ -57,11 +58,13 @@ module.exports = {
             INSERT INTO m_ledger_rules (
                 location_code, bank_id, source_type, external_id,
                 ledger_name, allowed_entry_type, notes_required_flag,
-                max_amount, effective_start_date, effective_end_date, created_by
+                max_amount, effective_start_date, effective_end_date,
+                allow_split_flag, created_by
             ) VALUES (
                 :location_code, :bank_id, 'Static', :external_id,
                 :ledger_name, :allowed_entry_type, :notes_required_flag,
-                :max_amount, :effective_start_date, :effective_end_date, :created_by
+                :max_amount, :effective_start_date, :effective_end_date,
+                :allow_split_flag, :created_by
             )
         `;
         return await db.sequelize.query(query, {
@@ -82,6 +85,7 @@ module.exports = {
                 max_amount           = :max_amount,
                 effective_start_date = :effective_start_date,
                 effective_end_date   = :effective_end_date,
+                allow_split_flag     = :allow_split_flag,
                 updated_by           = :updated_by,
                 updation_date        = NOW()
             WHERE rule_id = :rule_id
@@ -102,6 +106,22 @@ module.exports = {
         return await db.sequelize.query(query, {
             replacements: { id },
             type: QueryTypes.DELETE
+        });
+    },
+
+    // ── Allow Split flag — editable on all rule types ───────────────────────
+
+    updateSplitFlag: async ({ rule_id, allow_split_flag, updated_by }) => {
+        const query = `
+            UPDATE m_ledger_rules
+            SET allow_split_flag = :allow_split_flag,
+                updated_by       = :updated_by,
+                updation_date    = NOW()
+            WHERE rule_id = :rule_id
+        `;
+        return await db.sequelize.query(query, {
+            replacements: { rule_id, allow_split_flag, updated_by },
+            type: QueryTypes.UPDATE
         });
     },
 

--- a/db/migrations/bank-transaction-splits-trigger-update.sql
+++ b/db/migrations/bank-transaction-splits-trigger-update.sql
@@ -1,0 +1,214 @@
+-- ============================================================================
+-- bank-transaction-splits-trigger-update.sql
+-- ============================================================================
+-- Purpose:
+--   Update after_cashflow_close to handle split bank transactions.
+--
+--   Before this migration:
+--     The trigger's receipt INSERT read all t_bank_transaction rows with
+--     closed_flag = 'N' and external_source = 'CREDIT', creating one receipt
+--     per bank transaction.
+--
+--   After this migration:
+--     INSERT #1 (non-split): same as before, but adds
+--       AND IFNULL(is_split, 'N') = 'N'
+--     so split parent rows are skipped.
+--
+--     INSERT #2 (split rows): reads from t_bank_transaction_splits joined
+--     to the parent (for date / bank info). One receipt per Credit split row.
+--     Dedup guard uses source_split_id = s.split_id (not source_txn_id)
+--     so all N split receipts are created correctly even when multiple
+--     splits share the same parent t_bank_id.
+--
+--   Receipt creation contract (matches existing non-split pattern):
+--     • cashflow_date is stamped by the existing
+--         UPDATE t_receipts SET cashflow_date = NEW.cashflow_date
+--         WHERE cashflow_date IS NULL ...
+--       statement that already runs inside the trigger.
+--     • source_txn_id  = parent t_bank_id  (unchanged, for traceability)
+--     • source_split_id = split_id          (new column, for per-split dedup)
+--
+-- Run after: bank-transaction-splits.sql (adds source_split_id to t_receipts,
+--            adds is_split to t_bank_transaction, creates t_bank_transaction_splits)
+-- ============================================================================
+
+DROP TRIGGER IF EXISTS after_cashflow_close;
+
+DELIMITER ;;
+
+CREATE TRIGGER `after_cashflow_close`
+AFTER UPDATE ON `t_cashflow_closing`
+FOR EACH ROW
+BEGIN
+    IF @disable_triggers IS NULL OR @disable_triggers = 0 THEN
+
+        IF NEW.closing_status = 'CLOSED' THEN
+
+            -- ── INSERT #1: Non-split Credit bank transactions ─────────────────
+            --    Identical to the original trigger logic, with the addition of
+            --    AND IFNULL(is_split, 'N') = 'N' to skip split parents.
+            INSERT INTO t_receipts (
+                receipt_no,
+                creditlist_id,
+                amount,
+                receipt_date,
+                receipt_type,
+                location_code,
+                cashflow_date,
+                notes,
+                created_by,
+                updated_by,
+                creation_date,
+                updation_date,
+                source_txn_id,
+                source_split_id
+            )
+            SELECT
+                COALESCE(rmax.max_receipt_no, 0) + rn.row_num AS receipt_no,
+                rn.external_id,
+                rn.credit_amount,
+                CAST(rn.trans_date AS DATETIME)               AS receipt_date,
+                'Bank Deposit',
+                mb.location_code,
+                NEW.cashflow_date,
+                'Bank Transaction',
+                'system',
+                'system',
+                NOW(),
+                NOW(),
+                rn.t_bank_id,
+                NULL                                          -- not a split receipt
+            FROM (
+                SELECT *,
+                       ROW_NUMBER() OVER (ORDER BY t_bank_id) AS row_num
+                FROM t_bank_transaction
+                WHERE COALESCE(closed_flag, 'N') = 'N'
+                  AND external_source            = 'CREDIT'
+                  AND credit_amount              > 0
+                  AND IFNULL(is_split, 'N')      = 'N'        -- ← skip split parents
+            ) AS rn
+            JOIN m_bank mb ON rn.bank_id = mb.bank_id
+            LEFT JOIN (
+                SELECT MAX(receipt_no) AS max_receipt_no
+                FROM t_receipts
+                WHERE location_code = NEW.location_code
+            ) AS rmax ON TRUE
+            WHERE mb.location_code = NEW.location_code
+              AND NOT EXISTS (
+                  SELECT 1 FROM t_receipts r
+                  WHERE r.source_txn_id = rn.t_bank_id
+                    AND r.source_split_id IS NULL
+              );
+
+            -- ── INSERT #2: Split Credit allocations ───────────────────────────
+            --    For each split row that is a Credit allocation and whose parent
+            --    is open (closed_flag = 'N') at this location, create one receipt.
+            --    Dedup guard uses source_split_id so all N splits are created even
+            --    when they share the same parent t_bank_id.
+            INSERT INTO t_receipts (
+                receipt_no,
+                creditlist_id,
+                amount,
+                receipt_date,
+                receipt_type,
+                location_code,
+                cashflow_date,
+                notes,
+                created_by,
+                updated_by,
+                creation_date,
+                updation_date,
+                source_txn_id,
+                source_split_id
+            )
+            SELECT
+                COALESCE(rmax2.max_receipt_no, 0) + ROW_NUMBER() OVER (ORDER BY s.split_id) AS receipt_no,
+                s.external_id,
+                s.amount,
+                CAST(tbt.trans_date AS DATETIME)                AS receipt_date,
+                'Bank Deposit',
+                mb.location_code,
+                NEW.cashflow_date,
+                CASE
+                    WHEN s.remarks IS NOT NULL AND s.remarks != ''
+                    THEN CONCAT('Split from Bank - ', s.remarks)
+                    ELSE 'Split from Bank'
+                END,
+                'system',
+                'system',
+                NOW(),
+                NOW(),
+                tbt.t_bank_id,
+                s.split_id
+            FROM t_bank_transaction_splits s
+            JOIN t_bank_transaction tbt ON s.t_bank_id = tbt.t_bank_id
+            JOIN m_bank mb              ON tbt.bank_id = mb.bank_id
+            LEFT JOIN (
+                SELECT MAX(receipt_no) AS max_receipt_no
+                FROM t_receipts
+                WHERE location_code = NEW.location_code
+            ) AS rmax2 ON TRUE
+            WHERE mb.location_code          = NEW.location_code
+              AND s.external_source         = 'CREDIT'
+              AND s.amount                  > 0
+              AND s.external_id             IS NOT NULL
+              AND COALESCE(tbt.closed_flag, 'N') = 'N'        -- parent still open
+              AND NOT EXISTS (
+                  SELECT 1 FROM t_receipts r
+                  WHERE r.source_split_id = s.split_id
+              );
+
+            -- ── Close all open bank transactions for this location ────────────
+            UPDATE t_bank_transaction
+            SET closed_flag = 'Y',
+                closed_date = NEW.cashflow_date
+            WHERE COALESCE(closed_flag, 'N') = 'N'
+              AND bank_id IN (
+                  SELECT bank_id FROM m_bank WHERE location_code = NEW.location_code
+              );
+
+            -- ── Stamp cashflow_date on all unclaimed non-cash receipts ────────
+            --    This covers both non-split receipts AND split receipts that were
+            --    created by INSERT #2 above (cashflow_date = NEW.cashflow_date
+            --    already set in the INSERT, so this UPDATE is a no-op for them,
+            --    but harmless and kept for clarity).
+            UPDATE t_receipts
+            SET cashflow_date = NEW.cashflow_date
+            WHERE cashflow_date IS NULL
+              AND location_code = NEW.location_code
+              AND receipt_type != 'Cash';
+
+            -- Stamp cash receipts claimed during generate_cashflow
+            UPDATE t_receipts
+            SET cashflow_date       = NEW.cashflow_date,
+                pending_cashflow_id = NULL
+            WHERE pending_cashflow_id = NEW.cashflow_id;
+
+            -- Stamp employee payables
+            UPDATE t_employee_payable
+            SET cashflow_date       = NEW.cashflow_date,
+                pending_cashflow_id = NULL
+            WHERE pending_cashflow_id = NEW.cashflow_id;
+
+            -- Stamp stock receipts
+            UPDATE t_tank_stk_rcpt
+            SET cashflow_date = NEW.cashflow_date
+            WHERE cashflow_date IS NULL
+              AND location_code = NEW.location_code;
+
+            CALL generate_closing_Stock(NEW.location_code, NEW.cashflow_date, NEW.cashflow_date);
+
+        END IF;
+
+    END IF;
+END;;
+
+DELIMITER ;
+
+
+-- ── Verify ───────────────────────────────────────────────────────────────────
+-- After migration, confirm the trigger body contains 'is_split'.
+SELECT TRIGGER_NAME, ACTION_STATEMENT
+FROM INFORMATION_SCHEMA.TRIGGERS
+WHERE TRIGGER_SCHEMA = DATABASE()
+  AND TRIGGER_NAME   = 'after_cashflow_close';

--- a/db/migrations/bank-transaction-splits.sql
+++ b/db/migrations/bank-transaction-splits.sql
@@ -1,0 +1,228 @@
+-- ============================================================================
+-- bank-transaction-splits.sql
+-- ============================================================================
+-- Purpose:
+--   Adds split-transaction support to the bank statement module.
+--
+--   1. m_ledger_rules  → add allow_split_flag (controls which ledgers may
+--                         appear as split targets, e.g. Paytm = 'N')
+--   2. m_bank_allowed_ledgers_v → recreate to expose allow_split_flag
+--   3. t_bank_transaction → add is_split flag
+--   4. t_bank_transaction_splits → new child table for split allocations
+--
+-- Design contract:
+--   • A parent t_bank_transaction row is the raw bank line (full amount).
+--   • When is_split = 'Y', classification and receipt creation come from
+--     t_bank_transaction_splits rows instead of the parent.
+--   • SUM(splits.amount) must equal the parent credit_amount (or debit_amount).
+--   • allow_split_flag = 'N' on a ledger rule prevents that ledger from
+--     appearing in the split modal dropdown, enforced in both UI and API.
+--
+-- Safe to re-run:
+--   ALTER TABLE ... ADD COLUMN uses IF NOT EXISTS guard (MySQL 8+).
+--   CREATE TABLE uses IF NOT EXISTS.
+--   CREATE OR REPLACE VIEW is idempotent.
+-- ============================================================================
+
+
+-- ── 0. Location config key: ALLOW_BANK_SPLIT ─────────────────────────────────
+--    Controls whether the split transaction UI is shown on the bank statement
+--    page.  Disabled by default — must be explicitly enabled per location.
+--    Insert the row below for each location that should have split enabled:
+--
+--      INSERT INTO m_location_config (location_code, config_name, config_value)
+--      VALUES ('SFS', 'ALLOW_BANK_SPLIT', 'true')
+--      ON DUPLICATE KEY UPDATE config_value = 'true';
+--
+--    To enable globally across all locations:
+--      INSERT INTO m_location_config (location_code, config_name, config_value)
+--      VALUES ('*', 'ALLOW_BANK_SPLIT', 'true')
+--      ON DUPLICATE KEY UPDATE config_value = 'true';
+-- ────────────────────────────────────────────────────────────────────────────
+
+
+-- ── 1. Add allow_split_flag to m_ledger_rules ────────────────────────────────
+--    Default 'N' — no ledger is split-eligible unless explicitly set to 'Y'.
+--    Enable splitting for specific ledgers (e.g. Credit customers) as needed:
+--
+--      UPDATE m_ledger_rules SET allow_split_flag = 'Y'
+--      WHERE source_type = 'Credit';
+-- ────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE m_ledger_rules
+    ADD COLUMN IF NOT EXISTS allow_split_flag CHAR(1) NOT NULL DEFAULT 'N';
+
+
+-- ── 2. Recreate m_bank_allowed_ledgers_v to expose allow_split_flag ──────────
+--    Mirrors the structure from bank-ledger-list-update.sql exactly, with
+--    allow_split_flag added as an additional projected column.
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE VIEW m_bank_allowed_ledgers_v AS
+SELECT
+    lr.rule_id,
+    lr.location_code,
+    lr.bank_id,
+    lr.source_type,
+    lr.external_id,
+    lr.allowed_entry_type,
+    lr.notes_required_flag,
+    lr.max_amount,
+    lr.allow_split_flag,
+    CASE
+        WHEN lr.source_type = 'Supplier' THEN ms.supplier_name
+        WHEN lr.source_type = 'Credit'   THEN mcl.Company_Name
+        WHEN lr.source_type = 'Static'   THEN lr.ledger_name
+        WHEN lr.source_type = 'Bank'     THEN mb2.ledger_name
+    END AS ledger_name,
+    CASE
+        WHEN lr.source_type = 'Supplier' THEN ms.supplier_short_name
+        WHEN lr.source_type = 'Credit'   THEN mcl.Company_Name
+        WHEN lr.source_type = 'Static'   THEN lr.ledger_name
+        WHEN lr.source_type = 'Bank'     THEN
+            CONCAT(mb2.bank_name,
+                   IF(mb2.account_nickname IS NOT NULL AND mb2.account_nickname != '',
+                      CONCAT(' (', mb2.account_nickname, ')'), ''))
+    END AS ledger_display_name
+FROM m_ledger_rules lr
+LEFT JOIN m_supplier ms
+    ON  lr.source_type = 'Supplier'
+    AND lr.external_id = ms.supplier_id
+    AND COALESCE(ms.effective_end_date, '9999-12-31') > CURDATE()
+LEFT JOIN m_credit_list mcl
+    ON  lr.source_type = 'Credit'
+    AND lr.external_id = mcl.creditlist_id
+    AND COALESCE(mcl.effective_end_date, '9999-12-31') > CURDATE()
+LEFT JOIN m_bank mb2
+    ON  lr.source_type = 'Bank'
+    AND lr.external_id = mb2.bank_id
+    AND mb2.active_flag = 'Y'
+WHERE lr.source_type = 'Static'
+   OR (lr.source_type = 'Supplier' AND ms.supplier_id    IS NOT NULL)
+   OR (lr.source_type = 'Credit'   AND mcl.creditlist_id IS NOT NULL)
+   OR (lr.source_type = 'Bank'     AND mb2.bank_id       IS NOT NULL)
+ORDER BY source_type, ledger_display_name;
+
+
+-- ── 3. Add is_split to t_bank_transaction ────────────────────────────────────
+--    'Y' = this row has been split into child rows in t_bank_transaction_splits.
+--    When is_split = 'Y': ledger_name / external_id / external_source on the
+--    parent are irrelevant — use the splits table instead.
+-- ────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE t_bank_transaction
+    ADD COLUMN IF NOT EXISTS is_split CHAR(1) NOT NULL DEFAULT 'N';
+
+
+-- ── 4. Add source_split_id to t_receipts ─────────────────────────────────────
+--    Allows precise per-split dedup in the after_cashflow_close trigger and
+--    clean deletion when a split is removed.
+--    NULL  = receipt was NOT created from a split row (existing rows unaffected).
+--    INT   = split_id of the t_bank_transaction_splits row that created it.
+-- ────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE t_receipts
+    ADD COLUMN IF NOT EXISTS source_split_id INT NULL
+        COMMENT 'FK to t_bank_transaction_splits.split_id; NULL for non-split receipts.',
+    ADD KEY IF NOT EXISTS idx_receipts_source_split_id (source_split_id);
+
+
+-- ── 5. Create t_bank_transaction_splits ──────────────────────────────────────
+--    One row per ledger allocation within a split transaction.
+--    amount values must sum to the parent's credit_amount (or debit_amount).
+--    Receipts auto-created for Credit splits carry source_txn_id = t_bank_id
+--    (same parent FK used by all other receipt creation paths).
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS t_bank_transaction_splits (
+    split_id        INT           NOT NULL AUTO_INCREMENT,
+    t_bank_id       INT           NOT NULL,
+    amount          DECIMAL(12,2) NOT NULL,
+    ledger_name     VARCHAR(100)  NOT NULL,
+    external_id     INT               NULL,
+    external_source VARCHAR(50)       NULL,
+    remarks         VARCHAR(255)      NULL,
+    created_by      VARCHAR(50)       NULL,
+    creation_date   DATETIME      NOT NULL DEFAULT NOW(),
+
+    PRIMARY KEY (split_id),
+    CONSTRAINT fk_split_txn FOREIGN KEY (t_bank_id)
+        REFERENCES t_bank_transaction (t_bank_id)
+        ON DELETE CASCADE
+);
+
+
+-- ── 5. v_bank_txn_classified — unified view for tally export & reports ───────
+--    Callers that previously read FROM t_bank_transaction for ledger/amount
+--    classification should use this view instead.  It presents:
+--      • Non-split rows exactly as they appear in t_bank_transaction (is_split = 'N')
+--      • Split rows expanded — one row per t_bank_transaction_splits child,
+--        inheriting the parent's date / bank / transaction_type / closed_flag
+--        but using the child's amount, ledger_name, and external_source.
+--
+--    Usage in stored procedures (e.g. tally_export_v2):
+--      Replace:  FROM t_bank_transaction tbt
+--      With:     FROM v_bank_txn_classified tbt
+--    for the BANK DEBIT and BANK CREDIT cursors.  All other cursor filters
+--    (closed_flag, external_source, location_code, date range) remain unchanged.
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE VIEW v_bank_txn_classified AS
+-- ── Non-split rows: pass through unchanged ───────────────────────────────────
+SELECT
+    tbt.t_bank_id,
+    tbt.trans_date,
+    tbt.bank_id,
+    tbt.transaction_type,
+    tbt.debit_amount,
+    tbt.credit_amount,
+    tbt.ledger_name,
+    tbt.external_source,
+    tbt.remarks,
+    tbt.closed_flag
+FROM t_bank_transaction tbt
+WHERE IFNULL(tbt.is_split, 'N') = 'N'
+
+UNION ALL
+
+-- ── Split rows: one row per split child, parent metadata inherited ────────────
+SELECT
+    tbt.t_bank_id,
+    tbt.trans_date,
+    tbt.bank_id,
+    tbt.transaction_type,
+    CASE WHEN tbt.debit_amount  > 0 THEN s.amount ELSE NULL END AS debit_amount,
+    CASE WHEN tbt.credit_amount > 0 THEN s.amount ELSE NULL END AS credit_amount,
+    s.ledger_name,
+    s.external_source,
+    CONCAT(
+        IFNULL(tbt.remarks, ''),
+        CASE WHEN s.remarks IS NOT NULL AND s.remarks != ''
+             THEN CONCAT(' - ', s.remarks) ELSE '' END
+    ) AS remarks,
+    tbt.closed_flag
+FROM t_bank_transaction tbt
+JOIN t_bank_transaction_splits s ON s.t_bank_id = tbt.t_bank_id
+WHERE tbt.is_split = 'Y';
+
+
+-- ── Verify ───────────────────────────────────────────────────────────────────
+-- Confirm allow_split_flag column exists
+SELECT COLUMN_NAME, COLUMN_DEFAULT, IS_NULLABLE
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE()
+  AND TABLE_NAME   = 'm_ledger_rules'
+  AND COLUMN_NAME  = 'allow_split_flag';
+
+-- Confirm is_split column exists
+SELECT COLUMN_NAME, COLUMN_DEFAULT, IS_NULLABLE
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE()
+  AND TABLE_NAME   = 't_bank_transaction'
+  AND COLUMN_NAME  = 'is_split';
+
+-- Confirm splits table exists
+SELECT TABLE_NAME
+FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA = DATABASE()
+  AND TABLE_NAME   = 't_bank_transaction_splits';

--- a/routes/account-heads-routes.js
+++ b/routes/account-heads-routes.js
@@ -70,4 +70,12 @@ router.post(
     AccountHeadsController.updateEntryType
 );
 
+// Allow Split flag toggle (all rule types)
+router.post(
+    "/rules/:id/split-flag",
+    isLoggedIn,
+    appSecurity.hasPermission("EDIT_ACCOUNT_HEADS"),
+    AccountHeadsController.updateSplitFlag
+);
+
 module.exports = router;

--- a/routes/bank-statement-routes.js
+++ b/routes/bank-statement-routes.js
@@ -65,6 +65,32 @@ router.patch('/:id/reclassify',
     }
 );
 
+// GET route - Get split-eligible ledgers and existing splits for a transaction
+router.get('/:id/splits',
+    isLoginEnsured,
+    (req, res, next) => {
+        bankStatementController.getSplits(req, res, next);
+    }
+);
+
+// POST route - Save (or replace) splits for a transaction
+router.post('/:id/splits',
+    isLoginEnsured,
+    appSecurity.hasPermission('EDIT_BANK_STATEMENT'),
+    (req, res, next) => {
+        bankStatementController.saveSplits(req, res, next);
+    }
+);
+
+// DELETE route - Remove all splits and reset transaction to unclassified
+router.delete('/:id/splits',
+    isLoginEnsured,
+    appSecurity.hasPermission('EDIT_BANK_STATEMENT'),
+    (req, res, next) => {
+        bankStatementController.deleteSplits(req, res, next);
+    }
+);
+
 // DELETE route - Delete bank transaction
 router.delete('/:id',
     isLoginEnsured,

--- a/views/account-heads.pug
+++ b/views/account-heads.pug
@@ -171,6 +171,7 @@ block content
                                     th Entry Type
                                     th Max Amt
                                     th Effective
+                                    th Allow Split
                                     if canEdit
                                         th Actions
                             tbody#rulesTableBody
@@ -186,6 +187,17 @@ block content
                                             span.badge(class=rule.allowed_entry_type === 'CREDIT' ? 'badge-success' : (rule.allowed_entry_type === 'DEBIT' ? 'badge-danger' : 'badge-secondary'))= rule.allowed_entry_type
                                         td= rule.max_amount ? Number(rule.max_amount).toLocaleString('en-IN') : '—'
                                         td= rule.effective_start_date ? new Date(rule.effective_start_date).toLocaleDateString('en-GB') : '—'
+                                        td.text-center
+                                            if canEdit
+                                                button.btn.btn-sm.btn-split-flag(
+                                                    type="button"
+                                                    data-id=rule.rule_id
+                                                    data-value=(rule.allow_split_flag || 'N')
+                                                    class=(rule.allow_split_flag === 'Y' ? 'btn-success' : 'btn-outline-secondary')
+                                                    title=(rule.allow_split_flag === 'Y' ? 'Split allowed — click to disable' : 'Split disabled — click to enable'))
+                                                    = rule.allow_split_flag === 'Y' ? 'Yes' : 'No'
+                                            else
+                                                span= rule.allow_split_flag === 'Y' ? 'Yes' : 'No'
                                         if canEdit
                                             td
                                                 if isStatic
@@ -198,6 +210,7 @@ block content
                                                         data-entry-type=rule.allowed_entry_type,
                                                         data-notes=rule.notes_required_flag,
                                                         data-max-amount=rule.max_amount || '',
+                                                        data-allow-split=(rule.allow_split_flag || 'N'),
                                                         data-start=rule.effective_start_date ? rule.effective_start_date.toString().substring(0,10) : '',
                                                         data-end=rule.effective_end_date     ? rule.effective_end_date.toString().substring(0,10)   : '')
                                                         i.bi.bi-pencil
@@ -233,6 +246,7 @@ block content
                                                 data-entry-type=rule.allowed_entry_type,
                                                 data-notes=rule.notes_required_flag,
                                                 data-max-amount=rule.max_amount || '',
+                                                data-allow-split=(rule.allow_split_flag || 'N'),
                                                 data-start=rule.effective_start_date ? rule.effective_start_date.toString().substring(0,10) : '',
                                                 data-end=rule.effective_end_date     ? rule.effective_end_date.toString().substring(0,10)   : '')
                                                 i.bi.bi-pencil
@@ -258,6 +272,17 @@ block content
                                     p.mb-1
                                         b Max Amount:&nbsp;
                                         = Number(rule.max_amount).toLocaleString('en-IN')
+                                p.mb-1
+                                    b Allow Split:&nbsp;
+                                    if canEdit
+                                        button.btn.btn-sm.btn-split-flag(
+                                            type="button"
+                                            data-id=rule.rule_id
+                                            data-value=(rule.allow_split_flag || 'N')
+                                            class=(rule.allow_split_flag === 'Y' ? 'btn-success' : 'btn-outline-secondary'))
+                                            = rule.allow_split_flag === 'Y' ? 'Yes' : 'No'
+                                    else
+                                        = rule.allow_split_flag === 'Y' ? 'Yes' : 'No'
 
     //- ── Account Head Modals ──────────────────────────────────────────────────
 
@@ -376,20 +401,26 @@ block content
                                         each head in accountHeads
                                             option(value=head.account_head_id, data-name=head.account_head_name)= head.account_head_name
                         .form-row
-                            .col-md-4
+                            .col-md-3
                                 .form-group
                                     label Entry Type *
                                     select.form-control(name="allowed_entry_type", required)
                                         option(value="BOTH") BOTH
                                         option(value="DEBIT") DEBIT
                                         option(value="CREDIT") CREDIT
-                            .col-md-4
+                            .col-md-3
                                 .form-group
                                     label Notes Required
                                     select.form-control(name="notes_required_flag")
                                         option(value="N") No
                                         option(value="Y") Yes
-                            .col-md-4
+                            .col-md-3
+                                .form-group
+                                    label Allow Split
+                                    select.form-control(name="allow_split_flag")
+                                        option(value="N") No
+                                        option(value="Y") Yes
+                            .col-md-3
                                 .form-group
                                     label Max Amount
                                     input.form-control(type="number", name="max_amount", step="0.01", placeholder="Blank = unlimited")
@@ -435,20 +466,26 @@ block content
                                         each head in accountHeads
                                             option(value=head.account_head_id, data-name=head.account_head_name)= head.account_head_name
                         .form-row
-                            .col-md-4
+                            .col-md-3
                                 .form-group
                                     label Entry Type *
                                     select.form-control(name="allowed_entry_type", id="edit_rule_entry_type", required)
                                         option(value="BOTH") BOTH
                                         option(value="DEBIT") DEBIT
                                         option(value="CREDIT") CREDIT
-                            .col-md-4
+                            .col-md-3
                                 .form-group
                                     label Notes Required
                                     select.form-control(name="notes_required_flag", id="edit_rule_notes")
                                         option(value="N") No
                                         option(value="Y") Yes
-                            .col-md-4
+                            .col-md-3
+                                .form-group
+                                    label Allow Split
+                                    select.form-control(name="allow_split_flag", id="edit_rule_allow_split")
+                                        option(value="N") No
+                                        option(value="Y") Yes
+                            .col-md-3
                                 .form-group
                                     label Max Amount
                                     input.form-control(type="number", name="max_amount", id="edit_rule_max_amount", step="0.01", placeholder="Blank = unlimited")
@@ -633,6 +670,7 @@ block content
                 document.getElementById('edit_rule_head_select').value = d.accountHeadId;
                 document.getElementById('edit_rule_entry_type').value  = d.entryType;
                 document.getElementById('edit_rule_notes').value       = d.notes;
+                document.getElementById('edit_rule_allow_split').value = d.allowSplit || 'N';
                 document.getElementById('edit_rule_max_amount').value  = d.maxAmount;
                 document.getElementById('edit_rule_start').value       = d.start;
                 document.getElementById('edit_rule_end').value         = d.end;
@@ -654,6 +692,24 @@ block content
                 document.getElementById('et_allowed_entry_type').value   = d.entryType;
                 document.getElementById('editEntryTypeForm').action      = `/account-heads/rules/${d.id}/entry-type`;
                 $('#editEntryTypeModal').modal('show');
+            });
+
+            // ── Allow Split toggle ────────────────────────────────────────
+            document.addEventListener('click', function(e) {
+                const btn = e.target.closest('.btn-split-flag');
+                if (!btn) return;
+                const id      = btn.dataset.id;
+                const current = btn.dataset.value || 'N';
+                const next    = current === 'Y' ? 'N' : 'Y';
+                if (!confirm(`${next === 'Y' ? 'Enable' : 'Disable'} split for this ledger rule?`)) return;
+                fetch(`/account-heads/rules/${id}/split-flag`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: `allow_split_flag=${next}`
+                }).then(r => {
+                    if (r.ok || r.redirected) location.reload();
+                    else showMessage('Failed to update split flag', 'danger');
+                }).catch(() => showMessage('Failed to update split flag', 'danger'));
             });
 
             // ── Refresh ───────────────────────────────────────────────────

--- a/views/bank-statement.pug
+++ b/views/bank-statement.pug
@@ -46,6 +46,13 @@ block content
         .reclassify-btn:hover { color: #343a40; }
         .reclassify-form { min-width: 220px; }
         .ledger-unclassified { color: #856404; font-style: italic; }
+        .split-badge { font-size: 0.72em; color: #0c5460; background: #d1ecf1; border-radius: 3px; padding: 1px 5px; vertical-align: middle; white-space: nowrap; }
+        .split-btn { font-size: 0.72em; color: #155724; border: none; background: none; padding: 0 4px; cursor: pointer; vertical-align: middle; }
+        .split-btn:hover { text-decoration: underline; }
+        .split-remove-btn { font-size: 0.72em; color: #721c24; border: none; background: none; padding: 0 4px; cursor: pointer; vertical-align: middle; }
+        #splitModal .split-row-total { font-weight: 600; }
+        #splitModal .split-remaining.text-danger { color: #dc3545 !important; }
+        #splitModal .split-remaining.text-success { color: #28a745 !important; }
         .bulk-bar { position: fixed; bottom: 0; left: 0; right: 0; z-index: 1050; background: #343a40; color: #fff; padding: 10px 20px; display: none; align-items: center; gap: 12px; flex-wrap: wrap; }
         .bulk-bar .bulk-count { font-weight: 600; white-space: nowrap; }
         .bulk-bar select, .bulk-bar button { height: 32px; font-size: 0.85em; }
@@ -173,8 +180,10 @@ block content
                         if transactionList && transactionList.length > 0
                             each val, index in transactionList
                                 - const isUnclassified = !val.ledger_name || val.ledger_name === '' || val.ledger_name.toUpperCase() === 'OTHERS'
-                                - const canReclassify = !['Credit', 'Supplier'].includes(val.external_source)
-                                - const searchText = val.trans_date + ' ' + val.account_nickname + ' ' + (isUnclassified ? 'Unclassified ' + (val.ledger_name || '') : val.ledger_name) + ' ' + val.remarks
+                                - const isSplit = val.is_split === 'Y'
+                                - const canReclassify = !['Credit', 'Supplier'].includes(val.external_source) && !isSplit
+                                - const canSplit = allowBankSplit === 'true' && !['Credit', 'Supplier'].includes(val.external_source)
+                                - const searchText = val.trans_date + ' ' + val.account_nickname + ' ' + (isSplit ? 'Split ' : '') + (isUnclassified ? 'Unclassified ' + (val.ledger_name || '') : val.ledger_name) + ' ' + val.remarks
                                 tr(id='transaction_row_'+index data-search-text=searchText data-remarks=(val.remarks || ''))
                                     if allowBankReclassify === 'true'
                                         td.text-center
@@ -184,17 +193,26 @@ block content
                                     if accountList && accountList.length > 1
                                         td= val.account_nickname
                                     td.ledger-cell(data-t-bank-id=val.t_bank_id data-bank-id=val.bank_id)
-                                        span.ledger-display(class=isUnclassified ? 'ledger-unclassified' : '')= isUnclassified ? 'Unclassified' : val.ledger_name
-                                        if allowBankReclassify === 'true' && canReclassify
-                                            | &nbsp;
-                                            button.btn.btn-link.btn-sm.p-0.reclassify-btn(type='button' title='Reclassify ledger') ✎
-                                            .reclassify-form(style='display:none')
-                                                select.form-control.form-control-sm.reclassify-select
-                                                    option(value='') Loading...
-                                                .mt-1
-                                                    button.btn.btn-success.btn-sm.reclassify-save(type='button') ✓ Save
-                                                    |
-                                                    button.btn.btn-secondary.btn-sm.reclassify-cancel(type='button') ✕ Cancel
+                                        if isSplit
+                                            span.split-badge ⇄ Split (#{val.split_count})
+                                            if canSplit
+                                                | &nbsp;
+                                                button.split-btn(type='button' title='Edit split allocations' onclick='openSplitModal('+val.t_bank_id+', '+val.bank_id+')') ✎
+                                                button.split-remove-btn(type='button' title='Remove split and reset' onclick='removeSplit('+val.t_bank_id+')') ✕
+                                        else
+                                            span.ledger-display(class=isUnclassified ? 'ledger-unclassified' : '')= isUnclassified ? 'Unclassified' : val.ledger_name
+                                            if canSplit
+                                                | &nbsp;
+                                                if canReclassify
+                                                    button.btn.btn-link.btn-sm.p-0.reclassify-btn(type='button' title='Reclassify ledger') ✎
+                                                    .reclassify-form(style='display:none')
+                                                        select.form-control.form-control-sm.reclassify-select
+                                                            option(value='') Loading...
+                                                        .mt-1
+                                                            button.btn.btn-success.btn-sm.reclassify-save(type='button') ✓ Save
+                                                            |
+                                                            button.btn.btn-secondary.btn-sm.reclassify-cancel(type='button') ✕ Cancel
+                                                button.split-btn(type='button' title='Split this transaction across multiple ledgers' onclick='openSplitModal('+val.t_bank_id+', '+val.bank_id+')') ⇄ Split
                                     td.text-right= val.debit_amount && val.debit_amount !== null ? parseFloat(val.debit_amount).toFixed(2) : '-'
                                     td.text-right= val.credit_amount && val.credit_amount !== null ? parseFloat(val.credit_amount).toFixed(2) : '-'
                                     td= val.remarks
@@ -243,6 +261,37 @@ block content
                     button.btn.btn-info(type="button", id="bank-statement-add-new", onclick="addMoreRows()", title="Add new transaction row") Add New
                     span &nbsp;&nbsp;&nbsp;&nbsp;
                     button.btn.btn-primary(type="submit", id="bank-statement-save") Save               
+    // Split transaction modal
+    #splitModal.modal.fade(tabindex='-1' role='dialog' aria-labelledby='splitModalLabel' aria-hidden='true')
+        .modal-dialog.modal-lg(role='document')
+            .modal-content
+                .modal-header
+                    h5#splitModalLabel.modal-title Split Transaction
+                    button.close(type='button' data-dismiss='modal' aria-label='Close')
+                        span(aria-hidden='true') &times;
+                .modal-body
+                    .alert.alert-info.py-2.mb-3#splitTxnInfo
+                    table.table.table-sm.table-bordered
+                        thead.thead-light
+                            tr
+                                th(style='width:25%') Amount
+                                th Ledger
+                                th(style='width:30%') Remarks (optional)
+                                th(style='width:36px')
+                        tbody#splitRows
+                    .d-flex.justify-content-between.align-items-center.mt-2
+                        button.btn.btn-outline-secondary.btn-sm(type='button' onclick='addSplitRow()') + Add Row
+                        span
+                            | Total: &nbsp;
+                            strong#splitTotal 0.00
+                            |  &nbsp;/&nbsp;
+                            strong#splitParentAmt —
+                            | &nbsp;Remaining:&nbsp;
+                            strong#splitRemaining.split-remaining 0.00
+                .modal-footer
+                    button.btn.btn-secondary(type='button' data-dismiss='modal') Cancel
+                    button.btn.btn-success#splitSaveBtn(type='button' onclick='saveSplits()') Save Splits
+
     // Sticky bulk reclassify bar (only rendered when reclassify is enabled)
     if allowBankReclassify === 'true'
         #bulkBar.bulk-bar
@@ -260,6 +309,7 @@ block content
         const accountList = !{JSON.stringify(accountList || [])};
         const showAccountColumn = accountList && accountList.length > 1;
         const allowBankReclassify = '#{allowBankReclassify}' === 'true';
+        const allowBankSplit = '#{allowBankSplit}' === 'true';
 
         console.log('accountList:', accountList);
         console.log('showAccountColumn:', showAccountColumn);
@@ -900,6 +950,174 @@ block content
                 });
             }
         });
+
+        // ── Split transaction ───────────────────────────────────────────────
+        let _splitTBankId   = null;
+        let _splitBankId    = null;
+        let _splitParentAmt = 0;
+        let _splitLedgers   = [];
+        let _splitRowIdx    = 0;
+
+        window.openSplitModal = function(tBankId, bankId) {
+            _splitTBankId = tBankId;
+            _splitBankId  = bankId;
+            _splitLedgers = [];
+            _splitRowIdx  = 0;
+
+            document.getElementById('splitRows').innerHTML = '';
+            document.getElementById('splitSaveBtn').disabled = true;
+            document.getElementById('splitTxnInfo').textContent = 'Loading...';
+
+            fetch(`/bank-statement/${tBankId}/splits`)
+                .then(r => r.json())
+                .then(data => {
+                    if (!data.success) { alert('Error: ' + data.error); return; }
+
+                    const txn = data.transaction;
+                    _splitParentAmt = parseFloat(txn.credit_amount || txn.debit_amount || 0);
+                    _splitLedgers   = data.eligible_ledgers || [];
+
+                    const direction = txn.credit_amount > 0 ? 'Credit' : 'Debit';
+                    document.getElementById('splitParentAmt').textContent = _splitParentAmt.toFixed(2);
+                    document.getElementById('splitTxnInfo').textContent =
+                        `${txn.trans_date}  |  ${direction} ${_splitParentAmt.toFixed(2)}  |  ${txn.remarks || ''}`;
+
+                    // Populate with existing splits or one blank row
+                    const seed = data.existing_splits && data.existing_splits.length
+                        ? data.existing_splits
+                        : [{ amount: '', ledger_name: '', external_id: null, external_source: null, remarks: '' }];
+                    seed.forEach(s => _addSplitRow(s));
+
+                    document.getElementById('splitSaveBtn').disabled = false;
+                    $('#splitModal').modal('show');
+                })
+                .catch(() => alert('Failed to load split data'));
+        }
+
+        function _buildLedgerOptions(selected_external_id) {
+            let html = '<option value="">Select Ledger</option>';
+            _splitLedgers.forEach(l => {
+                const sel = String(l.external_id) === String(selected_external_id) ? ' selected' : '';
+                html += `<option value="${l.external_id}" data-ledger-name="${l.ledger_name}" data-source="${l.source_type}"${sel}>${l.ledger_display_name}</option>`;
+            });
+            return html;
+        }
+
+        function _addSplitRow(defaults) {
+            defaults = defaults || {};
+            const idx = _splitRowIdx++;
+            const tbody = document.getElementById('splitRows');
+            const tr = document.createElement('tr');
+            tr.dataset.idx = idx;
+            tr.innerHTML = `
+                <td>
+                    <input type="number" class="form-control form-control-sm text-right split-amount"
+                           step="0.01" min="0.01" placeholder="0.00"
+                           value="${defaults.amount || ''}" oninput="updateSplitTotal()">
+                </td>
+                <td>
+                    <select class="form-control form-control-sm split-ledger">
+                        ${_buildLedgerOptions(defaults.external_id)}
+                    </select>
+                </td>
+                <td>
+                    <input type="text" class="form-control form-control-sm split-remark"
+                           placeholder="Optional" maxlength="255"
+                           value="${(defaults.remarks || '').replace(/"/g, '&quot;')}">
+                </td>
+                <td class="text-center">
+                    <button type="button" class="btn btn-sm btn-outline-danger" onclick="removeSplitRow(this)">✕</button>
+                </td>`;
+            tbody.appendChild(tr);
+            updateSplitTotal();
+        }
+
+        window.addSplitRow = function() { _addSplitRow({}); }
+
+        window.removeSplitRow = function(btn) {
+            btn.closest('tr').remove();
+            updateSplitTotal();
+        }
+
+        window.updateSplitTotal = function() {
+            const amts = Array.from(document.querySelectorAll('#splitRows .split-amount'))
+                .map(i => parseFloat(i.value) || 0);
+            const total     = amts.reduce((s, v) => s + v, 0);
+            const remaining = _splitParentAmt - total;
+
+            document.getElementById('splitTotal').textContent     = total.toFixed(2);
+            document.getElementById('splitRemaining').textContent = remaining.toFixed(2);
+
+            const remEl = document.getElementById('splitRemaining');
+            remEl.classList.toggle('text-danger', Math.abs(remaining) > 0.01);
+            remEl.classList.toggle('text-success', Math.abs(remaining) <= 0.01);
+        }
+
+        window.saveSplits = function() {
+            const rows = Array.from(document.querySelectorAll('#splitRows tr'));
+            if (rows.length === 0) { alert('Add at least one split row'); return; }
+
+            const splits = [];
+            let valid = true;
+            rows.forEach(tr => {
+                const amt    = parseFloat(tr.querySelector('.split-amount').value) || 0;
+                const selEl  = tr.querySelector('.split-ledger');
+                const selOpt = selEl.options[selEl.selectedIndex];
+                const extId  = selEl.value;
+                const ledger = selOpt ? selOpt.getAttribute('data-ledger-name') : '';
+                const src    = selOpt ? selOpt.getAttribute('data-source') : '';
+                const rmk    = tr.querySelector('.split-remark').value.trim();
+
+                if (!amt || !extId) { valid = false; return; }
+                splits.push({ amount: amt, ledger_name: ledger, external_id: parseInt(extId), external_source: src, remarks: rmk });
+            });
+
+            if (!valid) { alert('Each row must have an amount and a ledger selected'); return; }
+
+            const total     = splits.reduce((s, r) => s + r.amount, 0);
+            const remaining = _splitParentAmt - total;
+            if (Math.abs(remaining) > 0.01) {
+                alert(`Split total (${total.toFixed(2)}) does not match transaction amount (${_splitParentAmt.toFixed(2)}). Difference: ${remaining.toFixed(2)}`);
+                return;
+            }
+
+            const btn = document.getElementById('splitSaveBtn');
+            btn.disabled = true;
+            btn.textContent = 'Saving...';
+
+            fetch(`/bank-statement/${_splitTBankId}/splits`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ splits })
+            })
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) {
+                    $('#splitModal').modal('hide');
+                    location.reload();
+                } else {
+                    alert('Error: ' + data.error);
+                    btn.disabled = false;
+                    btn.textContent = 'Save Splits';
+                }
+            })
+            .catch(() => {
+                alert('Failed to save splits');
+                btn.disabled = false;
+                btn.textContent = 'Save Splits';
+            });
+        }
+
+        window.removeSplit = function(tBankId) {
+            if (!confirm('Remove all split allocations and reset this transaction to unclassified?')) return;
+            fetch(`/bank-statement/${tBankId}/splits`, { method: 'DELETE' })
+                .then(r => r.json())
+                .then(data => {
+                    if (data.success) location.reload();
+                    else alert('Error: ' + data.error);
+                })
+                .catch(() => alert('Failed to remove split'));
+        }
 
         document.getElementById('transactionForm').addEventListener('submit', function(e) {
             const newRows = document.querySelectorAll('tr[id^="new-transaction-row"]');


### PR DESCRIPTION
- DELETE /bowser/closing/:id — cascades across all 3 delivery tables, DRAFT only
- Reopen gated by ALLOW_BOWSER_REOPEN location config (SuperUser always allowed)
- List page: Delete button for DRAFT, Reopen button for CLOSED (when permitted)
- Closing form: Reopen button hidden unless user has permission
- reopenBowserClosing clears stored ex_shortage on reopen
- Also fix insertId bug: use correct index from Sequelize INSERT result

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>