### PR TITLE
Release: fuel invoice upload, decant quantity fix, and deployment fixes

### DIFF
--- a/app.js
+++ b/app.js
@@ -228,8 +228,10 @@ const campaignPublicRoutes = require('./routes/campaign-public-routes');
 const gstRoutes = require('./routes/gst-routes');
 const transactionUploadRoutes = require('./routes/transaction-upload-routes');
 const dayBillRoutes = require('./routes/day-bill-routes');
+const glRoutes = require('./routes/gl-routes');
 const employeeRoutes  = require('./routes/employee-routes');
 const documentRoutes  = require('./routes/document-routes');
+const tankReceiptRoutes = require('./routes/tank-receipt-routes');
 
 //const auditingUtilitiesRoutes = require('./routes/auditing-utilities-routes');
 
@@ -395,8 +397,10 @@ app.use('/gst', gstRoutes);
 app.use('/transaction-upload', transactionUploadRoutes);
 app.use('/dsm-entry', require('./routes/dsm-entry-routes'));
 app.use('/day-bill', dayBillRoutes);
+app.use('/tank-receipts', tankReceiptRoutes);
 app.use('/employees', employeeRoutes);
 app.use('/documents', documentRoutes);
+app.use('/gl', glRoutes);
 app.use('/bowser', bowserRoutes);
 
 

--- a/config/invoice-parsers/BPCL.json
+++ b/config/invoice-parsers/BPCL.json
@@ -1,0 +1,88 @@
+{
+  "supplier": "BPCL",
+  "dateFormats": ["DD.MM.YYYY", "DD-MM-YYYY", "DD/MM/YYYY"],
+  "header": {
+    "invoice_number": {
+      "keyword": "INVOICE No.:",
+      "strategy": "value_after_keyword",
+      "pattern": "\\d+"
+    },
+    "invoice_date": {
+      "keyword": "DATE/TIME:",
+      "strategy": "value_after_keyword",
+      "pattern": "\\d{2}\\.\\d{2}\\.\\d{4}"
+    },
+    "truck_number": {
+      "keyword": "TL No:",
+      "strategy": "value_after_keyword",
+      "pattern": "[A-Z0-9]+"
+    },
+    "delivery_doc_no": {
+      "keyword": "DELIVERY No:",
+      "strategy": "value_after_keyword",
+      "pattern": "\\d+"
+    },
+    "seal_lock_no": {
+      "keyword": "Seal/Lock No:",
+      "strategy": "value_after_keyword",
+      "pattern": "[\\d/]+"
+    }
+  },
+  "lines": {
+    "product_block_start": "VAT/LST",
+    "product_block_end": "HSN :",
+    "fields": {
+      "product_name": {
+        "keyword": "VAT/LST",
+        "strategy": "value_at_keyword",
+        "pattern": "(?:\\d{2}\\.)([A-Za-z][A-Za-z\\s()/.-]*)(?=\\d)"
+      },
+      "quantity": {
+        "keyword": " KL",
+        "strategy": "number_before_keyword"
+      },
+      "rate_per_kl": {
+        "keyword": "/KL",
+        "strategy": "number_before_keyword"
+      },
+      "total_line_amount": {
+        "keyword": "VAT/LST",
+        "strategy": "number_before_keyword"
+      },
+      "vat_pct": {
+        "keyword": "VAT/LST",
+        "strategy": "value_after_keyword",
+        "pattern": "\\d+"
+      },
+      "vat_amount": {
+        "keyword": "VAT/LST",
+        "strategy": "last_number_on_line"
+      },
+      "delivery_charge": {
+        "keyword": "DLY/TAXABLE CHARGE",
+        "strategy": "value_after_keyword",
+        "pattern": "[\\d,]+\\.?\\d*"
+      },
+      "additional_vat_amount": {
+        "keyword": "Additional VAT",
+        "strategy": "value_after_keyword",
+        "pattern": "[\\d,]+\\.?\\d*"
+      },
+      "density": {
+        "keyword": "Base Density",
+        "strategy": "nth_number_on_line",
+        "position": 1
+      },
+      "hsn_code": {
+        "keyword": "HSN :",
+        "strategy": "value_after_keyword",
+        "pattern": "[\\d\\s]+"
+      }
+    }
+  },
+  "total_amount": {
+    "keyword": "TOTAL VALUE : Rs",
+    "strategy": "value_after_keyword",
+    "pattern": "[\\d,]+\\.?\\d*"
+  }
+}

--- a/config/invoice-parsers/HPCL.json
+++ b/config/invoice-parsers/HPCL.json
@@ -1,0 +1,7 @@
+{
+  "supplier": "HPCL",
+  "dateFormats": ["DD-MMM-YYYY", "DD/MM/YYYY", "DD-MM-YYYY"],
+  "header": {},
+  "lines": { "fields": {} },
+  "total_amount": {}
+}

--- a/config/invoice-parsers/IOCL.json
+++ b/config/invoice-parsers/IOCL.json
@@ -1,0 +1,86 @@
+{
+  "supplier": "IOCL",
+  "dateFormats": ["DD-MMM-YY", "DD-MMM-YYYY", "DD/MM/YYYY", "DD-MM-YYYY"],
+  "header": {
+    "invoice_number": {
+      "keyword": "SAP Entry no.",
+      "strategy": "value_before_keyword",
+      "pattern": "\\d{7,12}"
+    },
+    "invoice_date": {
+      "keyword": "Date",
+      "strategy": "value_on_prev_line",
+      "pattern": "\\d{1,2}-[A-Za-z]{3}-\\d{2,4}",
+      "exact_match": true
+    },
+    "truck_number": {
+      "keyword": "T.T.No.",
+      "strategy": "value_before_keyword",
+      "pattern": "[A-Z0-9]{6,12}"
+    },
+    "delivery_doc_no": {
+      "keyword": "Delivery no.",
+      "strategy": "value_after_keyword",
+      "pattern": "\\d+"
+    },
+    "seal_lock_no": {
+      "keyword": "Seal/Lock no:",
+      "strategy": "value_after_keyword",
+      "pattern": "[\\d\\s\\(\\)/]+"
+    }
+  },
+  "lines": {
+    "product_block_start": "BASIC DESTINATION PRICE",
+    "product_block_end": "Total for material",
+    "fields": {
+      "product_name": {
+        "strategy": "line_before_block_start"
+      },
+      "quantity": {
+        "keyword": "BASIC DESTINATION PRICE",
+        "strategy": "nth_number_on_line",
+        "position": 1
+      },
+      "rate_per_kl": {
+        "keyword": "BASIC DESTINATION PRICE",
+        "strategy": "nth_number_on_line",
+        "position": 2
+      },
+      "vat_pct": {
+        "keyword": "A/R Vat Payable",
+        "strategy": "nth_number_on_next_line",
+        "position": 1
+      },
+      "vat_amount": {
+        "keyword": "A/R Vat Payable",
+        "strategy": "nth_number_on_next_line",
+        "position": 2
+      },
+      "additional_vat_amount": {
+        "keyword": "Additional VAT",
+        "strategy": "nth_number_on_next_line",
+        "position": 2
+      },
+      "density": {
+        "keyword": "Density@15:",
+        "strategy": "value_after_keyword",
+        "pattern": "[\\d\\.]+"
+      },
+      "hsn_code": {
+        "keyword": "BASIC DESTINATION PRICE",
+        "strategy": "hsn_from_prev_line"
+      },
+      "total_line_amount": {
+        "keyword": "Total for material",
+        "strategy": "nth_number_on_line",
+        "position": 1
+      }
+    }
+  },
+  "total_amount": {
+    "keyword": "Total",
+    "strategy": "nth_number_on_next_line",
+    "position": 1,
+    "exact_match": true
+  }
+}

--- a/controllers/decant-edit-controller.js
+++ b/controllers/decant-edit-controller.js
@@ -198,7 +198,7 @@ const txnDecantLinesPromise = (ttank_id) => {
                         tdtank_id: decantdata.tdtank_id,
                         ttank_id: decantdata.ttank_id,
                         tank_id: decantdata.tank_id,
-                        quantity: (decantdata.quantity).toString(),
+                        quantity: parseFloat(decantdata.quantity).toString(),
                         closing_dip: decantdata.closing_dip,
                         opening_dip: decantdata.opening_dip,
                         EB_MS_FLAG: decantdata.EB_MS_FLAG,

--- a/controllers/tank-receipt-controller.js
+++ b/controllers/tank-receipt-controller.js
@@ -3,6 +3,7 @@ const dateFormat = require('dateformat');
 const utils = require("../utils/app-utils");
 const config = require("../config/app-config");
 const db = require("../db/db-connection");
+const fs = require('fs');
 const PersonDao = require("../dao/person-dao");
 const TxnReadDao = require("../dao/txn-read-dao");
 const TxnTankRcptDao = require ("../dao/txn-tankrcpt-dao");
@@ -11,6 +12,14 @@ const TankDao = require("../dao/tank-dao");
 const TruckDao = require("../dao/truck-dao");
 const LookupDao = require("../dao/lookup-dao");
 const locationConfig = require("../utils/location-config");
+const LocationDao = require("../dao/location-dao");
+const InvoiceParserService = require("../services/invoice-parser-service");
+const TankInvoiceDao = require("../dao/tank-invoice-dao");
+const InvoiceProductMapDao = require("../dao/invoice-product-map-dao");
+const { v4: uuidv4 } = require('uuid');
+
+// Temp store for uploaded PDF buffers pending user product confirmation (in-memory, short-lived)
+const tempInvoiceStore = new Map();
 
 
 module.exports = {
@@ -112,6 +121,137 @@ module.exports = {
             });
     },
 
+    parseInvoicePdf: async (req, res, next) => {
+        try {
+            if (!req.file) {
+                return res.status(400).json({ success: false, error: 'No PDF file uploaded.' });
+            }
+            const locationCode = req.user.location_code;
+            const location = await LocationDao.findByLocationCode(locationCode);
+            const companyName = location && location.company_name ? location.company_name : null;
+
+            if (!companyName) {
+                return res.status(400).json({ success: false, error: `No oil company configured for location ${locationCode}. Check m_location.company_name.` });
+            }
+
+            const pdfBuffer = fs.readFileSync(req.file.path);
+            fs.unlink(req.file.path, () => {});
+
+            const result = await InvoiceParserService.parseInvoice(pdfBuffer, companyName);
+
+            // Resolve supplier_id — mandatory
+            const supplierRow = await db.sequelize.query(
+                `SELECT supplier_id, supplier_name FROM m_supplier WHERE UPPER(supplier_short_name) = UPPER(:code) AND location_code = :loc LIMIT 1`,
+                { replacements: { code: result.supplier, loc: locationCode }, type: db.Sequelize.QueryTypes.SELECT }
+            ).then(r => r[0] || null);
+
+            if (!supplierRow) {
+                return res.status(400).json({
+                    success: false,
+                    error: `Supplier "${result.supplier}" not found in supplier master for this location. Please add it under Supplier Master first.`
+                });
+            }
+
+            // Stash buffer temporarily — saved to DB only after user confirms products
+            const tempId = uuidv4();
+            const originalFileName = req.file ? req.file.originalname : 'invoice.pdf';
+            tempInvoiceStore.set(tempId, { buffer: pdfBuffer, supplierId: supplierRow.supplier_id, originalFileName, expires: Date.now() + 30 * 60 * 1000 });
+            for (const [k, v] of tempInvoiceStore) { if (v.expires < Date.now()) tempInvoiceStore.delete(k); }
+
+            const [products, mappings] = await Promise.all([
+                getTankProductsForLocation(locationCode),
+                InvoiceProductMapDao.getMappings(locationCode, supplierRow.supplier_id)
+            ]);
+
+            return res.json({
+                success: true,
+                supplier: result.supplier,
+                supplierId: supplierRow.supplier_id,
+                supplierName: supplierRow.supplier_name,
+                tempId,
+                products,
+                mappings,
+                data: { header: result.header, lines: result.lines }
+            });
+        } catch (err) {
+            console.error('Error parsing invoice PDF:', err);
+            return res.status(500).json({ success: false, error: 'Failed to read invoice: ' + err.message });
+        }
+    },
+
+    saveInvoiceWithProducts: async (req, res, next) => {
+        try {
+            const { tempId, supplierId, supplier, header, lines } = req.body;
+            const locationCode = req.user.location_code;
+
+            if (!supplierId) {
+                return res.status(400).json({ success: false, error: 'Supplier is required.' });
+            }
+            if (!lines || lines.some(l => !l.product_id)) {
+                return res.status(400).json({ success: false, error: 'All invoice lines must have a product selected.' });
+            }
+
+            const temp = tempInvoiceStore.get(tempId);
+            const pdfBuffer = temp ? temp.buffer : null;
+            const originalFileName = temp ? temp.originalFileName : 'invoice.pdf';
+            if (temp) tempInvoiceStore.delete(tempId);
+
+            const headerData = {
+                location_id: locationCode,
+                supplier_id: Number(supplierId),
+                supplier,
+                invoice_number: header.invoice_number || null,
+                invoice_date: header.invoice_date || null,
+                truck_number: header.truck_number || null,
+                delivery_doc_no: header.delivery_doc_no || null,
+                seal_lock_no: header.seal_lock_no || null,
+                total_invoice_amount: header.total_invoice_amount || null
+            };
+
+            const lineData = lines.map(l => {
+                const charges = [];
+                if (l.vat_pct != null || l.vat_amount != null)
+                    charges.push({ charge_type: 'VAT', charge_pct: l.vat_pct || null, charge_amount: l.vat_amount || null });
+                if (l.additional_vat_amount != null)
+                    charges.push({ charge_type: 'ADDITIONAL_VAT', charge_pct: null, charge_amount: l.additional_vat_amount });
+                if (l.delivery_charge != null)
+                    charges.push({ charge_type: 'DELIVERY_CHARGE', charge_pct: null, charge_amount: l.delivery_charge });
+                return {
+                    product_id: Number(l.product_id),
+                    product_name: l.product_name || null,
+                    quantity: l.quantity || null,
+                    rate_per_kl: l.rate_per_kl || null,
+                    density: l.density || null,
+                    hsn_code: l.hsn_code || null,
+                    total_line_amount: l.total_line_amount || null,
+                    charges
+                };
+            });
+
+            const invoice = await TankInvoiceDao.saveInvoice(headerData, lineData, pdfBuffer, locationCode, Number(supplierId), originalFileName);
+            return res.json({ success: true, invoiceId: invoice.id, invoiceNumber: invoice.invoice_number });
+        } catch (err) {
+            console.error('Error saving invoice:', err);
+            return res.status(500).json({ success: false, error: 'Failed to save invoice: ' + err.message });
+        }
+    },
+
+    invoicePreview: async (req, res, next) => {
+        try {
+            const invoiceNumber = (req.query.invoiceNumber || '').trim();
+            if (!invoiceNumber) return res.status(400).json({ success: false, error: 'invoiceNumber required' });
+
+            const locationCode = req.user.location_code;
+            const invoice = await TankInvoiceDao.findByInvoiceNumber(locationCode, invoiceNumber);
+            if (!invoice) return res.json({ success: false, error: 'No invoice found for this invoice number.' });
+
+            return res.json({ success: true, invoice });
+        } catch (err) {
+            console.error('Error fetching invoice preview:', err);
+            return res.status(500).json({ success: false, error: err.message });
+        }
+    },
+
     closeData: (req, res, next) => {
      TxnTankRcptDao.finishClosing(req.query.id)
         .then(() => {
@@ -124,6 +264,13 @@ module.exports = {
 }
 
 }
+const getTankProductsForLocation = (locationCode) => {
+    return db.sequelize.query(
+        `SELECT product_id, product_name FROM m_product WHERE location_code = :locationCode AND is_tank_product = 1 ORDER BY product_name`,
+        { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT }
+    ).catch(() => []);
+};
+
 const getDraftsCount = (locationCode) => {
     return new Promise((resolve, reject) => {
         return TxnReadDao.getDraftClosingsCount(locationCode)
@@ -238,24 +385,33 @@ const txnDeleteDecantLinePromise = (decantLineId) => {
 
 const getHomeData = (req, res, next) => {
     let locationCode = req.user.location_code;
-    let fromDate = dateFormat(new Date(), "yyyy-mm-dd");
-    let toDate = dateFormat(new Date(), "yyyy-mm-dd");
+    const now = new Date();
+    let fromDate = dateFormat(new Date(now.getFullYear(), now.getMonth(), 1), "yyyy-mm-dd");
+    let toDate = dateFormat(now, "yyyy-mm-dd");
     if(req.query.tankreceipts_fromDate) {
         fromDate = req.query.tankreceipts_fromDate;
     }
     if(req.query.tankreceipts_toDate) {
         toDate = req.query.tankreceipts_toDate;
     }
-    Promise.allSettled([getTankRcptByDate(locationCode, fromDate, toDate), getTankProductColumns(locationCode), getTankProductQty(locationCode, fromDate, toDate)])
-        .then(values => {
+    Promise.allSettled([
+        getTankRcptByDate(locationCode, fromDate, toDate),
+        getTankProductColumns(locationCode),
+        getTankProductQty(locationCode, fromDate, toDate),
+        getInvoiceNumbersSet(locationCode)
+    ]).then(values => {
             const receipts = values[0].value || [];
             const productColumns = values[1].value || [];
+            const invoiceNumbers = values[3].value || new Set();
             const qtyMap = {};
             (values[2].value || []).forEach(row => {
                 if (!qtyMap[row.ttank_id]) qtyMap[row.ttank_id] = {};
                 qtyMap[row.ttank_id][row.product_code] = row.qty;
             });
-            receipts.forEach(r => Object.assign(r, qtyMap[r.ttank_id] || {}));
+            receipts.forEach(r => {
+                Object.assign(r, qtyMap[r.ttank_id] || {});
+                r.hasInvoice = invoiceNumbers.has(r.invoice_number);
+            });
 
             res.render('tankreceipts', {
                 title: 'Tank Receipts',
@@ -267,10 +423,7 @@ const getHomeData = (req, res, next) => {
                 fromDate: fromDate,
                 toDate: toDate,
             });
-
-            console.log("inside tank");
         });
-
 }
 
 const getTankRcptByDate = (locationCode, fromDate, toDate) => {
@@ -358,5 +511,41 @@ const getLocationId = (locationCode) => {
                 resolve({location_id:location_id});
             });
 
+    });
+}
+
+module.exports.checkInvoiceNumber = async (req, res) => {
+    try {
+        const { invoiceNumber, excludeId } = req.query;
+        const locationCode = req.session.passport.user.location_code;
+        if (!invoiceNumber || !invoiceNumber.trim()) return res.json({ duplicate: false });
+
+        const sql = `SELECT ttank_id, invoice_number, decant_date
+                     FROM t_tank_stk_rcpt
+                     WHERE location_code = :locationCode
+                       AND invoice_number = :invoiceNumber
+                       ${excludeId ? 'AND ttank_id != :excludeId' : ''}
+                     LIMIT 1`;
+        const rows = await db.sequelize.query(sql, {
+            replacements: { locationCode, invoiceNumber: invoiceNumber.trim(), excludeId: excludeId || null },
+            type: db.Sequelize.QueryTypes.SELECT
+        });
+        if (rows.length === 0) return res.json({ duplicate: false });
+        const r = rows[0];
+        return res.json({ duplicate: true, receiptId: r.ttank_id, decantDate: r.decant_date });
+    } catch (err) {
+        console.error('checkInvoiceNumber error:', err);
+        return res.json({ duplicate: false });
+    }
+};
+
+const getInvoiceNumbersSet = (locationCode) => {
+    return new Promise((resolve) => {
+        db.sequelize.query(
+            `SELECT invoice_number FROM t_tank_invoice WHERE location_id = :locationCode AND invoice_number IS NOT NULL`,
+            { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT }
+        ).then(rows => {
+            resolve(new Set(rows.map(r => r.invoice_number)));
+        }).catch(() => resolve(new Set()));
     });
 }

--- a/dao/invoice-product-map-dao.js
+++ b/dao/invoice-product-map-dao.js
@@ -1,0 +1,26 @@
+const db = require('../db/db-connection');
+const InvoiceProductMap = db.invoice_product_map;
+
+module.exports = {
+    // Get all mappings for a location+supplier as { invoiceProductName -> product_id }
+    getMappings: async (locationCode, supplierId) => {
+        const rows = await InvoiceProductMap.findAll({
+            where: { location_code: locationCode, supplier_id: supplierId }
+        });
+        const map = {};
+        rows.forEach(r => { map[r.invoice_product_name] = r.product_id; });
+        return map;
+    },
+
+    // Upsert mappings — called after user confirms product selections
+    saveMappings: async (locationCode, supplierId, mappings) => {
+        for (const m of mappings) {
+            await InvoiceProductMap.upsert({
+                location_code: locationCode,
+                supplier_id: supplierId,
+                invoice_product_name: m.invoice_product_name,
+                product_id: m.product_id
+            });
+        }
+    }
+};

--- a/dao/tank-invoice-dao.js
+++ b/dao/tank-invoice-dao.js
@@ -1,0 +1,108 @@
+const db = require('../db/db-connection');
+const { Op } = require('sequelize');
+const InvoiceProductMapDao = require('./invoice-product-map-dao');
+const DocumentStoreDao = require('./document-store-dao');
+
+const TankInvoice = db.tank_invoice;
+const TankInvoiceDtl = db.tank_invoice_dtl;
+const TankInvoiceCharges = db.tank_invoice_charges;
+
+module.exports = {
+
+    findAll: (locationId, fromDate, toDate) => {
+        const where = { location_id: locationId };
+        if (fromDate && toDate) {
+            where.invoice_date = { [Op.between]: [fromDate, toDate] };
+        }
+        return TankInvoice.findAll({
+            where,
+            include: [{ model: TankInvoiceDtl, as: 'lines', attributes: ['id', 'product_name', 'quantity'] }],
+            order: [['invoice_date', 'DESC'], ['id', 'DESC']]
+        });
+    },
+
+    findById: (id) => {
+        return TankInvoice.findByPk(id, {
+            include: [{
+                model: TankInvoiceDtl,
+                as: 'lines',
+                include: [{ model: TankInvoiceCharges, as: 'charges' }]
+            }]
+        });
+    },
+
+    findByInvoiceNumber: (locationId, invoiceNumber) => {
+        return TankInvoice.findOne({
+            where: { location_id: locationId, invoice_number: invoiceNumber },
+            attributes: { exclude: ['invoice_pdf'] },
+            include: [{
+                model: TankInvoiceDtl,
+                as: 'lines',
+                include: [{ model: TankInvoiceCharges, as: 'charges' }]
+            }],
+            order: [['id', 'DESC']]
+        });
+    },
+
+    // header: invoice header fields including supplier_id (mandatory)
+    // lines: array of { product_id (mandatory), product_name, quantity, ... charges[] }
+    // pdfBuffer: Buffer (optional — only on first save / re-upload)
+    // locationCode + supplierId: used to persist product mappings
+    saveInvoice: async (header, lines, pdfBuffer, locationCode, supplierId, originalFileName) => {
+        return db.sequelize.transaction(async (t) => {
+            let invoice = null;
+            if (header.invoice_number) {
+                invoice = await TankInvoice.findOne({
+                    where: { location_id: header.location_id, invoice_number: header.invoice_number },
+                    transaction: t
+                });
+            }
+            if (invoice) {
+                await invoice.update(header, { transaction: t });
+                // destroy charges first (FK), then lines
+                const existingLines = await TankInvoiceDtl.findAll({ where: { invoice_id: invoice.id }, transaction: t });
+                for (const el of existingLines) {
+                    await TankInvoiceCharges.destroy({ where: { invoice_dtl_id: el.id }, transaction: t });
+                }
+                await TankInvoiceDtl.destroy({ where: { invoice_id: invoice.id }, transaction: t });
+            } else {
+                invoice = await TankInvoice.create(header, { transaction: t });
+            }
+
+            for (const line of lines) {
+                const { charges, ...lineData } = line;
+                lineData.invoice_id = invoice.id;
+                const savedLine = await TankInvoiceDtl.create(lineData, { transaction: t });
+                if (charges && charges.length > 0) {
+                    const chargeRows = charges.map(c => ({ ...c, invoice_dtl_id: savedLine.id }));
+                    await TankInvoiceCharges.bulkCreate(chargeRows, { transaction: t });
+                }
+            }
+
+            return invoice;
+        }).then(async (invoice) => {
+            // Save PDF to document store (replace existing if re-uploading)
+            if (pdfBuffer) {
+                const existing = await DocumentStoreDao.findByEntity('TANK_INVOICE', invoice.id);
+                for (const doc of existing) await DocumentStoreDao.deleteById(doc.doc_id);
+                await DocumentStoreDao.create({
+                    entity_type:  'TANK_INVOICE',
+                    entity_id:    invoice.id,
+                    doc_category: 'PURCHASE_INVOICE',
+                    file_name:    originalFileName || 'invoice.pdf',
+                    mime_type:    'application/pdf',
+                    file_size:    pdfBuffer.length,
+                    file_data:    pdfBuffer,
+                    location_code: locationCode,
+                    created_by:   'system'
+                });
+            }
+
+            if (supplierId && locationCode) {
+                const mappings = lines.map(l => ({ invoice_product_name: l.product_name, product_id: l.product_id }));
+                await InvoiceProductMapDao.saveMappings(locationCode, supplierId, mappings).catch(() => {});
+            }
+            return invoice;
+        });
+    }
+};

--- a/dao/txn-tankrcpt-dao.js
+++ b/dao/txn-tankrcpt-dao.js
@@ -31,7 +31,8 @@ module.exports = {
         const receiptTxn = TxnTankReceipts.bulkCreate(data, {
             returning: true,
             updateOnDuplicate: ["ttank_id", "invoice_number", "invoice_date","decant_date","driver_id","driver_name","helper_id","helper_name","truck_id","truck_number",
-                "decant_incharge", "odometer_reading","decant_time","truck_halt_flag", "updated_by", "updation_date"]
+                "decant_incharge", "odometer_reading","decant_time","truck_halt_flag", "updated_by", "updation_date",
+                ]
         });
         return receiptTxn;
     },

--- a/db/db-connection.js
+++ b/db/db-connection.js
@@ -85,6 +85,10 @@ db.document_store = require("./document-store")(sequelize, Sequelize);
 db.employee = require("./employee")(sequelize, Sequelize);
 db.employee_salary = require("./employee-salary")(sequelize, Sequelize);
 db.employee_ledger = require("./employee-ledger")(sequelize, Sequelize);
+db.tank_invoice = require("./txn-tank-invoice")(sequelize, Sequelize);
+db.tank_invoice_dtl = require("./txn-tank-invoice-dtl")(sequelize, Sequelize);
+db.tank_invoice_charges = require("./txn-tank-invoice-charges")(sequelize, Sequelize);
+db.invoice_product_map = require("./txn-invoice-product-map")(sequelize, Sequelize);
 
 // relations
 db.pump.hasMany(db.txn_reading, {foreignKey: 'pump_id'});
@@ -308,6 +312,12 @@ db.day_bill_header.hasMany(db.day_bill_items, {foreignKey: 'header_id', as: 'ite
 db.day_bill_items.belongsTo(db.day_bill_header, {foreignKey: 'header_id'});
 db.day_bill_header.belongsTo(db.credit, {foreignKey: 'vendor_id', targetKey: 'creditlist_id', as: 'vendor'});
 db.day_bill_items.belongsTo(db.product, {foreignKey: 'product_id', targetKey: 'product_id'});
+
+// Tank invoice relations
+db.tank_invoice.hasMany(db.tank_invoice_dtl, {foreignKey: 'invoice_id', as: 'lines'});
+db.tank_invoice_dtl.belongsTo(db.tank_invoice, {foreignKey: 'invoice_id'});
+db.tank_invoice_dtl.hasMany(db.tank_invoice_charges, {foreignKey: 'invoice_dtl_id', as: 'charges'});
+db.tank_invoice_charges.belongsTo(db.tank_invoice_dtl, {foreignKey: 'invoice_dtl_id'});
 
 // Employee relations
 db.employee.hasMany(db.employee_ledger, {foreignKey: 'employee_id', as: 'ledgerEntries'});

--- a/db/migrations/invoice-product-map.sql
+++ b/db/migrations/invoice-product-map.sql
@@ -1,0 +1,19 @@
+-- Migration: Add product_id to invoice lines + product mapping table
+-- Run on dev DB. Truncates existing test invoice data first.
+
+TRUNCATE TABLE t_tank_invoice_charges;
+TRUNCATE TABLE t_tank_invoice_dtl;
+TRUNCATE TABLE t_tank_invoice;
+
+ALTER TABLE t_tank_invoice_dtl
+    ADD COLUMN product_id INT NOT NULL AFTER invoice_id;
+
+CREATE TABLE IF NOT EXISTS t_invoice_product_map (
+    id                   INT NOT NULL AUTO_INCREMENT,
+    location_code        VARCHAR(20) NOT NULL,
+    supplier             VARCHAR(10) NOT NULL,
+    invoice_product_name VARCHAR(100) NOT NULL,
+    product_id           INT NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_inv_prod_map (location_code, supplier, invoice_product_name)
+);

--- a/db/migrations/tank-invoice.sql
+++ b/db/migrations/tank-invoice.sql
@@ -1,0 +1,64 @@
+-- Migration: Fuel Purchase Invoice tables
+-- PDF stored in t_document_store (entity_type='TANK_INVOICE'), not here.
+-- Charges stored vertically to accommodate future tax regime changes (GST etc.)
+
+CREATE TABLE IF NOT EXISTS t_tank_invoice (
+    id                   INT NOT NULL AUTO_INCREMENT,
+    location_id          VARCHAR(20) NOT NULL,
+    supplier_id          INT NOT NULL,
+    supplier             VARCHAR(10) NULL,
+    invoice_number       VARCHAR(50) NULL,
+    invoice_date         DATE NULL,
+    truck_number         VARCHAR(20) NULL,
+    delivery_doc_no      VARCHAR(50) NULL,
+    seal_lock_no         VARCHAR(100) NULL,
+    total_invoice_amount DECIMAL(12,2) NULL,
+    created_at           TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS t_tank_invoice_dtl (
+    id                INT NOT NULL AUTO_INCREMENT,
+    invoice_id        INT NOT NULL,
+    product_id        INT NOT NULL,
+    product_name      VARCHAR(100) NULL,
+    quantity          DECIMAL(8,3) NULL,
+    rate_per_kl       DECIMAL(10,3) NULL,
+    density           DECIMAL(6,3) NULL,
+    hsn_code          VARCHAR(20) NULL,
+    total_line_amount DECIMAL(12,2) NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_tid_invoice FOREIGN KEY (invoice_id) REFERENCES t_tank_invoice (id)
+);
+
+CREATE TABLE IF NOT EXISTS t_tank_invoice_charges (
+    id             INT NOT NULL AUTO_INCREMENT,
+    invoice_dtl_id INT NOT NULL,
+    charge_type    VARCHAR(50) NOT NULL,
+    charge_pct     DECIMAL(5,2) NULL,
+    charge_amount  DECIMAL(12,2) NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_tic_dtl FOREIGN KEY (invoice_dtl_id) REFERENCES t_tank_invoice_dtl (id)
+);
+
+CREATE TABLE IF NOT EXISTS t_invoice_product_map (
+    id                   INT NOT NULL AUTO_INCREMENT,
+    location_code        VARCHAR(20) NOT NULL,
+    supplier_id          INT NOT NULL,
+    invoice_product_name VARCHAR(100) NOT NULL,
+    product_id           INT NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_inv_prod_map (location_code, supplier_id, invoice_product_name)
+);
+
+-- Data quality fix: t_tank_stk_rcpt_dtl.quantity must support fractional KL
+SET @dbname = DATABASE();
+SET @sql = IF(
+    (SELECT DATA_TYPE FROM information_schema.COLUMNS
+     WHERE TABLE_SCHEMA = @dbname
+       AND TABLE_NAME   = 't_tank_stk_rcpt_dtl'
+       AND COLUMN_NAME  = 'quantity') = 'int',
+    'ALTER TABLE t_tank_stk_rcpt_dtl MODIFY COLUMN quantity DECIMAL(8,3) NULL',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/db/txn-invoice-product-map.js
+++ b/db/txn-invoice-product-map.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = function(sequelize, DataTypes) {
+    return sequelize.define('t_invoice_product_map', {
+        id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+        location_code: { type: DataTypes.STRING(20) },
+        supplier_id: { type: DataTypes.INTEGER, allowNull: false },
+        invoice_product_name: { type: DataTypes.STRING(100) },
+        product_id: { type: DataTypes.INTEGER }
+    }, { timestamps: false, freezeTableName: true });
+};

--- a/db/txn-stkrcpt-dtl.js
+++ b/db/txn-stkrcpt-dtl.js
@@ -18,7 +18,7 @@ module.exports = function(sequelize, DataTypes) {
         },
         quantity: {
             field: 'quantity',
-            type: DataTypes.INTEGER,
+            type: DataTypes.DECIMAL(8, 3),
         },
         created_by: {
             field: 'created_by',
@@ -65,7 +65,7 @@ module.exports = function(sequelize, DataTypes) {
         amount: {
             field: 'amount',
             type: DataTypes.DECIMAL
-        }
+        },
     }, {
         timestamps: false,
         freezeTableName: true

--- a/db/txn-tank-invoice-charges.js
+++ b/db/txn-tank-invoice-charges.js
@@ -1,0 +1,34 @@
+"use strict";
+
+module.exports = function(sequelize, DataTypes) {
+    const TankInvoiceCharges = sequelize.define('t_tank_invoice_charges', {
+        id: {
+            field: 'id',
+            type: DataTypes.INTEGER,
+            primaryKey: true,
+            autoIncrement: true
+        },
+        invoice_dtl_id: {
+            field: 'invoice_dtl_id',
+            type: DataTypes.INTEGER
+        },
+        charge_type: {
+            field: 'charge_type',
+            type: DataTypes.STRING(50)
+        },
+        charge_pct: {
+            field: 'charge_pct',
+            type: DataTypes.DECIMAL(5, 2),
+            allowNull: true
+        },
+        charge_amount: {
+            field: 'charge_amount',
+            type: DataTypes.DECIMAL(12, 2),
+            allowNull: true
+        }
+    }, {
+        timestamps: false,
+        freezeTableName: true
+    });
+    return TankInvoiceCharges;
+};

--- a/db/txn-tank-invoice-dtl.js
+++ b/db/txn-tank-invoice-dtl.js
@@ -1,0 +1,55 @@
+"use strict";
+
+module.exports = function(sequelize, DataTypes) {
+    const TankInvoiceDtl = sequelize.define('t_tank_invoice_dtl', {
+        id: {
+            field: 'id',
+            type: DataTypes.INTEGER,
+            primaryKey: true,
+            autoIncrement: true
+        },
+        invoice_id: {
+            field: 'invoice_id',
+            type: DataTypes.INTEGER
+        },
+        product_id: {
+            field: 'product_id',
+            type: DataTypes.INTEGER,
+            allowNull: false
+        },
+        product_name: {
+            field: 'product_name',
+            type: DataTypes.STRING(100),
+            allowNull: true
+        },
+        quantity: {
+            field: 'quantity',
+            type: DataTypes.DECIMAL(8, 3),
+            allowNull: true
+        },
+        rate_per_kl: {
+            field: 'rate_per_kl',
+            type: DataTypes.DECIMAL(10, 3),
+            allowNull: true
+        },
+        density: {
+            field: 'density',
+            type: DataTypes.DECIMAL(6, 3),
+            allowNull: true
+        },
+        hsn_code: {
+            field: 'hsn_code',
+            type: DataTypes.STRING(20),
+            allowNull: true
+        },
+        total_line_amount: {
+            field: 'total_line_amount',
+            type: DataTypes.DECIMAL(12, 2),
+            allowNull: true
+        }
+    }, {
+        timestamps: false,
+        freezeTableName: true
+    });
+    return TankInvoiceDtl;
+};

--- a/db/txn-tank-invoice.js
+++ b/db/txn-tank-invoice.js
@@ -1,0 +1,64 @@
+"use strict";
+
+module.exports = function(sequelize, DataTypes) {
+    const TankInvoice = sequelize.define('t_tank_invoice', {
+        id: {
+            field: 'id',
+            type: DataTypes.INTEGER,
+            primaryKey: true,
+            autoIncrement: true
+        },
+        location_id: {
+            field: 'location_id',
+            type: DataTypes.STRING(20)
+        },
+        supplier_id: {
+            field: 'supplier_id',
+            type: DataTypes.INTEGER,
+            allowNull: false
+        },
+        supplier: {
+            field: 'supplier',
+            type: DataTypes.STRING(10),
+            allowNull: true
+        },
+        invoice_number: {
+            field: 'invoice_number',
+            type: DataTypes.STRING(50),
+            allowNull: true
+        },
+        invoice_date: {
+            field: 'invoice_date',
+            type: DataTypes.DATEONLY,
+            allowNull: true
+        },
+        truck_number: {
+            field: 'truck_number',
+            type: DataTypes.STRING(20),
+            allowNull: true
+        },
+        delivery_doc_no: {
+            field: 'delivery_doc_no',
+            type: DataTypes.STRING(50),
+            allowNull: true
+        },
+        seal_lock_no: {
+            field: 'seal_lock_no',
+            type: DataTypes.STRING(100),
+            allowNull: true
+        },
+        total_invoice_amount: {
+            field: 'total_invoice_amount',
+            type: DataTypes.DECIMAL(12, 2),
+            allowNull: true
+        },
+        created_at: {
+            field: 'created_at',
+            type: DataTypes.DATE
+        }
+    }, {
+        timestamps: false,
+        freezeTableName: true
+    });
+    return TankInvoice;
+};

--- a/db/txn-tank-stkrcpt.js
+++ b/db/txn-tank-stkrcpt.js
@@ -110,7 +110,6 @@ module.exports = function(sequelize, DataTypes) {
             field: 'truck_id',
             type: DataTypes.INTEGER
         },
-     
     }, {
         timestamps: false,
         freezeTableName: true

--- a/public/javascripts/app-scripts.js
+++ b/public/javascripts/app-scripts.js
@@ -2181,6 +2181,164 @@ function formDecant(ttank_id, user) {
     };
 }
 
+async function showInvoicePreview(passedNumber) {
+    const invoiceNumber = passedNumber || (document.getElementById('invoiceno') || {}).value || '';
+    if (!invoiceNumber.trim()) { alert('Enter an invoice number first.'); return; }
+
+    const body = document.getElementById('invoicePreviewBody');
+    if (!body) return;
+    body.innerHTML = '<div class="text-center text-muted py-3">Loading...</div>';
+    $('#invoicePreviewModal').modal('show');
+
+    try {
+        const resp = await fetch('/tank-receipts/invoice-preview?invoiceNumber=' + encodeURIComponent(invoiceNumber));
+        const json = await resp.json();
+        if (!json.success) {
+            body.innerHTML = '<div class="alert alert-warning">' + (json.error || 'Invoice not found.') + '</div>';
+            return;
+        }
+        body.innerHTML = renderInvoicePreview(json.invoice);
+    } catch (e) {
+        body.innerHTML = '<div class="alert alert-danger">Error: ' + e.message + '</div>';
+    }
+}
+
+function renderInvoicePreview(inv) {
+    const fmtN = (n) => n != null ? parseFloat(n).toLocaleString('en-IN', {minimumFractionDigits: 2, maximumFractionDigits: 2}) : '—';
+    const fmtD = (d) => d ? new Date(d).toLocaleDateString('en-IN', {day:'2-digit', month:'short', year:'numeric'}) : '—';
+
+    let html = `
+    <table class="table table-sm table-borderless mb-3">
+        <tbody>
+            <tr><td class="text-muted" style="width:160px">Supplier</td><td><strong>${inv.supplier || '—'}</strong></td>
+                <td class="text-muted" style="width:160px">Invoice No.</td><td>${inv.invoice_number || '—'}</td></tr>
+            <tr><td class="text-muted">Invoice Date</td><td>${fmtD(inv.invoice_date)}</td>
+                <td class="text-muted">Truck No.</td><td>${inv.truck_number || '—'}</td></tr>
+            <tr><td class="text-muted">Delivery Doc No.</td><td>${inv.delivery_doc_no || '—'}</td>
+                <td class="text-muted">Seal / Lock No.</td><td>${inv.seal_lock_no || '—'}</td></tr>
+            <tr><td class="text-muted">Total Amount</td><td colspan="3"><strong>₹ ${fmtN(inv.total_invoice_amount)}</strong></td></tr>
+        </tbody>
+    </table>
+    <h6 class="border-bottom pb-1">Product Lines</h6>
+    <table class="table table-sm table-hover">
+        <thead class="thead-light">
+            <tr>
+                <th>Product</th><th class="text-right">Qty (KL)</th><th class="text-right">Rate/KL</th>
+                <th class="text-right">Density</th><th>HSN</th><th class="text-right">Line Total</th>
+            </tr>
+        </thead>
+        <tbody>`;
+
+    (inv.lines || []).forEach(line => {
+        html += `<tr>
+            <td>${line.product_name || '—'}</td>
+            <td class="text-right">${line.quantity != null ? parseFloat(line.quantity).toFixed(3) : '—'}</td>
+            <td class="text-right">${fmtN(line.rate_per_kl)}</td>
+            <td class="text-right">${line.density != null ? parseFloat(line.density).toFixed(1) : '—'}</td>
+            <td>${line.hsn_code || '—'}</td>
+            <td class="text-right">₹ ${fmtN(line.total_line_amount)}</td>
+        </tr>`;
+        (line.charges || []).forEach(c => {
+            const pct = c.charge_pct != null ? ` (${c.charge_pct}%)` : '';
+            html += `<tr class="text-muted small">
+                <td colspan="5" class="pl-3 text-right">${c.charge_type.replace(/_/g,' ')}${pct}</td>
+                <td class="text-right">₹ ${fmtN(c.charge_amount)}</td>
+            </tr>`;
+        });
+    });
+
+    html += `</tbody></table>`;
+    return html;
+}
+
+async function uploadAndParseInvoice() {
+    const fileInput = document.getElementById('invoicePdfUpload');
+    if (!fileInput || !fileInput.files.length) {
+        alert('Please select a PDF file first.');
+        return;
+    }
+    const statusEl = document.getElementById('invoiceParseStatus');
+    statusEl.textContent = 'Reading invoice...';
+    statusEl.className = 'text-info small';
+
+    const formData = new FormData();
+    formData.append('invoicePdf', fileInput.files[0]);
+
+    try {
+        const resp = await fetch('/tank-receipts/parse-invoice', { method: 'POST', body: formData });
+        if (resp.status === 403) {
+            statusEl.textContent = 'Not authorised to upload invoices.';
+            statusEl.className = 'text-danger small';
+            return;
+        }
+        const json = await resp.json();
+        if (!resp.ok || !json.success) {
+            statusEl.textContent = 'Could not read invoice: ' + (json.error || 'Unknown error');
+            statusEl.className = 'text-danger small';
+            return;
+        }
+        prefillFromInvoice(json.data, json.supplier);
+        statusEl.textContent = 'Invoice read (' + (json.supplierName || json.supplier) + '). Select products below and save.';
+        statusEl.className = 'text-success small';
+        renderInvoiceConfirmForm(json.data, json.products, json.mappings, json.tempId, json.supplier, json.supplierId);
+    } catch (e) {
+        statusEl.textContent = 'Error: ' + e.message;
+        statusEl.className = 'text-danger small';
+    }
+}
+
+async function checkInvoiceNumberDuplicate() {
+    const input = document.getElementById('invoiceno');
+    if (!input) return;
+    const invoiceNumber = input.value.trim();
+    let warningEl = document.getElementById('invoiceNoDuplicateWarning');
+    if (!warningEl) {
+        warningEl = document.createElement('small');
+        warningEl.id = 'invoiceNoDuplicateWarning';
+        warningEl.className = 'text-warning d-block mt-1';
+        input.parentNode.appendChild(warningEl);
+    }
+    warningEl.textContent = '';
+    if (!invoiceNumber) return;
+
+    const excludeId = (document.getElementById('closing_hiddenId') || {}).value || '';
+    const params = new URLSearchParams({ invoiceNumber });
+    if (excludeId) params.append('excludeId', excludeId);
+
+    try {
+        const res = await fetch('/tank-receipts/check-invoice-number?' + params.toString());
+        const json = await res.json();
+        if (json.duplicate) {
+            const dt = json.decantDate ? ' on ' + new Date(json.decantDate).toLocaleDateString('en-GB', { day:'2-digit', month:'short', year:'numeric' }) : '';
+            warningEl.textContent = `⚠ Invoice ${invoiceNumber} is already recorded in receipt #${json.receiptId}${dt}.`;
+        }
+    } catch (e) { /* silent */ }
+}
+
+function prefillFromInvoice(data, supplier) {
+    const h = data.header || {};
+    const frozen = document.getElementById('freezedRecord_hiddenValue');
+    const isFrozen = frozen && frozen.value === 'true';
+
+    if (!isFrozen) {
+        const setVal = (id, val) => { const el = document.getElementById(id); if (el && val != null) el.value = val; };
+        setVal('invoiceno', h.invoice_number);
+        setVal('invoiceDate', h.invoice_date);
+        setVal('ttnumber', h.truck_number);
+    }
+
+    // Show invoice reference info (read-only display) — always shown
+    const refEl = document.getElementById('invoiceRefInfo');
+    if (refEl) {
+        const parts = [];
+        if (h.invoice_number) parts.push('Invoice: ' + h.invoice_number);
+        if (h.delivery_doc_no) parts.push('Delivery: ' + h.delivery_doc_no);
+        if (h.seal_lock_no) parts.push('Seal: ' + h.seal_lock_no);
+        if (h.total_invoice_amount) parts.push('Total: ₹' + Number(h.total_invoice_amount).toLocaleString('en-IN'));
+        refEl.textContent = parts.join('  |  ');
+    }
+}
+
 // Add new page - add credit sales to DB via ajax
 function saveDecantLines() {
     return new Promise((resolve, reject) => {
@@ -2238,11 +2396,12 @@ function saveDecantLines() {
 }
 
 function formDecantLines(tdtank_Id, decantLineTag, decantRow, user) {
+    const getVal = (id) => { const el = document.getElementById(id); return el ? el.value || null : null; };
     return {
         'tdtank_id': tdtank_Id,
         'ttank_id': document.getElementById('closing_hiddenId').value,
         'tank_id': document.getElementById(decantLineTag + 'tank_' + decantRow).value,
-        'quantity': parseInt(document.getElementById(decantLineTag + 'tankqty_' + decantRow).value),
+        'quantity': parseFloat(document.getElementById(decantLineTag + 'tankqty_' + decantRow).value),
         'opening_dip': document.getElementById(decantLineTag + 'opening_dip_' + decantRow).value,
         'closing_dip': document.getElementById(decantLineTag + 'closing_dip_' + decantRow).value,
         'EB_MS_FLAG': document.getElementById(decantLineTag + 'eb_' + decantRow).value,
@@ -3125,5 +3284,212 @@ function toggleSmartReadingSection() {
         smartSection.style.display = '';
     } else {
         smartSection.style.display = 'none';
+    }
+}
+
+
+function renderInvoiceConfirmForm(data, products, mappings, tempId, supplier, supplierId) {
+    const container = document.getElementById('invoiceTabContent');
+    if (!container) return;
+    const h = data.header || {};
+    const lines = data.lines || [];
+    const fmtN = (n) => n != null ? parseFloat(n).toLocaleString('en-IN', {minimumFractionDigits: 2, maximumFractionDigits: 2}) : '—';
+
+    const productOptions = (products || []).map(p =>
+        `<option value="${p.product_id}">${p.product_name}</option>`
+    ).join('');
+
+    const lineRows = lines.map((line, i) => {
+        const mappedId = (mappings || {})[line.product_name] || '';
+        const opts = `<option value="">-- Select product --</option>` +
+            (products || []).map(p =>
+                `<option value="${p.product_id}" ${p.product_id == mappedId ? 'selected' : ''}>${p.product_name}</option>`
+            ).join('');
+        return `<tr>
+            <td>${line.product_name || '—'}</td>
+            <td>
+                <select class="form-control form-control-sm inv-line-product" data-line="${i}" required>
+                    ${opts}
+                </select>
+            </td>
+            <td>${line.quantity != null ? line.quantity : '—'}</td>
+            <td>${line.rate_per_kl != null ? fmtN(line.rate_per_kl) : '—'}</td>
+            <td>${fmtN(line.total_line_amount)}</td>
+        </tr>`;
+    }).join('');
+
+    const decantInvoiceNo = ((document.getElementById('invoiceno') || {}).value || '').trim();
+    const parsedInvoiceNo = (h.invoice_number || '').trim();
+    const frozen = !!(document.getElementById('freezedRecord_hiddenValue'));
+    const mismatch = decantInvoiceNo && parsedInvoiceNo && decantInvoiceNo !== parsedInvoiceNo;
+    const mismatchBanner = mismatch
+        ? `<div class="alert alert-danger py-1 px-2 mb-2 small">
+               <strong>Cannot save — invoice number mismatch.</strong>
+               The decant header has <strong>${decantInvoiceNo}</strong> but this PDF is for <strong>${parsedInvoiceNo}</strong>.
+               ${frozen
+                   ? 'This receipt is closed and cannot be changed. Upload the correct invoice PDF.'
+                   : 'Update the invoice number on the Header tab to <strong>' + parsedInvoiceNo + '</strong> first, then re-upload.'}
+           </div>`
+        : '';
+
+    container.innerHTML = `
+        ${mismatchBanner}
+        <div class="mb-3 p-2 bg-light rounded small">
+            <strong>${h.invoice_number || ''}</strong>
+            ${h.invoice_date ? ' &nbsp;|&nbsp; ' + h.invoice_date : ''}
+            ${h.truck_number ? ' &nbsp;|&nbsp; TT: ' + h.truck_number : ''}
+            ${h.delivery_doc_no ? ' &nbsp;|&nbsp; Delivery: ' + h.delivery_doc_no : ''}
+            ${h.total_invoice_amount ? ' &nbsp;|&nbsp; Total: ₹' + fmtN(h.total_invoice_amount) : ''}
+        </div>
+        <table class="table table-sm table-bordered">
+            <thead class="thead-light">
+                <tr>
+                    <th>Invoice Product</th>
+                    <th>Map to Product <span class="text-danger">*</span></th>
+                    <th>Qty (KL)</th>
+                    <th>Rate/KL</th>
+                    <th>Amount</th>
+                </tr>
+            </thead>
+            <tbody>${lineRows}</tbody>
+        </table>
+        ${mismatch ? '' : `<button type="button" class="btn btn-primary btn-sm" onclick="saveInvoice('${tempId}', '${supplier}', ${supplierId})">
+            Save Invoice
+        </button>
+        <span id="invoiceSaveStatus" class="text-muted small ml-2"></span>`}`;
+
+    // Store parsed data on container for saveInvoice to read
+    container._parsedData = data;
+}
+
+async function saveInvoice(tempId, supplier, supplierId) {
+    const container = document.getElementById('invoiceTabContent');
+    const statusEl = document.getElementById('invoiceSaveStatus');
+    const data = container._parsedData || {};
+    const lines = (data.lines || []).slice();
+
+    const selects = container.querySelectorAll('.inv-line-product');
+    let valid = true;
+    selects.forEach((sel, i) => {
+        if (!sel.value) { sel.classList.add('is-invalid'); valid = false; }
+        else { sel.classList.remove('is-invalid'); lines[i] = Object.assign({}, lines[i], { product_id: sel.value }); }
+    });
+    if (!valid) { if (statusEl) { statusEl.textContent = 'Select a product for every line.'; statusEl.className = 'text-danger small ml-2'; } return; }
+
+    if (statusEl) { statusEl.textContent = 'Saving...'; statusEl.className = 'text-muted small ml-2'; }
+
+    try {
+        const resp = await fetch('/tank-receipts/save-invoice', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ tempId, supplier, supplierId, header: data.header || {}, lines })
+        });
+        const json = await resp.json();
+        if (!json.success) {
+            if (statusEl) { statusEl.textContent = json.error || 'Save failed.'; statusEl.className = 'text-danger small ml-2'; }
+            return;
+        }
+        // Show saved invoice and remember the number for tab re-open
+        if (json.invoiceNumber) {
+            const c = document.getElementById('invoiceTabContent');
+            if (c) c.dataset.savedInvoiceNumber = json.invoiceNumber;
+            loadInvoiceTabByNumber(json.invoiceNumber);
+        }
+
+        // Update invoiceParseStatus
+        const ps = document.getElementById('invoiceParseStatus');
+        if (ps) { ps.textContent = 'Invoice saved.'; ps.className = 'text-success small d-block mt-1'; }
+    } catch (e) {
+        if (statusEl) { statusEl.textContent = 'Error: ' + e.message; statusEl.className = 'text-danger small ml-2'; }
+    }
+}
+
+function loadInvoiceTab() {
+    const container = document.getElementById('invoiceTabContent');
+    const savedNumber = container && container.dataset.savedInvoiceNumber;
+    const invoiceNumber = savedNumber || (document.getElementById('invoiceno') || {}).value || '';
+    loadInvoiceTabByNumber(invoiceNumber);
+}
+
+async function loadInvoiceTabByNumber(invoiceNumber) {
+    const container = document.getElementById('invoiceTabContent');
+    if (!container) return;
+    if (!invoiceNumber || !invoiceNumber.trim()) {
+        container.innerHTML = '<div class="text-muted">No invoice attached yet.</div>';
+        return;
+    }
+    container.innerHTML = '<div class="text-muted py-2">Loading...</div>';
+    try {
+        const resp = await fetch('/tank-receipts/invoice-preview?invoiceNumber=' + encodeURIComponent(invoiceNumber));
+        const json = await resp.json();
+        if (!json.success) {
+            container.innerHTML = '<div class="text-muted">No invoice found for this receipt.</div>';
+            return;
+        }
+        container.innerHTML = renderInvoicePreview(json.invoice);
+    } catch (e) {
+        container.innerHTML = '<div class="alert alert-danger small">' + e.message + '</div>';
+    }
+}
+
+function updateTankReceiptDateRange() {
+    const dateRange = document.getElementById('tankReceiptDateRange').value;
+    const fromDateInput = document.getElementById('tankreceipts_fromDate');
+    const toDateInput = document.getElementById('tankreceipts_toDate');
+    const fromDateLabel = document.getElementById('tankrcpt_fromDateLabel');
+    const toDateLabel = document.getElementById('tankrcpt_toDateLabel');
+
+    const currentDate = new Date();
+    let fromDate, toDate;
+
+    function formatDateToISOString(date) {
+        const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+        return utcDate.toISOString().split('T')[0];
+    }
+
+    if (dateRange === 'this_week') {
+        fromDate = new Date();
+        fromDate.setDate(fromDate.getDate() - fromDate.getDay());
+        toDate = new Date();
+    } else if (dateRange === 'this_month') {
+        fromDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1);
+        toDate = new Date();
+    } else if (dateRange === 'last_month') {
+        fromDate = new Date(currentDate.getFullYear(), currentDate.getMonth() - 1, 1);
+        toDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), 0);
+    } else if (dateRange === 'this_financial_year') {
+        const yr = currentDate.getFullYear();
+        const mo = currentDate.getMonth();
+        fromDate = mo < 3 ? new Date(yr - 1, 3, 1) : new Date(yr, 3, 1);
+        toDate = new Date();
+    } else if (dateRange === 'last_financial_year') {
+        const yr = currentDate.getFullYear();
+        const mo = currentDate.getMonth();
+        if (mo < 3) {
+            fromDate = new Date(yr - 2, 3, 1);
+            toDate = new Date(yr - 1, 2, 31);
+        } else {
+            fromDate = new Date(yr - 1, 3, 1);
+            toDate = new Date(yr, 2, 31);
+        }
+    } else {
+        fromDate = '';
+        toDate = '';
+    }
+
+    fromDateInput.value = fromDate ? formatDateToISOString(fromDate) : '';
+    toDateInput.value = toDate ? formatDateToISOString(toDate) : '';
+
+    if (dateRange === 'custom') {
+        fromDateInput.style.display = 'block';
+        toDateInput.style.display = 'block';
+        fromDateLabel.style.display = 'table-cell';
+        toDateLabel.style.display = 'table-cell';
+    } else {
+        fromDateInput.style.display = 'none';
+        toDateInput.style.display = 'none';
+        fromDateLabel.style.display = 'none';
+        toDateLabel.style.display = 'none';
+        document.getElementById('receipts-by-date').submit();
     }
 }

--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -1,0 +1,61 @@
+// routes/gl-routes.js
+const express = require('express');
+const router = express.Router();
+const login = require('connect-ensure-login');
+const isLoginEnsured = login.ensureLoggedIn({});
+const security = require('../utils/app-security');
+const db = require('../db/db-connection');
+
+// GET /gl/api/ledgers/search?location=&group=&q=
+// Returns [{ledger_id, ledger_name}] — used by Select2 ajax typeahead on product ledger fields
+router.get('/api/ledgers/search', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.query.location || req.user.location_code;
+    const group = req.query.group || null;
+    const q = req.query.q || null;
+
+    try {
+        const rows = await db.sequelize.query(`
+            SELECT l.ledger_id, l.ledger_name
+            FROM gl_ledgers l
+            JOIN gl_ledger_groups g ON g.group_id = l.group_id
+            WHERE l.location_code = :locationCode
+              AND l.active_flag = 'Y'
+              AND (:group IS NULL OR g.group_name = :group)
+              AND (:q IS NULL OR l.ledger_name LIKE :qLike)
+            ORDER BY l.ledger_name
+            LIMIT 30
+        `, {
+            replacements: {
+                locationCode,
+                group,
+                q,
+                qLike: q ? `%${q}%` : null
+            },
+            type: db.Sequelize.QueryTypes.SELECT
+        });
+
+        res.json(rows);
+    } catch (error) {
+        console.error('Error searching ledgers:', error);
+        res.status(500).json({ error: 'Failed to search ledgers' });
+    }
+});
+
+module.exports = router;
+
+// Exported helper — used by products route to populate ledger dropdowns server-side
+module.exports.getLedgersByGroup = async function(locationCode, groupName) {
+    const rows = await db.sequelize.query(`
+        SELECT l.ledger_id, l.ledger_name
+        FROM gl_ledgers l
+        JOIN gl_ledger_groups g ON g.group_id = l.group_id
+        WHERE l.location_code = :locationCode
+          AND l.active_flag = 'Y'
+          AND g.group_name = :groupName
+        ORDER BY l.ledger_name
+    `, {
+        replacements: { locationCode, groupName },
+        type: db.Sequelize.QueryTypes.SELECT
+    });
+    return rows;
+};

--- a/routes/tank-receipt-routes.js
+++ b/routes/tank-receipt-routes.js
@@ -1,0 +1,71 @@
+const express = require('express');
+const router = express.Router();
+const login = require('connect-ensure-login');
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+const tankReceiptController = require('../controllers/tank-receipt-controller');
+
+const isLoginEnsured = login.ensureLoggedIn({});
+
+const storage = multer.diskStorage({
+    destination: (req, file, cb) => {
+        const uploadDir = path.join(__dirname, '..', 'uploads', 'tank-invoices');
+        if (!fs.existsSync(uploadDir)) fs.mkdirSync(uploadDir, { recursive: true });
+        cb(null, uploadDir);
+    },
+    filename: (req, file, cb) => {
+        const safeName = file.originalname.replace(/[^a-zA-Z0-9._-]/g, '_');
+        cb(null, `${Date.now()}-${safeName}`);
+    }
+});
+
+const upload = multer({
+    storage,
+    limits: { fileSize: 10 * 1024 * 1024 },
+    fileFilter: (req, file, cb) => {
+        if (file.mimetype === 'application/pdf') {
+            cb(null, true);
+        } else {
+            cb(new Error('Only PDF files are accepted'));
+        }
+    }
+});
+
+// Verify uploaded file starts with PDF magic bytes (%PDF)
+function validatePdfMagicBytes(req, res, next) {
+    if (!req.file) return next();
+    const fd = fs.openSync(req.file.path, 'r');
+    const buf = Buffer.alloc(4);
+    fs.readSync(fd, buf, 0, 4, 0);
+    fs.closeSync(fd);
+    if (buf.toString('ascii') !== '%PDF') {
+        fs.unlinkSync(req.file.path);
+        return res.status(400).json({ success: false, error: 'Uploaded file is not a valid PDF.' });
+    }
+    next();
+}
+
+router.post('/parse-invoice',
+    isLoginEnsured,
+    upload.single('invoicePdf'),
+    validatePdfMagicBytes,
+    (req, res, next) => tankReceiptController.parseInvoicePdf(req, res, next)
+);
+
+router.post('/save-invoice',
+    isLoginEnsured,
+    (req, res, next) => tankReceiptController.saveInvoiceWithProducts(req, res, next)
+);
+
+router.get('/invoice-preview',
+    isLoginEnsured,
+    (req, res, next) => tankReceiptController.invoicePreview(req, res, next)
+);
+
+router.get('/check-invoice-number',
+    isLoginEnsured,
+    (req, res, next) => tankReceiptController.checkInvoiceNumber(req, res, next)
+);
+
+module.exports = router;

--- a/services/invoice-parser-service.js
+++ b/services/invoice-parser-service.js
@@ -1,4 +1,5 @@
-const pdfParse = require('pdf-parse');
+const _pdfParseModule = require('pdf-parse');
+const pdfParse = typeof _pdfParseModule === 'function' ? _pdfParseModule : _pdfParseModule.default;
 const path = require('path');
 const fs = require('fs');
 const moment = require('moment');

--- a/services/invoice-parser-service.js
+++ b/services/invoice-parser-service.js
@@ -1,0 +1,319 @@
+const pdfParse = require('pdf-parse');
+const path = require('path');
+const fs = require('fs');
+const moment = require('moment');
+
+const SUPPLIER_MAP = {
+    'IOCL': 'IOCL',
+    'INDIAN OIL': 'IOCL',
+    'INDIANOIL': 'IOCL',
+    'BPCL': 'BPCL',
+    'BHARAT PETROLEUM': 'BPCL',
+    'HPCL': 'HPCL',
+    'HINDUSTAN PETROLEUM': 'HPCL'
+};
+
+function resolveSupplier(companyName) {
+    if (!companyName) return null;
+    return SUPPLIER_MAP[companyName.toUpperCase().trim()] || null;
+}
+
+function loadConfig(supplierKey) {
+    const configPath = path.join(__dirname, '..', 'config', 'invoice-parsers', `${supplierKey}.json`);
+    if (!fs.existsSync(configPath)) {
+        throw new Error(`No invoice parser config found for supplier: ${supplierKey}`);
+    }
+    return JSON.parse(fs.readFileSync(configPath, 'utf8'));
+}
+
+async function extractText(pdfBuffer) {
+    const data = await pdfParse(pdfBuffer);
+    return data.text || '';
+}
+
+function cleanNumber(raw, cleanType) {
+    if (raw == null) return null;
+    let s = String(raw).trim();
+    if (cleanType === 'remove_commas' || true) {
+        s = s.replace(/,/g, '');
+    }
+    const n = parseFloat(s);
+    return isNaN(n) ? null : n;
+}
+
+function normaliseDate(raw, formats) {
+    if (!raw) return null;
+    const cleaned = raw.trim();
+    for (const fmt of formats) {
+        const m = moment(cleaned, fmt, true);
+        if (m.isValid()) return m.format('YYYY-MM-DD');
+    }
+    // Loose parse as fallback
+    const m = moment(cleaned);
+    return m.isValid() ? m.format('YYYY-MM-DD') : null;
+}
+
+// Return all lines of text as array, with their positions
+function getLines(text) {
+    return text.split('\n').map(l => l.trim()).filter(l => l.length > 0);
+}
+
+// Find the first line index that contains the keyword (case-insensitive)
+function findLineIndex(lines, keyword, startFrom = 0, exactLine = false) {
+    const kw = keyword.toLowerCase();
+    for (let i = startFrom; i < lines.length; i++) {
+        const l = lines[i].toLowerCase();
+        if (exactLine ? l === kw : l.includes(kw)) return i;
+    }
+    return -1;
+}
+
+// Extract all numeric tokens from a line (strips commas)
+function numbersOnLine(line) {
+    const matches = line.replace(/,/g, '').match(/\d+\.?\d*/g);
+    return matches ? matches.map(Number) : [];
+}
+
+function applyStrategy(lines, fieldConfig, blockStart, blockEnd) {
+    const { keyword, strategy, pattern, position, clean, exact_match } = fieldConfig;
+
+    if (strategy === 'value_after_keyword') {
+        const idx = findLineIndex(lines, keyword, blockStart);
+        if (idx < 0 || idx > blockEnd) return null;
+        const line = lines[idx];
+        const kwPos = line.toLowerCase().indexOf(keyword.toLowerCase());
+        const after = line.slice(kwPos + keyword.length).trim().replace(/^[:\s]+/, '');
+        if (pattern) {
+            const m = after.match(new RegExp(pattern));
+            return m ? m[0].trim() : null;
+        }
+        return after.split(/\s+/)[0] || null;
+    }
+
+    if (strategy === 'value_at_keyword') {
+        const idx = findLineIndex(lines, keyword, blockStart);
+        if (idx < 0 || idx > blockEnd) return null;
+        const line = lines[idx];
+        if (pattern) {
+            const m = line.match(new RegExp(pattern));
+            if (!m) return null;
+            return (m[1] != null ? m[1] : m[0]).trim();
+        }
+        return null;
+    }
+
+    if (strategy === 'nth_number_on_line') {
+        const idx = findLineIndex(lines, keyword, blockStart);
+        if (idx < 0 || idx > blockEnd) return null;
+        const nums = numbersOnLine(lines[idx]);
+        const val = nums[position - 1] != null ? nums[position - 1] : null;
+        return val;
+    }
+
+    if (strategy === 'last_number_on_line') {
+        const idx = findLineIndex(lines, keyword, blockStart);
+        if (idx < 0 || idx > blockEnd) return null;
+        const nums = numbersOnLine(lines[idx]);
+        return nums.length > 0 ? nums[nums.length - 1] : null;
+    }
+
+    if (strategy === 'value_before_keyword') {
+        // Value appears on the same line BEFORE the keyword: "7005531183SAP Entry no."
+        const idx = findLineIndex(lines, keyword, blockStart);
+        if (idx < 0 || idx > blockEnd) return null;
+        const line = lines[idx];
+        const kwPos = line.toLowerCase().indexOf(keyword.toLowerCase());
+        const before = line.slice(0, kwPos).trim();
+        if (pattern) {
+            const m = before.match(new RegExp(pattern));
+            if (m) return m[0].trim();
+        }
+        if (before) return before.split(/\s+/).pop() || null;
+        // Fallback: value is on the previous line
+        if (idx > 0 && pattern) {
+            const m = lines[idx - 1].match(new RegExp(pattern));
+            if (m) return m[0].trim();
+        }
+        return idx > 0 ? lines[idx - 1].trim() : null;
+    }
+
+    if (strategy === 'value_on_prev_line') {
+        // Value is on the line before the keyword
+        const idx = findLineIndex(lines, keyword, blockStart, !!exact_match);
+        if (idx < 1 || idx > blockEnd) return null;
+        const prev = lines[idx - 1];
+        if (pattern) {
+            const m = prev.match(new RegExp(pattern));
+            return m ? m[0].trim() : null;
+        }
+        return prev.trim();
+    }
+
+    if (strategy === 'nth_number_on_next_line') {
+        // Keyword on one line, values on the next: "A/R Vat Payable\n13.000%39683.59"
+        const idx = findLineIndex(lines, keyword, blockStart, !!exact_match);
+        if (idx < 0 || idx > blockEnd || idx + 1 >= lines.length) return null;
+        const nextLine = lines[idx + 1];
+        const nums = numbersOnLine(nextLine);
+        return nums[position - 1] != null ? nums[position - 1] : null;
+    }
+
+    if (strategy === 'number_before_keyword') {
+        // Scan the block for a line containing keyword, extract the number right before it
+        const idx = findLineIndex(lines, keyword, blockStart);
+        if (idx < 0 || idx > blockEnd) return null;
+        const line = lines[idx];
+        const kwPos = line.toLowerCase().indexOf(keyword.toLowerCase());
+        const before = line.slice(0, kwPos).replace(/,/g, '').trim();
+        const m = before.match(/[\d.]+$/);
+        return m ? parseFloat(m[0]) : null;
+    }
+
+    if (strategy === 'number_before_keyword_on_prev_line') {
+        // BPCL: qty is on the line before DLY/TAXABLE CHARGE, before "KL"
+        const idx = findLineIndex(lines, keyword, blockStart);
+        if (idx < 0 || idx > blockEnd || idx === 0) return null;
+        const prevLine = lines[idx - 1];
+        const ukw = fieldConfig.unit_keyword || 'KL';
+        const ukwPos = prevLine.toUpperCase().indexOf(ukw);
+        if (ukwPos < 0) return null;
+        const before = prevLine.slice(0, ukwPos).replace(/,/g, '').trim();
+        const m = before.match(/[\d.]+$/);
+        return m ? parseFloat(m[0]) : null;
+    }
+
+    if (strategy === 'hsn_from_prev_line') {
+        // IOCL: "1016730   EBMS4.000KL2710 12 42." — HSN is "2710 12 42" at end of prev line
+        if (blockStart <= 0) return null;
+        for (let i = blockStart - 1; i >= Math.max(0, blockStart - 3); i--) {
+            const l = lines[i];
+            if (!l) continue;
+            const m = l.match(/(2710[\s\d]+)/);
+            if (m) return m[1].trim().replace(/\s+/g, ' ').replace(/\.$/, '');
+        }
+        return null;
+    }
+
+    if (strategy === 'line_before_block_start') {
+        // Product name: walk back from blockStart, find line containing product name
+        // IOCL format: "1016730   EBMS4.000KL2710 12 42." → extract "EBMS"
+        if (blockStart <= 0) return null;
+        for (let i = blockStart - 1; i >= Math.max(0, blockStart - 5); i--) {
+            const l = lines[i];
+            if (!l || l.length < 2) continue;
+            // Strip leading item number (digits + spaces)
+            const stripped = l.replace(/^\d+\s+/, '').trim();
+            if (!stripped) continue;
+            // Extract text up to the first digit sequence (product name ends before qty)
+            const nameMatch = stripped.match(/^([A-Z][A-Z0-9\s\-]*?)(?=\d|\s*$)/);
+            if (nameMatch && nameMatch[1].trim().length > 1) {
+                return nameMatch[1].trim();
+            }
+            // Fallback: if line doesn't start with digit and isn't just numbers
+            if (!/^\d/.test(l)) {
+                return l.replace(/^\d+[.\s]+/, '').split(/\s{2,}/)[0].trim();
+            }
+        }
+        return null;
+    }
+
+    return null;
+}
+
+function parseHeaderFields(lines, headerConfig, dateFormats) {
+    const result = {};
+    const totalLines = lines.length;
+
+    for (const [fieldName, fieldConfig] of Object.entries(headerConfig)) {
+        let raw = applyStrategy(lines, fieldConfig, 0, totalLines - 1);
+        if (raw == null) { result[fieldName] = null; continue; }
+
+        if (fieldName === 'invoice_date') {
+            result[fieldName] = normaliseDate(String(raw), dateFormats);
+        } else if (['total_invoice_amount'].includes(fieldName)) {
+            result[fieldName] = cleanNumber(raw);
+        } else {
+            result[fieldName] = String(raw).trim();
+        }
+    }
+    return result;
+}
+
+function parseProductLines(lines, linesConfig, dateFormats) {
+    const { product_block_start, product_block_end, fields } = linesConfig;
+    if (!product_block_start || !fields) return [];
+
+    const results = [];
+    let searchFrom = 0;
+
+    while (true) {
+        const blockStartIdx = findLineIndex(lines, product_block_start, searchFrom);
+        if (blockStartIdx < 0) break;
+
+        const blockEndIdx = findLineIndex(lines, product_block_end, blockStartIdx);
+        const effectiveEnd = blockEndIdx >= 0 ? blockEndIdx : Math.min(blockStartIdx + 20, lines.length - 1);
+
+        const lineResult = {};
+        for (const [fieldName, fieldConfig] of Object.entries(fields)) {
+            if (fieldConfig._skip) continue;
+            let raw = applyStrategy(lines, fieldConfig, blockStartIdx, effectiveEnd);
+            if (raw == null) { lineResult[fieldName] = null; continue; }
+
+            if (['quantity', 'rate_per_kl', 'vat_pct', 'vat_amount',
+                 'additional_vat_amount', 'delivery_charge', 'density',
+                 'total_line_amount'].includes(fieldName)) {
+                lineResult[fieldName] = cleanNumber(raw);
+            } else {
+                lineResult[fieldName] = String(raw).trim();
+            }
+        }
+
+        // Only add if we got at least quantity or total
+        if (lineResult.quantity || lineResult.total_line_amount) {
+            results.push(lineResult);
+        }
+
+        searchFrom = effectiveEnd + 1;
+        if (searchFrom >= lines.length) break;
+    }
+
+    return results;
+}
+
+function parseTotalAmount(lines, totalConfig) {
+    if (!totalConfig || !totalConfig.keyword) return null;
+    const totalLines = lines.length;
+    let raw = applyStrategy(lines, totalConfig, 0, totalLines - 1);
+    return cleanNumber(raw);
+}
+
+async function parseInvoice(pdfBuffer, companyName) {
+    const supplierKey = resolveSupplier(companyName);
+    if (!supplierKey) {
+        throw new Error(`Unknown supplier: "${companyName}". Add to SUPPLIER_MAP in invoice-parser-service.js`);
+    }
+
+    const config = loadConfig(supplierKey);
+    const rawText = await extractText(pdfBuffer);
+
+    if (!rawText || rawText.trim().length < 50) {
+        throw new Error('No readable text found in PDF. File may be a scanned image or password-protected.');
+    }
+
+    const lines = getLines(rawText);
+
+    const header = parseHeaderFields(lines, config.header || {}, config.dateFormats || []);
+    const productLines = config.lines ? parseProductLines(lines, config.lines, config.dateFormats || []) : [];
+    const totalAmount = parseTotalAmount(lines, config.total_amount);
+
+    if (totalAmount) header.total_invoice_amount = totalAmount;
+
+    return {
+        supplier: supplierKey,
+        header,
+        lines: productLines,
+        rawText
+    };
+}
+
+module.exports = { parseInvoice, resolveSupplier };

--- a/services/invoice-parser-service.js
+++ b/services/invoice-parser-service.js
@@ -1,5 +1,4 @@
-const _pdfParseModule = require('pdf-parse');
-const pdfParse = typeof _pdfParseModule === 'function' ? _pdfParseModule : _pdfParseModule.default;
+const pdfParse = require('pdf-parse');
 const path = require('path');
 const fs = require('fs');
 const moment = require('moment');

--- a/views/edit-draft-tankrcpt.pug
+++ b/views/edit-draft-tankrcpt.pug
@@ -39,6 +39,8 @@ block content
                         a.nav-link#decantlines_tab(data-toggle="tab" href="#new_decantlines" onclick=`trackMenu(this)`) Decant Lines
                     li.nav-item.col-md
                         a.nav-link#summary_tab(data-toggle="tab" href="#summary" onclick="populateReceiptSummary(this)") Summary
+                    li.nav-item.col-md
+                        a.nav-link#invoice_tab(data-toggle="tab" href="#invoice_tab_pane" onclick="loadInvoiceTab()") Invoice
             else
                 ul.nav.nav-tabs
                     li.nav-item.col-md
@@ -47,6 +49,8 @@ block content
                         a.nav-link#decantlines_tab(data-toggle="tab" href="#new_decantlines") Decant Lines
                     li.nav-item.col-md.active
                         a.nav-link.active#summary_tab(data-toggle="tab" href="#summary" onclick="populateReceiptSummary(this)") Summary
+                    li.nav-item.col-md
+                        a.nav-link#invoice_tab(data-toggle="tab" href="#invoice_tab_pane" onclick="loadInvoiceTab()") Invoice
             div.tab-content
                 // ----------------------- New Decant Header details ----------------------------
                 div.row &nbsp;
@@ -73,8 +77,8 @@ block content
                                                 td
                                                     input(type='hidden' id='h_invoiceDate' value= receiptsData.h_invoiceDate)
                                                     input#invoiceDate.form-control(type='date', name='invoiceDate', value=receiptsData.invoice_date max=currentDate required)
-                                                td  
-                                                    input#invoiceno.form-control(type="text" name="invoice_no" value=receiptsData.invoice_number required)
+                                                td
+                                                    input#invoiceno.form-control(type="text" name="invoice_no" value=receiptsData.invoice_number required onblur="checkInvoiceNumberDuplicate()")
                                                 td 
                                                     input(type='hidden' id='h_decantDate' value= receiptsData.h_decantDate)
                                                     input#decantDate.form-control(type='date', name='decantDate', value=receiptsData.decant_date max=currentDate required)
@@ -199,9 +203,24 @@ block content
                                                 - var rowCnt = 0
                                                 while rowCnt < maxDecantLines
                                                     +summaryDecantLinesData(rowCnt++)
-                    if(!freezedRecord)            
+                    if(!freezedRecord)
                         div.row
                             div.col &nbsp;
                         div(align="center")
                             span
                                 button.btn.btn-dark(type="button", onClick='finishClosing(\'closing\',\'close-receipt\', \'tankReceipt_tab\')') CLOSE &raquo;
+
+                // ----------------------- Invoice ----------------------------
+                div.tab-pane.fade#invoice_tab_pane
+                    div.p-3
+                        div.mb-3
+                            label.font-weight-bold Upload Invoice PDF
+                            div.mt-1
+                                input#invoicePdfUpload.form-control-file(type='file' accept='.pdf' onchange='uploadAndParseInvoice()')
+                            span#invoiceParseStatus.text-muted.small.d-block.mt-1
+                        div.mt-2#invoiceTabContent
+                            div.text-muted No invoice attached yet.
+
+            if(freezedRecord)
+                script.
+                    document.addEventListener('DOMContentLoaded', function() { populateReceiptSummary(); });

--- a/views/new-decant.pug
+++ b/views/new-decant.pug
@@ -14,10 +14,11 @@ block content
                     a.nav-link#decantlines_tab(data-toggle="tab" href="#new_decantlines" onclick=`trackMenu(this)`) Decant Lines
                 li.nav-item.col-md
                     a.nav-link#summary_tab(data-toggle="tab" href="#summary" onclick="populateReceiptSummary(this)") Summary
+                li.nav-item.col-md
+                    a.nav-link#invoice_tab(data-toggle="tab" href="#invoice_tab_pane" onclick="loadInvoiceTab()") Invoice
             div.tab-content
                 // ----------------------- New Decant details ----------------------------
                 div.row &nbsp;
-                //div.tab-pane.active#new_decantheader
                 div.container-fluid#new_decantheader(class="tab-pane active")
                     div.row &nbsp;
                     input(type='hidden' name='location' id='location_id' value= location)
@@ -45,8 +46,8 @@ block content
                                                 td
                                                     input(type='hidden' id='h_invoiceDate' value= currentDate)
                                                     input#invoiceDate.form-control(type='date', name='decant_invoiceDate', value=currentDate max=currentDate required)
-                                                td  
-                                                    input#invoiceno.form-control(type="text" name="decant_invoiceno" required) 
+                                                td
+                                                    input#invoiceno.form-control(type="text" name="decant_invoiceno" required onblur="checkInvoiceNumberDuplicate()")
                                                 td
                                                     input(type='hidden' id='h_decantDate' value= currentDate)
                                                     input#decantDate.form-control(type='date', name='decant_decantDate', value=currentDate max=currentDate required)
@@ -176,4 +177,15 @@ block content
                     div(align="center")
                         span
                             button.btn.btn-dark(type="button", onClick='finishClosing(\'closing\',\'close-receipt\', \'tankReceipt_tab\')') CLOSE &raquo;
+
+                // ----------------------- Invoice ----------------------------
+                div.tab-pane.fade#invoice_tab_pane
+                    div.p-3
+                        div.mb-3
+                            label.font-weight-bold Upload Invoice PDF
+                            div.mt-1
+                                input#invoicePdfUpload.form-control-file(type='file' accept='.pdf' onchange='uploadAndParseInvoice()')
+                            span#invoiceParseStatus.text-muted.small.d-block.mt-1
+                        div.mt-2#invoiceTabContent
+                            div.text-muted No invoice attached yet.
 

--- a/views/tankreceipts.pug
+++ b/views/tankreceipts.pug
@@ -4,13 +4,23 @@ block content
     form(method='GET' action='/tankreceipts' id='receipts-by-date')
         table.center
             tr
-                td From Date:
+                td Date Range:
                 td
-                    input#tankreceipts_fromDate.form-control(type='date', name='tankreceipts_fromDate', value=fromDate max=currentDate format="dd/mm/yyyy" required)
+                    select#tankReceiptDateRange.form-control(onchange='updateTankReceiptDateRange()')
+                        option(value='this_week') This Week
+                        option(value='this_month' selected) This Month
+                        option(value='last_month') Last Month
+                        option(value='this_financial_year') This Financial Year
+                        option(value='last_financial_year') Last Financial Year
+                        option(value='custom') Custom Date
                 td &nbsp;
-                td To Date:
+                td#tankrcpt_fromDateLabel(style='display:none') From Date:
                 td
-                    input#tankreceipts_toDate.form-control(type='date', name='tankreceipts_toDate', value=toDate max=currentDate format="dd/mm/yyyy" required)
+                    input#tankreceipts_fromDate.form-control(type='date', name='tankreceipts_fromDate', value=fromDate max=currentDate required style='display:none')
+                td &nbsp;
+                td#tankrcpt_toDateLabel(style='display:none') To Date:
+                td
+                    input#tankreceipts_toDate.form-control(type='date', name='tankreceipts_toDate', value=toDate max=currentDate required style='display:none')
                 td &nbsp;
                 td
                     button.btn.btn-primary(type='submit') Go
@@ -47,6 +57,10 @@ block content
                                    span= val.invoice_date
                                 td
                                     span= val.invoice_number
+                                    if val.hasInvoice
+                                        |
+                                        button.btn.btn-link.btn-sm.p-0.ml-1(type='button' title='View Invoice' onclick=`showInvoicePreview('${val.invoice_number}')`)
+                                            span.bi.bi-file-pdf-fill.text-danger
                                 td
                                     span= val.decant_date
                                 td
@@ -103,3 +117,15 @@ block content
                 div.row
                     div.col
                         button.btn.btn-primary(type='button' onclick='getNewDecantPage()') Add New
+
+    div.modal.fade#invoicePreviewModal(tabindex='-1' role='dialog' aria-labelledby='invoicePreviewTitle' aria-hidden='true')
+        div.modal-dialog.modal-lg(role='document')
+            div.modal-content
+                div.modal-header.bg-light
+                    h5.modal-title#invoicePreviewTitle Purchase Invoice
+                    button.close(type='button' data-dismiss='modal' aria-label='Close')
+                        span(aria-hidden='true') &times;
+                div.modal-body#invoicePreviewBody
+                    div.text-center.text-muted Loading...
+                div.modal-footer
+                    button.btn.btn-secondary(type='button' data-dismiss='modal') Close


### PR DESCRIPTION
## Summary
- Fuel purchase invoice upload with PDF parsing (IOCL/BPCL/HPCL) in dedicated Invoice tab on decant pages
- Two-step parse → confirm flow with auto-learning product mappings (`t_invoice_product_map`)
- Invoice stored as standalone entity (`t_tank_invoice`), PDF blob in generic `t_document_store`
- Hard block when uploaded PDF invoice number mismatches decant header
- Invoice number duplicate check across decant headers (blur warning)
- PDF icon on receipts list only when invoice exists; list defaults to current month
- Fix decant line quantity display after DECIMAL column migration (`"8.000"` → `"8"` for dropdown match)
- Fix `loadInvoiceTab()` showing wrong invoice after save
- Various deploy fixes (missing routes mount, pdf-parse version pin)

## DB Migrations
- `db/migrations/tank-invoice.sql` — already run on prod DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)