### PR TITLE
Fix bowser closing list — add testing qty column and correct bowser sales

### DIFF
--- a/dao/bowser-dao.js
+++ b/dao/bowser-dao.js
@@ -124,8 +124,8 @@ module.exports = {
     getBowserClosings: (locationCode, fromDate, toDate) => {
         return db.sequelize.query(`
             SELECT bc.bowser_closing_id, bc.closing_date, bc.status,
-                   bc.opening_meter, bc.closing_meter,
-                   (bc.closing_meter - bc.opening_meter) AS meter_diff,
+                   bc.opening_meter, bc.closing_meter, bc.testing_qty,
+                   (bc.closing_meter - bc.opening_meter - bc.testing_qty) AS meter_diff,
                    bc.rate, bc.ex_shortage,
                    b.bowser_name, b.capacity_litres
             FROM t_bowser_closing bc

--- a/views/bowser/bowser-closing-list.pug
+++ b/views/bowser/bowser-closing-list.pug
@@ -28,6 +28,7 @@ block content
                             th Bowser
                             th Open Meter
                             th Close Meter
+                            th Testing Qty (L)
                             th Bowser Sales (L)
                             th Rate (₹/L)
                             th Ex / Shortage (₹)
@@ -35,7 +36,8 @@ block content
                             th
                     tbody
                         each c in closings
-                            - const meterDiff = (parseFloat(c.closing_meter) - parseFloat(c.opening_meter)).toFixed(3)
+                            - const testingQty = parseFloat(c.testing_qty || 0).toFixed(3)
+                            - const meterDiff = (parseFloat(c.closing_meter) - parseFloat(c.opening_meter) - parseFloat(c.testing_qty || 0)).toFixed(3)
                             - const exShortage = c.ex_shortage != null ? parseFloat(c.ex_shortage).toFixed(2) : '—'
                             - const exClass = c.ex_shortage != null ? (parseFloat(c.ex_shortage) >= 0 ? 'text-danger' : 'text-success') : ''
                             tr
@@ -43,6 +45,7 @@ block content
                                 td= c.bowser_name
                                 td= parseFloat(c.opening_meter).toFixed(3)
                                 td= parseFloat(c.closing_meter).toFixed(3)
+                                td= testingQty
                                 td= meterDiff
                                 td= c.rate ? parseFloat(c.rate).toFixed(4) : '—'
                                 td(class=exClass)= exShortage


### PR DESCRIPTION
## Summary
- Adds **Testing Qty (L)** column to the bowser closing list page
- Fixes **Bowser Sales (L)** to correctly deduct testing_qty in both the DAO query and the view calculation

🤖 Generated with [Claude Code](https://claude.com/claude-code)