### PR TITLE
Fix pdf-parse import (pdfParse is not a function)

### DIFF
--- a/services/invoice-parser-service.js
+++ b/services/invoice-parser-service.js
@@ -1,4 +1,5 @@
-const pdfParse = require('pdf-parse');
+const _pdfParseModule = require('pdf-parse');
+const pdfParse = typeof _pdfParseModule === 'function' ? _pdfParseModule : _pdfParseModule.default;
 const path = require('path');
 const fs = require('fs');
 const moment = require('moment');


### PR DESCRIPTION
## Summary
- `pdf-parse` on the server exports the function differently — added a fallback to handle both `module.exports` and `.default` forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)