### PR TITLE
Pin pdf-parse to 1.1.1 (v2.x has incompatible API)

### DIFF
--- a/services/invoice-parser-service.js
+++ b/services/invoice-parser-service.js
@@ -1,5 +1,4 @@
-const _pdfParseModule = require('pdf-parse');
-const pdfParse = typeof _pdfParseModule === 'function' ? _pdfParseModule : _pdfParseModule.default;
+const pdfParse = require('pdf-parse');
 const path = require('path');
 const fs = require('fs');
 const moment = require('moment');


### PR DESCRIPTION
## Summary
- Server had `pdf-parse` v2.4.5 installed which exports a class-based API incompatible with our code
- Pinned to v1.1.1 which exports a simple function — matches existing usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)