### PR TITLE
Add testing quantity to bowser closing and rename sale tabs

### DIFF
--- a/controllers/bowser-controller.js
+++ b/controllers/bowser-controller.js
@@ -237,7 +237,7 @@ module.exports = {
     saveDraft: async (req, res) => {
         try {
             const { bowser_closing_id, bowser_id, closing_date,
-                    opening_meter, closing_meter, rate, fills_received, opening_stock } = req.body;
+                    opening_meter, closing_meter, testing_qty, rate, fills_received, opening_stock } = req.body;
             const locationCode = req.user.location_code;
             const createdBy = String(req.user.Person_id);
             const parsedRate = parsePositiveRate(rate);
@@ -249,6 +249,7 @@ module.exports = {
             if (bowser_closing_id) {
                 await BowserDao.updateBowserClosing(bowser_closing_id, {
                     openingMeter: opening_meter, closingMeter: closing_meter,
+                    testingQty: testing_qty || 0,
                     rate: parsedRate,
                     fillsReceived: fills_received, openingStock: opening_stock,
                     updatedBy: createdBy
@@ -267,6 +268,7 @@ module.exports = {
                 const [insertId] = await BowserDao.createBowserClosing({
                     bowserId: bowser_id, locationCode, closingDate: closing_date,
                     openingMeter: opening_meter, closingMeter: closing_meter,
+                    testingQty: testing_qty || 0,
                     rate: parsedRate,
                     fillsReceived: fills_received, openingStock: opening_stock,
                     createdBy

--- a/dao/bowser-dao.js
+++ b/dao/bowser-dao.js
@@ -140,8 +140,8 @@ module.exports = {
         return db.sequelize.query(`
             SELECT bc.*, b.bowser_name, b.capacity_litres, b.product_id,
                    p.product_name, p.price AS product_price,
-                   (bc.closing_meter - bc.opening_meter) AS meter_diff,
-                   (bc.opening_stock + bc.fills_received - (bc.closing_meter - bc.opening_meter)) AS closing_stock
+                   (bc.closing_meter - bc.opening_meter - bc.testing_qty) AS meter_diff,
+                   (bc.opening_stock + bc.fills_received - (bc.closing_meter - bc.opening_meter - bc.testing_qty)) AS closing_stock
             FROM t_bowser_closing bc
             JOIN m_bowser  b ON b.bowser_id  = bc.bowser_id
             JOIN m_product p ON p.product_id = b.product_id
@@ -174,9 +174,9 @@ module.exports = {
     createBowserClosing: (data) => {
         return db.sequelize.query(`
             INSERT INTO t_bowser_closing
-                (bowser_id, location_code, closing_date, opening_meter, closing_meter, rate,
+                (bowser_id, location_code, closing_date, opening_meter, closing_meter, testing_qty, rate,
                  fills_received, opening_stock, status, created_by)
-            VALUES (:bowserId, :locationCode, :closingDate, :openingMeter, :closingMeter, :rate,
+            VALUES (:bowserId, :locationCode, :closingDate, :openingMeter, :closingMeter, :testingQty, :rate,
                     :fillsReceived, :openingStock, 'DRAFT', :createdBy)
         `, { replacements: data, type: db.Sequelize.QueryTypes.INSERT });
     },
@@ -186,6 +186,7 @@ module.exports = {
             UPDATE t_bowser_closing
             SET opening_meter  = :openingMeter,
                 closing_meter  = :closingMeter,
+                testing_qty    = :testingQty,
                 rate           = :rate,
                 fills_received = :fillsReceived,
                 opening_stock  = :openingStock,
@@ -203,7 +204,7 @@ module.exports = {
                     COALESCE((SELECT SUM(amount) FROM t_bowser_credits       WHERE bowser_closing_id = :bowserClosingId), 0) +
                     COALESCE((SELECT SUM(amount) FROM t_bowser_digital_sales  WHERE bowser_closing_id = :bowserClosingId), 0) +
                     COALESCE((SELECT SUM(amount) FROM t_bowser_cashsales      WHERE bowser_closing_id = :bowserClosingId), 0) -
-                    (closing_meter - opening_meter) * rate
+                    (closing_meter - opening_meter - testing_qty) * rate
                 ),
                 updated_by  = :updatedBy,
                 updation_date = NOW()
@@ -365,14 +366,14 @@ module.exports = {
     getExShortage: (bowserClosingId) => {
         return db.sequelize.query(`
             SELECT
-                (bc.closing_meter - bc.opening_meter) * bc.rate          AS reading_amount,
+                (bc.closing_meter - bc.opening_meter - bc.testing_qty) * bc.rate AS reading_amount,
                 COALESCE(SUM(cr.amount), 0)                              AS credit_amount,
                 COALESCE((SELECT SUM(amount) FROM t_bowser_digital_sales WHERE bowser_closing_id = :bowserClosingId), 0) AS digital_amount,
                 COALESCE((SELECT SUM(amount) FROM t_bowser_cashsales     WHERE bowser_closing_id = :bowserClosingId), 0) AS cash_amount
             FROM t_bowser_closing bc
             LEFT JOIN t_bowser_credits cr ON cr.bowser_closing_id = bc.bowser_closing_id
             WHERE bc.bowser_closing_id = :bowserClosingId
-            GROUP BY bc.bowser_closing_id, bc.closing_meter, bc.opening_meter, bc.rate
+            GROUP BY bc.bowser_closing_id, bc.closing_meter, bc.opening_meter, bc.testing_qty, bc.rate
         `, { replacements: { bowserClosingId }, type: db.Sequelize.QueryTypes.SELECT })
         .then(rows => {
             if (!rows[0]) return { reading_amount: 0, credit_amount: 0, digital_amount: 0, cash_amount: 0, ex_shortage: 0 };

--- a/db/migrations/bowser-add-testing-qty.sql
+++ b/db/migrations/bowser-add-testing-qty.sql
@@ -1,0 +1,20 @@
+-- Add testing_qty to t_bowser_closing
+-- Testing quantity is fuel used for calibration/testing, deducted from meter diff before sales reconciliation.
+SET @dbname = DATABASE();
+SET @colname = 'testing_qty';
+SET @tblname = 't_bowser_closing';
+
+SET @sql = IF(
+    NOT EXISTS (
+        SELECT 1 FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = @dbname AND TABLE_NAME = @tblname AND COLUMN_NAME = @colname
+    ),
+    CONCAT('ALTER TABLE ', @tblname, ' ADD COLUMN testing_qty DECIMAL(10,3) NOT NULL DEFAULT 0 COMMENT ''Fuel used for testing/calibration'' AFTER closing_meter'),
+    'SELECT ''Column already exists, skipping.'' AS status'
+);
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT 'bowser-add-testing-qty migration done.' AS status;

--- a/views/bowser/bowser-closing.pug
+++ b/views/bowser/bowser-closing.pug
@@ -17,11 +17,11 @@ block content
             li.nav-item.col-md
                 a.nav-link#readings_tab(href='#tab-readings' onclick='event.preventDefault(); bowserNav("readings_tab")') Readings
             li.nav-item.col-md
-                a.nav-link#credit_tab(href='#tab-credit' onclick='event.preventDefault(); bowserNav("credit_tab")') Credit
+                a.nav-link#credit_tab(href='#tab-credit' onclick='event.preventDefault(); bowserNav("credit_tab")') Credit Sales
             li.nav-item.col-md
-                a.nav-link#digital_tab(href='#tab-digital' onclick='event.preventDefault(); bowserNav("digital_tab")') Digital
+                a.nav-link#digital_tab(href='#tab-digital' onclick='event.preventDefault(); bowserNav("digital_tab")') Digital Sales
             li.nav-item.col-md
-                a.nav-link#cash_tab(href='#tab-cash' onclick='event.preventDefault(); bowserNav("cash_tab")') Cash
+                a.nav-link#cash_tab(href='#tab-cash' onclick='event.preventDefault(); bowserNav("cash_tab")') Cash Sales
             li.nav-item.col-md
                 a.nav-link#summary_tab(href='#tab-summary' onclick='event.preventDefault(); bowserNav("summary_tab")') Summary
 
@@ -110,6 +110,15 @@ block content
                                                 input#bc_opening_meter.form-control(
                                                     type='number' min='0' step='0.001'
                                                     value= closing ? closing.opening_meter : ''
+                                                    oninput='computeMeterDiff()'
+                                                    disabled= isClosed ? true : false
+                                                )
+                                        tr
+                                            td Testing Qty (L)
+                                            td
+                                                input#bc_testing_qty.form-control(
+                                                    type='number' min='0' step='0.001'
+                                                    value= closing ? (closing.testing_qty || 0) : 0
                                                     oninput='computeMeterDiff()'
                                                     disabled= isClosed ? true : false
                                                 )
@@ -679,6 +688,7 @@ block content
                     rate:           rate,
                     opening_meter:  document.getElementById('bc_opening_meter')?.value || 0,
                     closing_meter:  document.getElementById('bc_closing_meter')?.value || 0,
+                    testing_qty:    document.getElementById('bc_testing_qty')?.value   || 0,
                     fills_received: document.getElementById('bc_fills_received')?.value || 0,
                     opening_stock:  document.getElementById('bc_opening_stock')?.value || 0
                 })
@@ -699,9 +709,10 @@ block content
 
         // ── Readings tab ───────────────────────────────────────────────────────
         function computeMeterDiff() {
-            const open  = parseFloat(document.getElementById('bc_opening_meter').value) || 0;
-            const close = parseFloat(document.getElementById('bc_closing_meter').value) || 0;
-            const diff  = Math.max(0, close - open);
+            const open    = parseFloat(document.getElementById('bc_opening_meter').value) || 0;
+            const close   = parseFloat(document.getElementById('bc_closing_meter').value) || 0;
+            const testing = parseFloat(document.getElementById('bc_testing_qty').value)   || 0;
+            const diff    = Math.max(0, close - open - testing);
             document.getElementById('bc_meter_diff').value = diff.toFixed(3);
             computeClosingStock();
             updateAllTotals();
@@ -730,6 +741,7 @@ block content
                     bowser_closing_id: hiddenId,
                     opening_meter:     document.getElementById('bc_opening_meter').value,
                     closing_meter:     document.getElementById('bc_closing_meter').value,
+                    testing_qty:       document.getElementById('bc_testing_qty').value || 0,
                     rate:              rate,
                     fills_received:    document.getElementById('bc_fills_received').value,
                     opening_stock:     document.getElementById('bc_opening_stock').value


### PR DESCRIPTION
## Summary
- Adds **Testing Qty (L)** field to the Readings tab in bowser closing — deducted from meter diff before sales reconciliation
- Renames tab headers: Credit → Credit Sales, Digital → Digital Sales, Cash → Cash Sales
- Includes DB migration: `bowser-add-testing-qty.sql` (already run on dev and prod)

## Test plan
- [ ] Open a bowser closing draft — verify Testing Qty field appears in Readings tab
- [ ] Enter a testing qty and confirm meter diff reduces accordingly
- [ ] Verify ex/shortage in Summary reflects the testing qty deduction
- [ ] Confirm tab headers show Credit Sales, Digital Sales, Cash Sales

🤖 Generated with [Claude Code](https://claude.com/claude-code)