### PR TITLE
Extend stock reports to cover fuel products with value columns and Excel export

### DIFF
--- a/controllers/stock-adjustment-controller.js
+++ b/controllers/stock-adjustment-controller.js
@@ -10,8 +10,7 @@ module.exports = {
             const locationCode = req.user.location_code;
             const currentDate = moment().format('YYYY-MM-DD');
 
-            // Fetch products not linked to pumps
-            const products = await stockAdjustmentDao.getProductsNotLinkedToPumps(locationCode);
+            const products = await stockAdjustmentDao.getStockTrackingProducts(locationCode);
 
             res.render('stock-adjustment-form', {
                 title: 'Add Stock Adjustment',
@@ -42,8 +41,7 @@ getStockAdjustmentListPage: async (req, res, next) => {
             adjustmentType: req.query.adjustmentType || null
         };
 
-        // Get all products for filter dropdown
-        const products = await stockAdjustmentDao.getProductsNotLinkedToPumps(locationCode);
+        const products = await stockAdjustmentDao.getStockTrackingProducts(locationCode);
         
         // Get filtered adjustments
         const adjustmentsList = await stockAdjustmentDao.getStockAdjustmentsList(

--- a/controllers/stock-reports-controller.js
+++ b/controllers/stock-reports-controller.js
@@ -3,6 +3,31 @@ const stockReportsDao = require('../dao/stock-reports-dao');
 const stockAdjustmentDao = require('../dao/stock-adjustment-dao');
 const moment = require('moment');
 
+function buildStockSummary(rawResults) {
+    return rawResults.map(item => {
+        const openingQty   = item.opening_balance !== null ? parseFloat(item.opening_balance) : null;
+        const closingQty   = item.closing_balance !== null ? parseFloat(item.closing_balance) : null;
+        const openingPrice = parseFloat(item.opening_price || 0);
+        const closingPrice = parseFloat(item.closing_price || 0);
+        return {
+            product_id:      item.product_id,
+            product_name:    item.product_name,
+            unit:            item.unit,
+            is_tank_product: item.is_tank_product,
+            is_lube_product: item.is_lube_product,
+            opening_balance: openingQty,
+            opening_value:   openingQty !== null ? parseFloat((openingQty * openingPrice).toFixed(2)) : null,
+            total_in:        parseFloat(item.total_in  || 0),
+            purchase_value:  parseFloat(item.purchase_value || 0),
+            total_out:       parseFloat(item.total_out || 0),
+            sales_value:     parseFloat(item.sales_value || 0),
+            closing_balance: closingQty,
+            closing_value:   closingQty !== null ? parseFloat((closingQty * closingPrice).toFixed(2)) : null,
+            has_movement:    (parseFloat(item.total_in || 0) > 0 || parseFloat(item.total_out || 0) > 0)
+        };
+    });
+}
+
 module.exports = {
 
   // Stock Summary Report
@@ -10,89 +35,46 @@ getStockSummaryReport: async (req, res, next) => {
     try {
         const locationCode = req.user.location_code;
         const caller = req.body.caller || 'notpdf';
-        
-        // Get date range from body (POST) or query (GET)
-        let fromDate = req.body.fromDate || req.query.fromDate;
-        let toDate = req.body.toDate || req.query.toDate;
-        
-        // Convert to YYYY-MM-DD format
-        if (fromDate instanceof Date) {
-            fromDate = moment(fromDate).format('YYYY-MM-DD');
-        } else if (fromDate) {
-            fromDate = moment(fromDate).format('YYYY-MM-DD');
-        }
+        const showValues = req.body.showValues === 'true' || req.query.showValues === 'true';
 
-        if (toDate instanceof Date) {
-            toDate = moment(toDate).format('YYYY-MM-DD');
-        } else if (toDate) {
-            toDate = moment(toDate).format('YYYY-MM-DD');
-        }
+        let fromDate = req.body.fromDate || req.query.fromDate;
+        let toDate   = req.body.toDate   || req.query.toDate;
+
+        if (fromDate instanceof Date) fromDate = moment(fromDate).format('YYYY-MM-DD');
+        else if (fromDate) fromDate = moment(fromDate).format('YYYY-MM-DD');
+        if (toDate instanceof Date)   toDate   = moment(toDate).format('YYYY-MM-DD');
+        else if (toDate)              toDate   = moment(toDate).format('YYYY-MM-DD');
 
         let stockSummary = [];
 
-        // Generate report if dates are provided
         if (fromDate && toDate) {
-            // Use optimized stored procedure
-            const rawResults = await stockReportsDao.getStockSummaryOptimized(
-                locationCode,
-                fromDate,
-                toDate
-            );
-
-            
-            
-                        
-            // Format results
-            stockSummary = rawResults.map(item => ({
-                product_id: item.product_id,
-                product_name: item.product_name,
-                unit: item.unit,
-                opening_balance: item.opening_balance,
-                total_in: parseFloat(item.total_in || 0),
-                total_out: parseFloat(item.total_out || 0),
-                closing_balance: item.closing_balance,
-                has_movement: (item.total_in > 0 || item.total_out > 0)
-            }));
-
-            
-
+            const rawResults = await stockReportsDao.getStockSummaryOptimized(locationCode, fromDate, toDate);
+            stockSummary = buildStockSummary(rawResults);
         }
 
         const formattedFromDate = fromDate ? moment(fromDate).format('DD/MM/YYYY') : '';
-        const formattedToDate = toDate ? moment(toDate).format('DD/MM/YYYY') : '';
+        const formattedToDate   = toDate   ? moment(toDate).format('DD/MM/YYYY')   : '';
         const currentDate = moment().format('YYYY-MM-DD');
 
+        const viewData = {
+            title: 'Stock Summary Report',
+            user: req.user,
+            stockSummary,
+            fromDate,
+            toDate,
+            formattedFromDate,
+            formattedToDate,
+            currentDate,
+            showValues
+        };
+
         if (caller === 'notpdf') {
-            res.render('reports-stock-summary', {
-                title: 'Stock Summary Report',
-                user: req.user,
-                stockSummary: stockSummary,
-                fromDate: fromDate,
-                toDate: toDate,
-                formattedFromDate: formattedFromDate,
-                formattedToDate: formattedToDate,
-                currentDate: currentDate
-            });
+            res.render('reports-stock-summary', viewData);
         } else {
-            // For PDF generation
             return new Promise((resolve, reject) => {
-                res.render('reports-stock-summary', {
-                    title: 'Stock Summary Report',
-                    user: req.user,
-                    stockSummary: stockSummary,
-                    fromDate: fromDate,
-                    toDate: toDate,
-                    formattedFromDate: formattedFromDate,
-                    formattedToDate: formattedToDate,
-                    currentDate: currentDate
-                }, (err, html) => {
-                    if (err) {
-                        console.error('getStockSummaryReport: Error in res.render:', err);
-                        reject(err);
-                    } else {
-                        console.log('getStockSummaryReport: Successfully rendered HTML');
-                        resolve(html);
-                    }
+                res.render('reports-stock-summary', viewData, (err, html) => {
+                    if (err) { console.error('getStockSummaryReport render error:', err); reject(err); }
+                    else resolve(html);
                 });
             });
         }
@@ -101,7 +83,106 @@ getStockSummaryReport: async (req, res, next) => {
         console.error('Error in getStockSummaryReport:', error);
         req.flash('error', 'Failed to generate stock summary report');
         res.redirect('/home');
+    }
+},
+
+// Stock Summary Excel Export
+exportStockSummaryExcel: async (req, res, next) => {
+    try {
+        const ExcelJS = require('exceljs');
+        const locationCode = req.user.location_code;
+
+        let fromDate = req.body.fromDate || req.query.fromDate;
+        let toDate   = req.body.toDate   || req.query.toDate;
+        if (fromDate) fromDate = moment(fromDate).format('YYYY-MM-DD');
+        if (toDate)   toDate   = moment(toDate).format('YYYY-MM-DD');
+
+        if (!fromDate || !toDate) {
+            return res.status(400).send('Date range required for export');
         }
+
+        const rawResults = await stockReportsDao.getStockSummaryOptimized(locationCode, fromDate, toDate);
+        const rows = buildStockSummary(rawResults);
+
+        const wb = new ExcelJS.Workbook();
+        const ws = wb.addWorksheet('Stock Summary');
+
+        const periodLabel = `${moment(fromDate).format('DD-MMM-YYYY')} to ${moment(toDate).format('DD-MMM-YYYY')}`;
+
+        // Station name + address header (rows 1-2 blank = row 2 + 3 in 1-based sheet)
+        ws.getRow(1).getCell(1).value = req.user.station_name || locationCode;
+        ws.getRow(1).getCell(1).font = { bold: true, size: 13 };
+        ws.getRow(2).getCell(1).value = periodLabel;
+
+        // Column headers (row 4)
+        const headers = [
+            'Product Name', 'Opening', 'Value', 'Purchase', 'Amount',
+            'Sales', 'Amount', 'Closing', 'Amount'
+        ];
+        const headerRow = ws.getRow(4);
+        headers.forEach((h, i) => {
+            const cell = headerRow.getCell(i + 1);
+            cell.value = h;
+            cell.font = { bold: true };
+            cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFD9D9D9' } };
+            cell.border = {
+                top: { style: 'thin' }, bottom: { style: 'thin' },
+                left: { style: 'thin' }, right: { style: 'thin' }
+            };
+            cell.alignment = { horizontal: 'center' };
+        });
+
+        // Data rows
+        let totalOpeningVal = 0, totalPurchaseQty = 0, totalPurchaseVal = 0;
+        let totalSalesQty = 0, totalSalesVal = 0, totalClosingVal = 0;
+
+        rows.forEach((item, idx) => {
+            const r = ws.getRow(5 + idx);
+            const fmt = (v) => v !== null && v !== undefined ? parseFloat(parseFloat(v).toFixed(2)) : null;
+            r.getCell(1).value = item.product_name;
+            r.getCell(2).value = fmt(item.opening_balance);
+            r.getCell(3).value = fmt(item.opening_value);
+            r.getCell(4).value = fmt(item.total_in);
+            r.getCell(5).value = fmt(item.purchase_value);
+            r.getCell(6).value = fmt(item.total_out);
+            r.getCell(7).value = fmt(item.sales_value);
+            r.getCell(8).value = fmt(item.closing_balance);
+            r.getCell(9).value = fmt(item.closing_value);
+
+            if (item.opening_value)  totalOpeningVal  += item.opening_value;
+            if (item.total_in)       totalPurchaseQty += item.total_in;
+            if (item.purchase_value) totalPurchaseVal += item.purchase_value;
+            if (item.total_out)      totalSalesQty    += item.total_out;
+            if (item.sales_value)    totalSalesVal    += item.sales_value;
+            if (item.closing_value)  totalClosingVal  += item.closing_value;
+        });
+
+        // Total row
+        const totalRow = ws.getRow(5 + rows.length);
+        totalRow.getCell(1).value = 'Total';
+        totalRow.getCell(1).font = { bold: true };
+        totalRow.getCell(3).value = parseFloat(totalOpeningVal.toFixed(2));
+        totalRow.getCell(4).value = parseFloat(totalPurchaseQty.toFixed(2));
+        totalRow.getCell(5).value = parseFloat(totalPurchaseVal.toFixed(2));
+        totalRow.getCell(6).value = parseFloat(totalSalesQty.toFixed(2));
+        totalRow.getCell(7).value = parseFloat(totalSalesVal.toFixed(2));
+        totalRow.getCell(9).value = parseFloat(totalClosingVal.toFixed(2));
+        [1,2,3,4,5,6,7,8,9].forEach(c => { totalRow.getCell(c).font = { bold: true }; });
+
+        // Column widths
+        ws.getColumn(1).width = 36;
+        [2,3,4,5,6,7,8,9].forEach(c => { ws.getColumn(c).width = 14; });
+
+        const fileName = `StockSummary_${locationCode}_${moment(fromDate).format('DDMMYYYY')}_${moment(toDate).format('DDMMYYYY')}.xlsx`;
+        res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+        res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+        await wb.xlsx.write(res);
+        res.end();
+
+    } catch (error) {
+        console.error('Error in exportStockSummaryExcel:', error);
+        res.status(500).send('Failed to generate Excel export');
+    }
 },
     
 // Stock Ledger Report
@@ -128,8 +209,8 @@ getStockLedgerReport: async (req, res, next) => {
             toDate = moment(toDate).format('YYYY-MM-DD');
         }
 
-        // Get all products for dropdown
-        const products = await stockAdjustmentDao.getProductsNotLinkedToPumps(locationCode);
+        // Get all stock-tracked products (fuel + lube) for dropdown
+        const products = await stockAdjustmentDao.getStockTrackingProducts(locationCode);
 
         let ledgerData = [];
         let productInfo = null;

--- a/dao/stock-adjustment-dao.js
+++ b/dao/stock-adjustment-dao.js
@@ -62,6 +62,7 @@ getStockAdjustmentsList: async (locationCode, filters = {}) => {
 },
 
     // Get all lube products (including metered lubes like 2T LOOSE and MAK ADBLUE - LOOSE)
+    // Kept for backwards compatibility — adjustment screens now use getStockTrackingProducts
     getProductsNotLinkedToPumps: async (locationCode) => {
         try {
             const query = `
@@ -81,6 +82,31 @@ getStockAdjustmentsList: async (locationCode, filters = {}) => {
             });
         } catch (error) {
             console.error('Error fetching products:', error);
+            throw error;
+        }
+    },
+
+    // Get all stock-tracked products: lube (is_lube_product=1) + fuel (is_tank_product=1, is_lube_product=0)
+    getStockTrackingProducts: async (locationCode) => {
+        try {
+            const query = `
+                SELECT
+                    p.product_id,
+                    p.product_name,
+                    p.unit,
+                    p.is_tank_product,
+                    p.is_lube_product
+                FROM m_product p
+                WHERE p.location_code = ?
+                  AND (p.is_lube_product = 1 OR (p.is_tank_product = 1 AND p.is_lube_product = 0))
+                ORDER BY p.is_lube_product ASC, p.product_name
+            `;
+            return await db.sequelize.query(query, {
+                replacements: [locationCode],
+                type: Sequelize.QueryTypes.SELECT
+            });
+        } catch (error) {
+            console.error('Error fetching stock tracking products:', error);
             throw error;
         }
     },

--- a/dao/stock-reports-dao.js
+++ b/dao/stock-reports-dao.js
@@ -162,12 +162,11 @@ getStockLedger: async (productId, locationCode, fromDate, toDate) => {
 
                 UNION ALL
 
-                -- Meter Sales (metered lube products like 2T LOOSE and MAK ADBLUE - LOOSE)
-                -- Returns no rows for regular lube products (no m_pump row will match)
+                -- Meter Sales (fuel + metered lubes like 2T LOOSE) — grouped by day
                 SELECT
-                    c.closing_date as txn_date,
+                    DATE(c.closing_date) as txn_date,
                     CONVERT('METER SALE' USING utf8mb4) as txn_type,
-                    CONVERT(CAST(c.closing_id AS CHAR) USING utf8mb4) as reference_no,
+                    CONVERT('' USING utf8mb4) as reference_no,
                     SUM(r.closing_reading - r.opening_reading - COALESCE(r.testing, 0)) as quantity,
                     SUM(r.closing_reading - r.opening_reading - COALESCE(r.testing, 0)) as out_qty,
                     0 as in_qty,
@@ -181,7 +180,7 @@ getStockLedger: async (productId, locationCode, fromDate, toDate) => {
                 WHERE c.location_code = ?
                 AND DATE(c.closing_date) BETWEEN ? AND ?
                 AND (r.closing_reading - r.opening_reading - COALESCE(r.testing, 0)) > 0
-                GROUP BY c.closing_date, c.closing_id
+                GROUP BY DATE(c.closing_date)
 
                 UNION ALL
 

--- a/db/migrations/fuel-stock-summary.sql
+++ b/db/migrations/fuel-stock-summary.sql
@@ -1,0 +1,444 @@
+-- Migration: Fuel Stock Summary
+-- Extends stock reports to cover fuel products (is_tank_product=1, is_lube_product=0)
+-- alongside existing lube products.
+--
+-- Key rules applied in all queries:
+--   Purchase IN  : lube invoices (is_lube_product=1)  OR  tank receipts (is_tank_product=1, is_lube_product=0)
+--   Cash/credit/2T sales OUT : is_lube_product=1 only
+--   Meter sales OUT           : is_tank_product=1 only  (fuel + metered lubes like 2T LOOSE)
+--   Adjustments IN/OUT        : all tracked products
+--
+-- This prevents double-counting: fuel credit sales appear in both t_credits AND
+-- t_reading; by restricting t_credits/t_cashsales to is_lube_product=1, only
+-- t_reading is used for fuel.
+--
+-- Also adds price/value columns to get_all_products_stock_summary:
+--   opening_price, closing_price : last known rate (from readings/invoices)
+--   purchase_value               : sum of actual purchase amounts in period
+--   sales_value                  : sum of actual sales amounts in period
+--
+-- Run order:
+--   1. DROP/CREATE get_closing_product_stock_balance
+--   2. DROP/CREATE get_all_products_stock_summary
+
+-- ─── 1. Update get_closing_product_stock_balance ──────────────────────────────
+
+DROP FUNCTION IF EXISTS `get_closing_product_stock_balance`;
+
+DELIMITER ;;
+CREATE DEFINER=`petromath_prod`@`%` FUNCTION `get_closing_product_stock_balance`(
+    p_product_id    INT,
+    p_location_code VARCHAR(50),
+    p_closing_bal_date DATE
+) RETURNS decimal(15,2)
+BEGIN
+    DECLARE l_stock_start_date  DATE;
+    DECLARE l_is_tank_product   TINYINT DEFAULT 0;
+    DECLARE l_is_lube_product   TINYINT DEFAULT 0;
+    DECLARE l_total_purchases   DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_total_adj_in      DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_total_adj_out     DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_cashsales         DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_creditsales       DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_2toil             DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_metersales        DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_total_sales       DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_balance           DECIMAL(15,2) DEFAULT 0;
+
+    -- Determine product type
+    SELECT is_tank_product, is_lube_product
+    INTO l_is_tank_product, l_is_lube_product
+    FROM m_product
+    WHERE product_id = p_product_id;
+
+    -- Stock start date = earliest adjustment of any type
+    SELECT MIN(adjustment_date) INTO l_stock_start_date
+    FROM t_lubes_stock_adjustment
+    WHERE product_id = p_product_id
+      AND location_code = p_location_code;
+
+    IF l_stock_start_date IS NULL OR p_closing_bal_date < l_stock_start_date THEN
+        RETURN NULL;
+    END IF;
+
+    -- ── Purchases ──────────────────────────────────────────────────────────────
+
+    IF l_is_lube_product = 1 THEN
+        -- Lube invoices (packed + metered lubes)
+        SELECT COALESCE(SUM(li.qty), 0)
+        INTO l_total_purchases
+        FROM t_lubes_inv_lines li
+        JOIN t_lubes_inv_hdr hdr ON li.lubes_hdr_id = hdr.lubes_hdr_id
+        WHERE li.product_id = p_product_id
+          AND hdr.location_code = p_location_code
+          AND DATE(hdr.invoice_date) >= l_stock_start_date
+          AND DATE(hdr.invoice_date) <= p_closing_bal_date;
+    ELSE
+        -- Tank stock receipts (fuel products only), qty stored in KL → convert to litres
+        SELECT COALESCE(SUM(trd.quantity * 1000), 0)
+        INTO l_total_purchases
+        FROM t_tank_stk_rcpt_dtl trd
+        JOIN t_tank_stk_rcpt tr  ON trd.ttank_id  = tr.ttank_id
+        JOIN m_tank t            ON trd.tank_id   = t.tank_id
+        WHERE t.product_code   = (SELECT product_name FROM m_product WHERE product_id = p_product_id)
+          AND tr.location_code = p_location_code
+          AND DATE(tr.invoice_date) >= l_stock_start_date
+          AND DATE(tr.invoice_date) <= p_closing_bal_date;
+    END IF;
+
+    -- ── Sales (lube-specific: cashsales, credits, 2T oil) ──────────────────────
+
+    IF l_is_lube_product = 1 THEN
+        SELECT COALESCE(SUM(cs.qty), 0)
+        INTO l_cashsales
+        FROM t_cashsales cs
+        JOIN t_closing c ON cs.closing_id = c.closing_id
+        WHERE cs.product_id = p_product_id
+          AND c.location_code = p_location_code
+          AND DATE(c.closing_date) >= l_stock_start_date
+          AND DATE(c.closing_date) <= p_closing_bal_date;
+
+        SELECT COALESCE(SUM(tc.qty), 0)
+        INTO l_creditsales
+        FROM t_credits tc
+        JOIN t_closing c ON tc.closing_id = c.closing_id
+        WHERE tc.product_id = p_product_id
+          AND c.location_code = p_location_code
+          AND DATE(c.closing_date) >= l_stock_start_date
+          AND DATE(c.closing_date) <= p_closing_bal_date;
+
+        SELECT COALESCE(SUM(o.given_qty - o.returned_qty), 0)
+        INTO l_2toil
+        FROM t_2toil o
+        JOIN t_closing c ON o.closing_id = c.closing_id
+        WHERE o.product_id = p_product_id
+          AND c.location_code = p_location_code
+          AND DATE(c.closing_date) >= l_stock_start_date
+          AND DATE(c.closing_date) <= p_closing_bal_date;
+    END IF;
+
+    -- ── Meter sales (fuel + metered lubes, i.e. is_tank_product=1) ─────────────
+
+    IF l_is_tank_product = 1 THEN
+        SELECT COALESCE(SUM(r.closing_reading - r.opening_reading - COALESCE(r.testing, 0)), 0)
+        INTO l_metersales
+        FROM t_reading r
+        JOIN t_closing c  ON r.closing_id  = c.closing_id
+        JOIN m_pump mp    ON r.pump_id     = mp.pump_id AND mp.location_code = p_location_code
+        JOIN m_product pr ON mp.product_code = pr.product_name AND pr.product_id = p_product_id
+        WHERE c.location_code = p_location_code
+          AND DATE(c.closing_date) >= l_stock_start_date
+          AND DATE(c.closing_date) <= p_closing_bal_date
+          AND (r.closing_reading - r.opening_reading - COALESCE(r.testing, 0)) > 0;
+    END IF;
+
+    SET l_total_sales = l_cashsales + l_creditsales + l_2toil + l_metersales;
+
+    -- ── Adjustments ────────────────────────────────────────────────────────────
+
+    SELECT COALESCE(SUM(qty), 0)
+    INTO l_total_adj_in
+    FROM t_lubes_stock_adjustment
+    WHERE product_id = p_product_id
+      AND location_code = p_location_code
+      AND adjustment_type IN ('IN', 'OPENING')
+      AND DATE(adjustment_date) >= l_stock_start_date
+      AND DATE(adjustment_date) <= p_closing_bal_date;
+
+    SELECT COALESCE(SUM(qty), 0)
+    INTO l_total_adj_out
+    FROM t_lubes_stock_adjustment
+    WHERE product_id = p_product_id
+      AND location_code = p_location_code
+      AND adjustment_type = 'OUT'
+      AND DATE(adjustment_date) >= l_stock_start_date
+      AND DATE(adjustment_date) <= p_closing_bal_date;
+
+    SET l_balance = l_total_purchases + l_total_adj_in - l_total_sales - l_total_adj_out;
+
+    RETURN l_balance;
+END ;;
+DELIMITER ;
+
+
+-- ─── 2. Update get_all_products_stock_summary ─────────────────────────────────
+-- Now covers: fuel (is_tank_product=1, is_lube_product=0) + lubes (is_lube_product=1)
+-- Returns extra columns for Excel/value display:
+--   opening_price    : last known rate before the period (for value = opening_balance × opening_price)
+--   purchase_value   : sum of actual purchase invoice amounts in period
+--   sales_value      : sum of actual sales amounts in period
+--   closing_price    : last known rate on/before to_date (for value = closing_balance × closing_price)
+
+DROP PROCEDURE IF EXISTS `get_all_products_stock_summary`;
+
+DELIMITER ;;
+CREATE DEFINER=`petromath_prod`@`%` PROCEDURE `get_all_products_stock_summary`(
+    IN p_location_code VARCHAR(50),
+    IN p_from_date     DATE,
+    IN p_to_date       DATE
+)
+BEGIN
+    DECLARE l_opening_date DATE;
+    SET l_opening_date = DATE_SUB(p_from_date, INTERVAL 1 DAY);
+
+    SELECT
+        p.product_id,
+        p.product_name,
+        p.unit,
+        p.is_tank_product,
+        p.is_lube_product,
+
+        -- ── Opening balance ───────────────────────────────────────────────────
+        COALESCE(
+            get_closing_product_stock_balance(p.product_id, p_location_code, l_opening_date),
+            (SELECT SUM(qty)
+             FROM t_lubes_stock_adjustment
+             WHERE product_id = p.product_id
+               AND location_code = p_location_code
+               AND adjustment_type = 'OPENING'
+               AND DATE(adjustment_date) = p_from_date)
+        ) AS opening_balance,
+
+        -- ── Closing balance ───────────────────────────────────────────────────
+        get_closing_product_stock_balance(p.product_id, p_location_code, p_to_date) AS closing_balance,
+
+        -- ── Opening price (for opening value = opening_balance × opening_price)
+        -- Fuel: last shift price before/on l_opening_date
+        -- Lube: last invoice rate before/on l_opening_date
+        COALESCE(
+            CASE WHEN p.is_lube_product = 0 AND p.is_tank_product = 1 THEN
+                (SELECT r.price
+                 FROM t_reading r
+                 JOIN t_closing c  ON r.closing_id = c.closing_id
+                 JOIN m_pump mp    ON r.pump_id = mp.pump_id AND mp.location_code = p_location_code
+                 WHERE mp.product_code = p.product_name
+                   AND c.location_code = p_location_code
+                   AND DATE(c.closing_date) <= l_opening_date
+                 ORDER BY c.closing_date DESC, r.reading_id DESC
+                 LIMIT 1)
+            ELSE
+                (SELECT li.net_rate
+                 FROM t_lubes_inv_lines li
+                 JOIN t_lubes_inv_hdr hdr ON li.lubes_hdr_id = hdr.lubes_hdr_id
+                 WHERE li.product_id = p.product_id
+                   AND hdr.location_code = p_location_code
+                   AND DATE(hdr.invoice_date) <= l_opening_date
+                 ORDER BY hdr.invoice_date DESC
+                 LIMIT 1)
+            END
+        , 0) AS opening_price,
+
+        -- ── Closing price (for closing value = closing_balance × closing_price)
+        COALESCE(
+            CASE WHEN p.is_lube_product = 0 AND p.is_tank_product = 1 THEN
+                (SELECT r.price
+                 FROM t_reading r
+                 JOIN t_closing c  ON r.closing_id = c.closing_id
+                 JOIN m_pump mp    ON r.pump_id = mp.pump_id AND mp.location_code = p_location_code
+                 WHERE mp.product_code = p.product_name
+                   AND c.location_code = p_location_code
+                   AND DATE(c.closing_date) <= p_to_date
+                 ORDER BY c.closing_date DESC, r.reading_id DESC
+                 LIMIT 1)
+            ELSE
+                (SELECT li.net_rate
+                 FROM t_lubes_inv_lines li
+                 JOIN t_lubes_inv_hdr hdr ON li.lubes_hdr_id = hdr.lubes_hdr_id
+                 WHERE li.product_id = p.product_id
+                   AND hdr.location_code = p_location_code
+                   AND DATE(hdr.invoice_date) <= p_to_date
+                 ORDER BY hdr.invoice_date DESC
+                 LIMIT 1)
+            END
+        , 0) AS closing_price,
+
+        -- ── Total IN (qty) ────────────────────────────────────────────────────
+        COALESCE((
+            SELECT SUM(qty) FROM (
+
+                -- Lube invoices (is_lube_product=1)
+                SELECT li.qty AS qty
+                FROM t_lubes_inv_lines li
+                JOIN t_lubes_inv_hdr hdr ON li.lubes_hdr_id = hdr.lubes_hdr_id
+                WHERE li.product_id = p.product_id
+                  AND hdr.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(hdr.invoice_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- Tank receipts (fuel only: is_tank_product=1, is_lube_product=0)
+                SELECT trd.quantity * 1000 AS qty
+                FROM t_tank_stk_rcpt_dtl trd
+                JOIN t_tank_stk_rcpt tr ON trd.ttank_id = tr.ttank_id
+                JOIN m_tank t           ON trd.tank_id  = t.tank_id
+                WHERE t.product_code    = p.product_name
+                  AND tr.location_code  = p_location_code
+                  AND p.is_tank_product = 1
+                  AND p.is_lube_product = 0
+                  AND DATE(tr.invoice_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- Adjustments IN (all products)
+                SELECT qty
+                FROM t_lubes_stock_adjustment
+                WHERE product_id     = p.product_id
+                  AND location_code  = p_location_code
+                  AND adjustment_type = 'IN'
+                  AND DATE(adjustment_date) BETWEEN p_from_date AND p_to_date
+
+            ) AS ins
+        ), 0) AS total_in,
+
+        -- ── Purchase value (actual invoice amounts, for Excel) ─────────────────
+        COALESCE((
+            SELECT SUM(amt) FROM (
+
+                -- Lube invoice amounts
+                SELECT (li.qty * li.net_rate) AS amt
+                FROM t_lubes_inv_lines li
+                JOIN t_lubes_inv_hdr hdr ON li.lubes_hdr_id = hdr.lubes_hdr_id
+                WHERE li.product_id = p.product_id
+                  AND hdr.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(hdr.invoice_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- Tank receipt amounts (fuel only)
+                SELECT trd.amount AS amt
+                FROM t_tank_stk_rcpt_dtl trd
+                JOIN t_tank_stk_rcpt tr ON trd.ttank_id = tr.ttank_id
+                JOIN m_tank t           ON trd.tank_id  = t.tank_id
+                WHERE t.product_code    = p.product_name
+                  AND tr.location_code  = p_location_code
+                  AND p.is_tank_product = 1
+                  AND p.is_lube_product = 0
+                  AND DATE(tr.invoice_date) BETWEEN p_from_date AND p_to_date
+
+            ) AS purch_amts
+        ), 0) AS purchase_value,
+
+        -- ── Total OUT (qty) ───────────────────────────────────────────────────
+        COALESCE((
+            SELECT SUM(qty) FROM (
+
+                -- Cash sales (lube products only)
+                SELECT cs.qty
+                FROM t_cashsales cs
+                JOIN t_closing c ON cs.closing_id = c.closing_id
+                WHERE cs.product_id   = p.product_id
+                  AND c.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- Credit sales (lube products only — fuel credits tracked via meter)
+                SELECT cr.qty
+                FROM t_credits cr
+                JOIN t_closing c ON cr.closing_id = c.closing_id
+                WHERE cr.product_id   = p.product_id
+                  AND c.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- 2T oil (lube products only)
+                SELECT (o.given_qty - o.returned_qty)
+                FROM t_2toil o
+                JOIN t_closing c ON o.closing_id = c.closing_id
+                WHERE o.product_id    = p.product_id
+                  AND c.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+                  AND (o.given_qty - o.returned_qty) > 0
+
+                UNION ALL
+
+                -- Meter sales (fuel + metered lubes: is_tank_product=1)
+                SELECT (r.closing_reading - r.opening_reading - COALESCE(r.testing, 0))
+                FROM t_reading r
+                JOIN t_closing c ON r.closing_id = c.closing_id
+                JOIN m_pump mp   ON r.pump_id = mp.pump_id AND mp.location_code = p_location_code
+                WHERE mp.product_code  = p.product_name
+                  AND c.location_code  = p_location_code
+                  AND p.is_tank_product = 1
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+                  AND (r.closing_reading - r.opening_reading - COALESCE(r.testing, 0)) > 0
+
+                UNION ALL
+
+                -- Adjustments OUT (all products)
+                SELECT qty
+                FROM t_lubes_stock_adjustment
+                WHERE product_id     = p.product_id
+                  AND location_code  = p_location_code
+                  AND adjustment_type = 'OUT'
+                  AND DATE(adjustment_date) BETWEEN p_from_date AND p_to_date
+
+            ) AS outs
+        ), 0) AS total_out,
+
+        -- ── Sales value (actual sale amounts, for Excel) ───────────────────────
+        COALESCE((
+            SELECT SUM(amt) FROM (
+
+                -- Cash sale amounts (lube only)
+                SELECT cs.amount AS amt
+                FROM t_cashsales cs
+                JOIN t_closing c ON cs.closing_id = c.closing_id
+                WHERE cs.product_id   = p.product_id
+                  AND c.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- Credit sale amounts (lube only)
+                SELECT cr.amount AS amt
+                FROM t_credits cr
+                JOIN t_closing c ON cr.closing_id = c.closing_id
+                WHERE cr.product_id   = p.product_id
+                  AND c.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- 2T oil amounts (lube only)
+                SELECT ((o.given_qty - o.returned_qty) * o.price) AS amt
+                FROM t_2toil o
+                JOIN t_closing c ON o.closing_id = c.closing_id
+                WHERE o.product_id    = p.product_id
+                  AND c.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+                  AND (o.given_qty - o.returned_qty) > 0
+
+                UNION ALL
+
+                -- Meter sale amounts (fuel + metered lubes)
+                SELECT ((r.closing_reading - r.opening_reading - COALESCE(r.testing, 0)) * r.price) AS amt
+                FROM t_reading r
+                JOIN t_closing c ON r.closing_id = c.closing_id
+                JOIN m_pump mp   ON r.pump_id = mp.pump_id AND mp.location_code = p_location_code
+                WHERE mp.product_code  = p.product_name
+                  AND c.location_code  = p_location_code
+                  AND p.is_tank_product = 1
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+                  AND (r.closing_reading - r.opening_reading - COALESCE(r.testing, 0)) > 0
+
+            ) AS sale_amts
+        ), 0) AS sales_value
+
+    FROM m_product p
+    WHERE p.location_code = p_location_code
+      AND (p.is_lube_product = 1 OR (p.is_tank_product = 1 AND p.is_lube_product = 0))
+    ORDER BY p.is_lube_product ASC, p.product_name;
+    -- Fuel products (is_lube_product=0) sort first, then lubes
+
+END ;;
+DELIMITER ;

--- a/routes/stock-reports-routes.js
+++ b/routes/stock-reports-routes.js
@@ -18,6 +18,11 @@ router.post('/summary', isLoginEnsured, function (req, res, next) {
     stockReportsController.getStockSummaryReport(req, res, next);
 });
 
+// Stock Summary Excel Export
+router.post('/summary/excel', isLoginEnsured, function (req, res, next) {
+    stockReportsController.exportStockSummaryExcel(req, res, next);
+});
+
 // Stock Ledger Report - GET (initial load)
 router.get('/ledger', isLoginEnsured, function (req, res, next) {
     req.body.fromDate = new Date(Date.now());

--- a/views/reports-stock-summary.pug
+++ b/views/reports-stock-summary.pug
@@ -1,50 +1,76 @@
 extends layout
 
 block content
-    form(method='POST' action='/reports/stock/summary')
+    form#summaryForm(method='POST' action='/reports/stock/summary')
+        input(type='hidden' name='showValues' id='showValuesInput' value=showValues ? 'true' : 'false')
         table.center
             tr
                 td From Date:
                 td
-                    input#fromDate.form-control(type='date', name='fromDate', value=fromDate, max=currentDate, format="dd/mm/yyyy", required)
+                    input#fromDate.form-control(type='date', name='fromDate', value=fromDate, max=currentDate, required)
                 td &nbsp;
                 td To Date:
                 td
-                    input#toDate.form-control(type='date', name='toDate', value=toDate, max=currentDate, format="dd/mm/yyyy", required)
+                    input#toDate.form-control(type='date', name='toDate', value=toDate, max=currentDate, required)
+                td &nbsp;
+                td
+                    .form-check.d-inline-flex.align-items-center.ml-3
+                        input#showValuesCheck.form-check-input(
+                            type='checkbox'
+                            checked=showValues
+                            onchange="document.getElementById('showValuesInput').value = this.checked ? 'true' : 'false';"
+                            style="margin-top:0"
+                        )
+                        label.form-check-label.ml-2(for='showValuesCheck') Show Values
                 td &nbsp;
                 include report-print-download.pug
+                td
+                    if fromDate && toDate && stockSummary && stockSummary.length > 0
+                        button.btn.btn-success.ml-2(
+                            type='button'
+                            onclick="exportExcel()"
+                        )
+                            i.fas.fa-file-excel
+                            |  Export Excel
+
     div &nbsp;
     div
         div.row &nbsp;
         h4.font-weight-bold.text-center Stock Summary Report
         if formattedFromDate && formattedToDate
             h4.text-center.text-muted= `${formattedFromDate} to ${formattedToDate}`
-        h4.font-weight-bold.text-success.text-center
+
         if stockSummary && stockSummary.length > 0
             div.row
             div.col-md-12
                 div.row &nbsp;
                 div.table-responsive
-                    table.table.table-bordered.table-hover.table-sm
+                    table.table.table-bordered.table-hover.table-sm#stockSummaryTable
                         thead.thead-light
                             tr
                                 th.text-center(rowspan='2') #
                                 th.text-center(rowspan='2') Product Name
                                 th.text-center(rowspan='2') Unit
-                                th.text-center(colspan='4') Stock Movement
+                                th.text-center(colspan= showValues ? '8' : '4') Stock Movement
                             tr
                                 th.text-right Opening
-                                th.text-right IN
-                                th.text-right OUT
+                                if showValues
+                                    th.text-right Value
+                                th.text-right Purchase
+                                if showValues
+                                    th.text-right Amount
+                                th.text-right Sales
+                                if showValues
+                                    th.text-right Amount
                                 th.text-right Closing
+                                if showValues
+                                    th.text-right Value
                         tbody
                             - var productsWithStock = 0
                             - var productsWithMovement = 0
-                            - var totalOpeningValue = 0
-                            - var totalInValue = 0
-                            - var totalOutValue = 0
-                            - var totalClosingValue = 0
-                            
+                            - var totOpeningVal = 0, totPurchaseQty = 0, totPurchaseVal = 0
+                            - var totSalesQty = 0, totSalesVal = 0, totClosingVal = 0
+
                             each item, index in stockSummary
                                 - var rowClass = ''
                                 if item.opening_balance === null || item.opening_balance === undefined
@@ -52,36 +78,43 @@ block content
                                 else if item.has_movement
                                     - rowClass = 'table-success-light'
                                     - productsWithMovement++
-                                
+
                                 if item.opening_balance !== null && item.opening_balance !== undefined
                                     - productsWithStock++
-                                    - totalOpeningValue += parseFloat(item.opening_balance || 0)
-                                    - totalInValue += parseFloat(item.total_in || 0)
-                                    - totalOutValue += parseFloat(item.total_out || 0)
-                                    - totalClosingValue += parseFloat(item.closing_balance || 0)
-                                
+                                    - if(item.opening_value) totOpeningVal += item.opening_value
+                                    - totPurchaseQty += item.total_in || 0
+                                    - if(item.purchase_value) totPurchaseVal += item.purchase_value
+                                    - totSalesQty += item.total_out || 0
+                                    - if(item.sales_value) totSalesVal += item.sales_value
+                                    - if(item.closing_value) totClosingVal += item.closing_value
+
                                 tr(class=rowClass)
                                     td.text-center= index + 1
                                     td= item.product_name
                                     td.text-center= item.unit
                                     if item.opening_balance === null || item.opening_balance === undefined
-                                        td.text-center(colspan='4')
+                                        td.text-center(colspan= showValues ? '8' : '4')
                                             span.text-warning.font-italic
                                                 i.fas.fa-exclamation-triangle
                                                 |  No opening stock
                                     else
-                                        td.text-right
-                                            = parseFloat(item.opening_balance || 0).toFixed(2)
+                                        td.text-right= parseFloat(item.opening_balance || 0).toFixed(2)
+                                        if showValues
+                                            td.text-right.text-muted= item.opening_value !== null ? parseFloat(item.opening_value).toFixed(2) : '-'
                                         td.text-right
                                             if item.total_in > 0
                                                 span.text-success.font-weight-bold= parseFloat(item.total_in).toFixed(2)
                                             else
                                                 span.text-muted -
+                                        if showValues
+                                            td.text-right.text-muted= item.purchase_value > 0 ? parseFloat(item.purchase_value).toFixed(2) : '-'
                                         td.text-right
                                             if item.total_out > 0
                                                 span.text-danger.font-weight-bold= parseFloat(item.total_out).toFixed(2)
                                             else
                                                 span.text-muted -
+                                        if showValues
+                                            td.text-right.text-muted= item.sales_value > 0 ? parseFloat(item.sales_value).toFixed(2) : '-'
                                         td.text-right
                                             if item.closing_balance === null || item.closing_balance === undefined
                                                 span.text-warning.font-italic N/A
@@ -89,30 +122,55 @@ block content
                                                 span.text-danger.font-weight-bold= parseFloat(item.closing_balance || 0).toFixed(2)
                                             else
                                                 = parseFloat(item.closing_balance || 0).toFixed(2)
+                                        if showValues
+                                            td.text-right.text-muted= item.closing_value !== null ? parseFloat(item.closing_value).toFixed(2) : '-'
+
                         tfoot.bg-light
                             tr.font-weight-bold
-                                td(colspan='3') 
+                                td(colspan='3')
                                     div Total Products: #{stockSummary.length}
                                     div.small.text-muted With Stock: #{productsWithStock} | With Movement: #{productsWithMovement}
-                                td.text-right= totalOpeningValue.toFixed(2)
-                                td.text-right.text-success= totalInValue.toFixed(2)
-                                td.text-right.text-danger= totalOutValue.toFixed(2)
-                                td.text-right= totalClosingValue.toFixed(2)
-                
-                if stockSummary.some(item => item.opening_balance === null || item.opening_balance === undefined)
-                    div.row &nbsp;
-                    div.alert.alert-info.mt-3
-                        i.fas.fa-info-circle
-                        strong  Note: 
-                        | Products highlighted in yellow do not have opening stock recorded. Please add opening stock via Stock Adjustment before using these products in reports.
+                                td.text-right -
+                                if showValues
+                                    td.text-right= totOpeningVal.toFixed(2)
+                                td.text-right= totPurchaseQty.toFixed(2)
+                                if showValues
+                                    td.text-right= totPurchaseVal.toFixed(2)
+                                td.text-right= totSalesQty.toFixed(2)
+                                if showValues
+                                    td.text-right= totSalesVal.toFixed(2)
+                                td.text-right -
+                                if showValues
+                                    td.text-right= totClosingVal.toFixed(2)
+
+            if stockSummary.some(item => item.opening_balance === null || item.opening_balance === undefined)
+                div.row &nbsp;
+                div.alert.alert-info.mt-3
+                    i.fas.fa-info-circle
+                    strong  Note:
+                    |  Products highlighted in yellow do not have opening stock recorded. Please add opening stock via Stock Adjustment.
         else
             div.row &nbsp;
             div.row.bg-light No records to display.
-    
-    // Include the overlay
+
     include overlay.pug
-    
+
     style.
-        .table-success-light {
-            background-color: #f0f9ff !important;
+        .table-success-light { background-color: #f0f9ff !important; }
+
+    script.
+        function exportExcel() {
+            const form = document.createElement('form');
+            form.method = 'POST';
+            form.action = '/reports/stock/summary/excel';
+            ['fromDate','toDate'].forEach(name => {
+                const inp = document.createElement('input');
+                inp.type  = 'hidden';
+                inp.name  = name;
+                inp.value = document.querySelector('[name="' + name + '"]').value;
+                form.appendChild(inp);
+            });
+            document.body.appendChild(form);
+            form.submit();
+            document.body.removeChild(form);
         }


### PR DESCRIPTION
## Summary
- Stock summary report now covers fuel (MS/HSD/CNG) and lubes in one unified report
- Value columns (opening/purchase/sales/closing ₹ amounts) shown via checkbox toggle
- Excel export in bank submission format matching the monthly bank stock statement
- Stock ledger meter sales grouped by day instead of per shift
- Adjustment screen now shows fuel products for opening balance entry
- Migrations run on both dev and prod DB

## Test plan
- [ ] Stock adjustment form shows fuel products (MS, HSD, CNG) in product dropdown
- [ ] Opening Balance type can be saved for fuel products
- [ ] Stock summary shows fuel rows with correct opening/IN/OUT/closing quantities
- [ ] Show Values checkbox toggles value columns on/off
- [ ] Excel export downloads with station name header, 9 columns, total row
- [ ] Stock ledger meter sales show one row per day (not per shift)
- [ ] Existing lube stock figures unchanged (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)