### PR TITLE
Fix decant line quantity display after DECIMAL column migration

### DIFF
--- a/controllers/decant-edit-controller.js
+++ b/controllers/decant-edit-controller.js
@@ -198,7 +198,7 @@ const txnDecantLinesPromise = (ttank_id) => {
                         tdtank_id: decantdata.tdtank_id,
                         ttank_id: decantdata.ttank_id,
                         tank_id: decantdata.tank_id,
-                        quantity: (decantdata.quantity).toString(),
+                        quantity: parseFloat(decantdata.quantity).toString(),
                         closing_dip: decantdata.closing_dip,
                         opening_dip: decantdata.opening_dip,
                         EB_MS_FLAG: decantdata.EB_MS_FLAG,


### PR DESCRIPTION
## Summary
- After `t_tank_stk_rcpt_dtl.quantity` was migrated from INT to DECIMAL(8,3), Sequelize returns values as `"8.000"` but `m_lookup` TANK_QUANTITY descriptions are `"8"` — strict equality fails, dropdown defaults to first option, showing wrong quantity in summary
- Fix: `parseFloat().toString()` strips trailing zeros so `"8.000"` → `"8"` and the lookup match works again

🤖 Generated with [Claude Code](https://claude.com/claude-code)