### PR TITLE
Add fuel invoice purchase screen with charges, edit-disable config, and combined purchases list

### DIFF
--- a/app.js
+++ b/app.js
@@ -188,6 +188,10 @@ app.use(compression());
 
 
 
+const distPath = path.join(__dirname, 'public/dist');
+if (require('fs').existsSync(distPath)) {
+    app.use(express.static(distPath, { maxAge: '7d' }));
+}
 app.use(express.static(path.join(__dirname, 'public'), { maxAge: '7d' }));
 
 
@@ -232,6 +236,7 @@ const glRoutes = require('./routes/gl-routes');
 const employeeRoutes  = require('./routes/employee-routes');
 const documentRoutes  = require('./routes/document-routes');
 const tankReceiptRoutes = require('./routes/tank-receipt-routes');
+const purchasesRoutes   = require('./routes/purchases-routes');
 
 //const auditingUtilitiesRoutes = require('./routes/auditing-utilities-routes');
 
@@ -398,6 +403,7 @@ app.use('/transaction-upload', transactionUploadRoutes);
 app.use('/dsm-entry', require('./routes/dsm-entry-routes'));
 app.use('/day-bill', dayBillRoutes);
 app.use('/tank-receipts', tankReceiptRoutes);
+app.use('/purchases',    purchasesRoutes);
 app.use('/employees', employeeRoutes);
 app.use('/documents', documentRoutes);
 app.use('/gl', glRoutes);

--- a/controllers/lubes-invoice-controller.js
+++ b/controllers/lubes-invoice-controller.js
@@ -394,39 +394,64 @@ function gatherLubesInvoices(fromDate, toDate, supplierId, user, res, next, mess
         toDate = financialYearDates.toDate;
     }
     
-    // Create promises for both data fetches
+    const { Op } = require('sequelize');
+    const TankInvoice = db.tank_invoice;
+    const TankInvoiceDtl = db.tank_invoice_dtl;
+
     const suppliersPromise = lubesInvoiceDao.getSuppliers(user.location_code);
-    const invoicesPromise = lubesInvoiceDao.findLubesInvoices(
-        user.location_code, 
-        fromDate, 
-        toDate, 
-        supplierId
-    );
-    
-    // Execute both promises together
-    Promise.all([suppliersPromise, invoicesPromise])
-        .then(([suppliers, invoices]) => {
+    const lubesPromise = lubesInvoiceDao.findLubesInvoices(user.location_code, fromDate, toDate, supplierId);
+    const fuelPromise = TankInvoice.findAll({
+        where: { location_id: user.location_code, invoice_date: { [Op.between]: [fromDate, toDate] } },
+        include: [{ model: TankInvoiceDtl, as: 'lines', attributes: ['quantity'] }],
+        order: [['invoice_date', 'DESC'], ['id', 'DESC']]
+    });
+
+    Promise.all([suppliersPromise, lubesPromise, fuelPromise])
+        .then(([suppliers, lubesInvoices, fuelInvoices]) => {
             let invoiceValues = [];
-            
-            if(invoices && invoices.length > 0) {
-                invoices.forEach(invoice => {
+
+            if (lubesInvoices && lubesInvoices.length > 0) {
+                lubesInvoices.forEach(invoice => {
                     invoiceValues.push({
+                        type: 'LUBE',
                         lubes_hdr_id: invoice.lubes_hdr_id,
                         invoice_number: invoice.invoice_number,
                         supplier_name: invoice.Supplier ? invoice.Supplier.supplier_name : 'N/A',
                         closing_status: invoice.closing_status,
                         notes: invoice.notes,
                         date: dateFormat(invoice.invoice_date, 'dd-mmm-yyyy'),
+                        invoice_date_raw: invoice.invoice_date,
                         amount: parseFloat(invoice.invoice_amount) || 0,
                         total_lines: invoice.LubesInvoiceLines ? invoice.LubesInvoiceLines.length : 0
                     });
                 });
             }
-            
+
+            if (fuelInvoices && fuelInvoices.length > 0) {
+                fuelInvoices.forEach(f => {
+                    const qty = (f.lines || []).reduce((s, l) => s + (parseFloat(l.quantity) || 0), 0);
+                    invoiceValues.push({
+                        type: 'FUEL',
+                        fuel_id: f.id,
+                        invoice_number: f.invoice_number || '',
+                        supplier_name: f.supplier || '',
+                        closing_status: 'SAVED',
+                        notes: '',
+                        date: f.invoice_date ? dateFormat(new Date(f.invoice_date), 'dd-mmm-yyyy') : '',
+                        invoice_date_raw: f.invoice_date,
+                        amount: parseFloat(f.total_invoice_amount) || 0,
+                        total_lines: (f.lines || []).length,
+                        qty_kl: qty > 0 ? qty.toFixed(3) : ''
+                    });
+                });
+            }
+
+            invoiceValues.sort((a, b) => new Date(b.invoice_date_raw) - new Date(a.invoice_date_raw));
+
             res.render('lubes-invoice-home', {
-                title: "Lubes Invoice: Home", 
+                title: "Purchases",
                 user: user,
-                fromDate: fromDate, 
+                fromDate: fromDate,
                 toDate: toDate,
                 selectedSupplierId: supplierId,
                 suppliers: suppliers,

--- a/controllers/purchases-controller.js
+++ b/controllers/purchases-controller.js
@@ -1,0 +1,185 @@
+const db = require('../db/db-connection');
+const { Op } = require('sequelize');
+const TankInvoiceDao = require('../dao/tank-invoice-dao');
+const SupplierDao = require('../dao/supplier-dao');
+const locationConfig = require('../utils/location-config');
+const utils = require('../utils/app-utils');
+const dateFormat = require('dateformat');
+
+module.exports = {
+
+    getList: async (req, res, next) => {
+        try {
+            const locationCode = req.user.location_code;
+            const today = utils.currentDate();
+            const firstOfMonth = today.substring(0, 7) + '-01';
+            const fromDate = req.query.fromDate || firstOfMonth;
+            const toDate   = req.query.toDate   || today;
+            const typeFilter = req.query.type   || '';
+
+            const [fuelInvoices, lubeInvoices] = await Promise.all([
+                TankInvoiceDao.findAll(locationCode, fromDate, toDate),
+                db.t_lubes_inv_hdr.findAll({
+                    where: {
+                        location_code: locationCode,
+                        invoice_date: { [Op.between]: [fromDate, toDate] }
+                    },
+                    include: [{ model: db.m_supplier, as: 'Supplier', attributes: ['supplier_name'] }],
+                    order: [['invoice_date', 'DESC'], ['lubes_hdr_id', 'DESC']]
+                })
+            ]);
+
+            const rows = [];
+
+            if (!typeFilter || typeFilter === 'FUEL') {
+                fuelInvoices.forEach(f => {
+                    const qty = (f.lines || []).reduce((s, l) => s + (parseFloat(l.quantity) || 0), 0);
+                    rows.push({
+                        type: 'FUEL',
+                        id: f.id,
+                        invoice_date: f.invoice_date,
+                        invoice_date_fmt: f.invoice_date ? dateFormat(new Date(f.invoice_date), 'dd-mmm-yyyy') : '',
+                        invoice_number: f.invoice_number || '',
+                        supplier: f.supplier || '',
+                        amount: parseFloat(f.total_invoice_amount) || 0,
+                        qty_summary: qty > 0 ? qty.toFixed(3) + ' KL' : '',
+                        status: 'SAVED',
+                        link: `/purchases/fuel-invoice/${f.id}`
+                    });
+                });
+            }
+
+            if (!typeFilter || typeFilter === 'LUBE') {
+                lubeInvoices.forEach(l => {
+                    rows.push({
+                        type: 'LUBE',
+                        id: l.lubes_hdr_id,
+                        invoice_date: l.invoice_date,
+                        invoice_date_fmt: l.invoice_date ? dateFormat(new Date(l.invoice_date), 'dd-mmm-yyyy') : '',
+                        invoice_number: l.invoice_number || '',
+                        supplier: l.Supplier ? l.Supplier.supplier_name : '',
+                        amount: parseFloat(l.invoice_amount) || 0,
+                        qty_summary: '',
+                        status: l.closing_status || '',
+                        link: `/lubes-invoice?id=${l.lubes_hdr_id}`
+                    });
+                });
+            }
+
+            rows.sort((a, b) => new Date(b.invoice_date) - new Date(a.invoice_date));
+
+            res.render('purchases', {
+                user: req.user,
+                rows,
+                fromDate,
+                toDate,
+                typeFilter,
+                currentDate: today
+            });
+        } catch (err) {
+            next(err);
+        }
+    },
+
+    getNewFuelInvoice: async (req, res, next) => {
+        try {
+            const locationCode = req.user.location_code;
+            const [suppliers, products] = await Promise.all([
+                SupplierDao.findSuppliers(locationCode),
+                db.sequelize.query(
+                    `SELECT product_id, product_name FROM m_product WHERE location_code = :locationCode AND is_tank_product = 1`,
+                    { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT }
+                )
+            ]);
+            res.render('fuel-invoice', {
+                user: req.user,
+                invoice: null,
+                suppliers,
+                products,
+                currentDate: utils.currentDate(),
+                isNew: true,
+                editDisabled: false
+            });
+        } catch (err) {
+            next(err);
+        }
+    },
+
+    getFuelInvoice: async (req, res, next) => {
+        try {
+            const locationCode = req.user.location_code;
+            const id = req.params.id;
+            const [invoice, suppliers, products, editDisabledCfg] = await Promise.all([
+                TankInvoiceDao.findById(id),
+                SupplierDao.findSuppliers(locationCode),
+                db.sequelize.query(
+                    `SELECT product_id, product_name FROM m_product WHERE location_code = :locationCode AND is_tank_product = 1`,
+                    { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT }
+                ),
+                locationConfig.getLocationConfigValue(locationCode, 'FUEL_INVOICE_EDIT_DISABLED', 'N')
+            ]);
+            if (!invoice) return res.status(404).send('Invoice not found');
+            res.render('fuel-invoice', {
+                user: req.user,
+                invoice,
+                suppliers,
+                products,
+                currentDate: utils.currentDate(),
+                isNew: false,
+                editDisabled: String(editDisabledCfg).toUpperCase() === 'Y'
+            });
+        } catch (err) {
+            next(err);
+        }
+    },
+
+    saveFuelInvoice: async (req, res, next) => {
+        try {
+            const locationCode = req.user.location_code;
+            const body = req.body;
+
+            if (!body.supplier_id) return res.status(400).json({ success: false, error: 'Supplier is required.' });
+            if (!body.invoice_number || !body.invoice_number.trim()) return res.status(400).json({ success: false, error: 'Invoice number is required.' });
+
+            const header = {
+                location_id:          locationCode,
+                supplier_id:          Number(body.supplier_id),
+                supplier:             body.supplier_name || null,
+                invoice_number:       body.invoice_number.trim(),
+                invoice_date:         body.invoice_date   || null,
+                truck_number:         body.truck_number   || null,
+                delivery_doc_no:      body.delivery_doc_no || null,
+                seal_lock_no:         body.seal_lock_no   || null,
+                total_invoice_amount: body.total_invoice_amount || null
+            };
+
+            const lines = (Array.isArray(body.lines) ? body.lines : []).map(l => ({
+                product_id:        Number(l.product_id),
+                product_name:      l.product_name      || null,
+                quantity:          l.quantity          || null,
+                rate_per_kl:       l.rate_per_kl       || null,
+                density:           l.density           || null,
+                hsn_code:          l.hsn_code          || null,
+                total_line_amount: l.total_line_amount || null,
+                charges: (Array.isArray(l.charges) ? l.charges : [])
+                    .filter(c => c.charge_type && c.charge_type.trim())
+                    .map(c => ({
+                        charge_type:   c.charge_type.trim(),
+                        charge_pct:    c.charge_pct    || null,
+                        charge_amount: c.charge_amount || null
+                    }))
+            }));
+
+            if (!lines.length) return res.status(400).json({ success: false, error: 'At least one product line is required.' });
+            if (lines.some(l => !l.product_id)) return res.status(400).json({ success: false, error: 'All lines must have a product selected.' });
+
+            const invoice = await TankInvoiceDao.saveInvoice(
+                header, lines, null, locationCode, header.supplier_id, null
+            );
+            return res.json({ success: true, id: invoice.id });
+        } catch (err) {
+            console.error('saveFuelInvoice error:', err);
+            return res.status(500).json({ success: false, error: err.message });
+        }
+    }
+};

--- a/routes/purchases-routes.js
+++ b/routes/purchases-routes.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+const login = require('connect-ensure-login');
+const purchasesController = require('../controllers/purchases-controller');
+
+const isLoginEnsured = login.ensureLoggedIn({});
+
+router.get('/',                  isLoginEnsured, (req, res, next) => purchasesController.getList(req, res, next));
+router.get('/fuel-invoice/new',  isLoginEnsured, (req, res, next) => purchasesController.getNewFuelInvoice(req, res, next));
+router.get('/fuel-invoice/:id',  isLoginEnsured, (req, res, next) => purchasesController.getFuelInvoice(req, res, next));
+router.post('/fuel-invoice/save',isLoginEnsured, (req, res, next) => purchasesController.saveFuelInvoice(req, res, next));
+
+module.exports = router;

--- a/views/fuel-invoice.pug
+++ b/views/fuel-invoice.pug
@@ -1,0 +1,317 @@
+extends layout
+
+block content
+    div.container-fluid.mt-3
+
+        div.d-flex.align-items-center.mb-3
+            h5.mb-0
+                a.text-secondary(href='/lubes-invoice-home') Purchases
+                span.text-muted  /
+                | Fuel Invoice
+            div.ml-auto
+                if !isNew && invoice
+                    span.badge.badge-secondary.mr-2 ##{invoice.id}
+
+        //- PDF Upload card (always shown even when edit is disabled — for remapping)
+        div.card.mb-3
+            div.card-body.py-2
+                div.d-flex.align-items-center
+                    label.font-weight-bold.mb-0.mr-3 Upload Invoice PDF
+                    input#fuelInvoicePdfUpload.form-control-file(type='file' accept='.pdf' style='max-width:320px' onchange='fuelInvoiceUploadAndParse()')
+                    span#fuelParseStatus.text-muted.small.ml-3
+
+        //- Header card
+        div.card.mb-3
+            div.card-header.py-2
+                strong Header
+            div.card-body
+                div.row
+                    div.col-md-3.form-group
+                        label.small Supplier #[span.text-danger *]
+                        select#fi_supplier_id.form-control.form-control-sm(required disabled=editDisabled)
+                            option(value='') -- Select --
+                            each s in suppliers
+                                option(value=s.supplier_id selected=(invoice && invoice.supplier_id == s.supplier_id))= s.supplier_name
+                    div.col-md-2.form-group
+                        label.small Invoice Number #[span.text-danger *]
+                        input#fi_invoice_number.form-control.form-control-sm(type='text' value=(invoice ? invoice.invoice_number : '') required readonly=editDisabled)
+                    div.col-md-2.form-group
+                        label.small Invoice Date
+                        input#fi_invoice_date.form-control.form-control-sm(type='date' value=(invoice ? invoice.invoice_date : '') max=currentDate readonly=editDisabled)
+                    div.col-md-2.form-group
+                        label.small TT Number
+                        input#fi_truck_number.form-control.form-control-sm(type='text' value=(invoice ? invoice.truck_number : '') readonly=editDisabled)
+                    div.col-md-2.form-group
+                        label.small Delivery Doc No
+                        input#fi_delivery_doc_no.form-control.form-control-sm(type='text' value=(invoice ? invoice.delivery_doc_no : '') readonly=editDisabled)
+                div.row
+                    div.col-md-3.form-group
+                        label.small Seal / Lock No
+                        input#fi_seal_lock_no.form-control.form-control-sm(type='text' value=(invoice ? invoice.seal_lock_no : '') readonly=editDisabled)
+                    div.col-md-2.form-group
+                        label.small Total Invoice Amount
+                        input#fi_total_amount.form-control.form-control-sm(type='number' step='0.01' min='0' value=(invoice ? invoice.total_invoice_amount : '') readonly=editDisabled)
+
+        //- Lines card
+        div.card.mb-3
+            div.card-header.py-2.d-flex.align-items-center
+                strong Lines
+                if !editDisabled
+                    button.btn.btn-outline-secondary.btn-sm.ml-auto(type='button' onclick='fuelInvoiceAddLine()') + Add Line
+            div.card-body.p-0
+                div.table-responsive
+                    table.table.table-sm.table-bordered.mb-0#fi_lines_table
+                        thead.thead-light
+                            tr
+                                th Invoice Product Name
+                                th Map to Product #[span.text-danger *]
+                                th Qty (KL)
+                                th Rate/KL
+                                th Density
+                                th HSN Code
+                                th Amount
+                                th
+                        tbody#fi_lines_body
+
+        div.mb-3
+            button.btn.btn-primary(type='button' onclick='fuelInvoiceSave()')
+                = editDisabled ? 'Save Mapping' : 'Save Invoice'
+            a.btn.btn-secondary.ml-2(href='/lubes-invoice-home') Cancel
+            span#fi_save_status.text-muted.small.ml-3
+
+    script.
+        const FI_PRODUCTS = !{JSON.stringify(products)};
+        const FI_EXISTING_LINES = !{JSON.stringify(invoice ? (invoice.lines || []) : [])};
+        const FI_EDIT_DISABLED = !{JSON.stringify(editDisabled)};
+
+        document.addEventListener('DOMContentLoaded', function() {
+            if (FI_EXISTING_LINES.length > 0) {
+                FI_EXISTING_LINES.forEach(l => fuelInvoiceAddLine(l));
+            } else {
+                fuelInvoiceAddLine();
+            }
+        });
+
+        let fi_lineCount = 0;
+        const fi_chargeCounters = {};
+
+        function fuelInvoiceAddLine(data) {
+            const i = fi_lineCount++;
+            const opts = FI_PRODUCTS.map(p =>
+                `<option value="${p.product_id}" ${data && data.product_id == p.product_id ? 'selected' : ''}>${p.product_name}</option>`
+            ).join('');
+            const d = data || {};
+            const ro = FI_EDIT_DISABLED ? 'readonly' : '';
+            const removeBtn = FI_EDIT_DISABLED ? '' :
+                `<button type="button" class="btn btn-sm btn-link text-danger" onclick="fuelInvoiceRemoveLine(${i})">&times;</button>`;
+
+            const row = `<tr id="fi_line_${i}">
+                <td><input type="text" class="form-control form-control-sm fi-product-name" value="${d.product_name || ''}" placeholder="As on invoice" ${ro}></td>
+                <td>
+                    <select class="form-control form-control-sm fi-product-id" required>
+                        <option value="">-- Select --</option>${opts}
+                    </select>
+                </td>
+                <td><input type="number" class="form-control form-control-sm fi-quantity" step="0.001" min="0" value="${d.quantity || ''}" ${ro}></td>
+                <td><input type="number" class="form-control form-control-sm fi-rate" step="0.001" min="0" value="${d.rate_per_kl || ''}" ${ro}></td>
+                <td><input type="number" class="form-control form-control-sm fi-density" step="0.001" min="0" value="${d.density || ''}" ${ro}></td>
+                <td><input type="text" class="form-control form-control-sm fi-hsn" value="${d.hsn_code || ''}" ${ro}></td>
+                <td><input type="number" class="form-control form-control-sm fi-line-amount" step="0.01" min="0" value="${d.total_line_amount || ''}" ${ro}></td>
+                <td>${removeBtn}</td>
+            </tr>
+            <tr id="fi_charges_row_${i}">
+                <td colspan="8" class="p-2 bg-light">${buildChargesHtml(i, d.charges || [])}</td>
+            </tr>`;
+            document.getElementById('fi_lines_body').insertAdjacentHTML('beforeend', row);
+        }
+
+        function buildChargesHtml(lineIdx, charges) {
+            fi_chargeCounters[lineIdx] = 0;
+            let rows = '';
+            (charges || []).forEach(c => { rows += buildChargeRow(lineIdx, c); });
+
+            const addBtn = FI_EDIT_DISABLED ? '' :
+                `<button type="button" class="btn btn-sm btn-outline-secondary mt-1" onclick="fuelInvoiceAddCharge(${lineIdx})">+ Add Charge</button>`;
+
+            return `<div>
+                <span class="text-muted" style="font-size:0.8em;font-weight:600">CHARGES / TAX</span>
+                <table class="table table-sm table-bordered mb-1" style="max-width:520px">
+                    <thead class="thead-light"><tr>
+                        <th style="width:40%">Charge Type</th>
+                        <th style="width:20%">Rate %</th>
+                        <th style="width:25%">Amount</th>
+                        <th style="width:15%"></th>
+                    </tr></thead>
+                    <tbody id="fi_charges_body_${lineIdx}">${rows}</tbody>
+                </table>
+                ${addBtn}
+            </div>`;
+        }
+
+        function buildChargeRow(lineIdx, c) {
+            const ci = ++fi_chargeCounters[lineIdx];
+            const cid = `fi_chg_${lineIdx}_${ci}`;
+            const ro = FI_EDIT_DISABLED ? 'readonly' : '';
+            const removeBtn = FI_EDIT_DISABLED ? '' :
+                `<button type="button" class="btn btn-sm btn-link text-danger p-0" onclick="document.getElementById('${cid}').remove()">&times;</button>`;
+            return `<tr id="${cid}">
+                <td><input type="text" class="form-control form-control-sm fi-charge-type" value="${c.charge_type || ''}" placeholder="e.g. CGST" ${ro}></td>
+                <td><input type="number" class="form-control form-control-sm fi-charge-pct" step="0.01" value="${c.charge_pct || ''}" ${ro}></td>
+                <td><input type="number" class="form-control form-control-sm fi-charge-amount" step="0.01" value="${c.charge_amount || ''}" ${ro}></td>
+                <td class="text-center">${removeBtn}</td>
+            </tr>`;
+        }
+
+        function fuelInvoiceAddCharge(lineIdx) {
+            const tbody = document.getElementById(`fi_charges_body_${lineIdx}`);
+            if (tbody) tbody.insertAdjacentHTML('beforeend', buildChargeRow(lineIdx, {}));
+        }
+
+        function fuelInvoiceRemoveLine(i) {
+            const el = document.getElementById(`fi_line_${i}`);
+            if (el) el.remove();
+            const cr = document.getElementById(`fi_charges_row_${i}`);
+            if (cr) cr.remove();
+        }
+
+        function fuelInvoiceCollectLines() {
+            const rows = document.querySelectorAll('#fi_lines_body tr[id^="fi_line_"]');
+            return Array.from(rows).map(row => {
+                const idx = row.id.replace('fi_line_', '');
+                const chargeRows = document.querySelectorAll(`#fi_charges_body_${idx} tr`);
+                const charges = Array.from(chargeRows)
+                    .map(cr => ({
+                        charge_type:   (cr.querySelector('.fi-charge-type') || {}).value || '',
+                        charge_pct:    (cr.querySelector('.fi-charge-pct') || {}).value || '',
+                        charge_amount: (cr.querySelector('.fi-charge-amount') || {}).value || ''
+                    }))
+                    .filter(c => c.charge_type.trim());
+                return {
+                    product_name:      row.querySelector('.fi-product-name').value.trim(),
+                    product_id:        row.querySelector('.fi-product-id').value,
+                    quantity:          row.querySelector('.fi-quantity').value,
+                    rate_per_kl:       row.querySelector('.fi-rate').value,
+                    density:           row.querySelector('.fi-density').value,
+                    hsn_code:          row.querySelector('.fi-hsn').value,
+                    total_line_amount: row.querySelector('.fi-line-amount').value,
+                    charges
+                };
+            });
+        }
+
+        async function fuelInvoiceSave() {
+            const statusEl = document.getElementById('fi_save_status');
+            const supplierId = document.getElementById('fi_supplier_id').value;
+            const invoiceNumber = document.getElementById('fi_invoice_number').value.trim();
+            const supplierName = document.getElementById('fi_supplier_id').options[document.getElementById('fi_supplier_id').selectedIndex].text;
+
+            if (!supplierId) { alert('Please select a supplier.'); return; }
+            if (!invoiceNumber) { alert('Invoice number is required.'); return; }
+
+            const lines = fuelInvoiceCollectLines();
+            if (!lines.length) { alert('Add at least one product line.'); return; }
+            if (lines.some(l => !l.product_id)) { alert('Select a product for every line.'); return; }
+
+            statusEl.textContent = 'Saving...';
+            statusEl.className = 'text-muted small ml-3';
+
+            try {
+                const resp = await fetch('/purchases/fuel-invoice/save', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        supplier_id:          supplierId,
+                        supplier_name:        supplierName,
+                        invoice_number:       invoiceNumber,
+                        invoice_date:         document.getElementById('fi_invoice_date').value,
+                        truck_number:         document.getElementById('fi_truck_number').value,
+                        delivery_doc_no:      document.getElementById('fi_delivery_doc_no').value,
+                        seal_lock_no:         document.getElementById('fi_seal_lock_no').value,
+                        total_invoice_amount: document.getElementById('fi_total_amount').value,
+                        lines
+                    })
+                });
+                const json = await resp.json();
+                if (!json.success) {
+                    statusEl.textContent = json.error || 'Save failed.';
+                    statusEl.className = 'text-danger small ml-3';
+                    return;
+                }
+                statusEl.textContent = 'Saved.';
+                statusEl.className = 'text-success small ml-3';
+                window.location.href = '/purchases/fuel-invoice/' + json.id;
+            } catch (e) {
+                statusEl.textContent = 'Error: ' + e.message;
+                statusEl.className = 'text-danger small ml-3';
+            }
+        }
+
+        async function fuelInvoiceUploadAndParse() {
+            const input = document.getElementById('fuelInvoicePdfUpload');
+            const statusEl = document.getElementById('fuelParseStatus');
+            if (!input.files || !input.files[0]) return;
+            statusEl.textContent = 'Reading invoice...';
+            statusEl.className = 'text-muted small ml-3';
+
+            const supplierId = document.getElementById('fi_supplier_id').value;
+
+            const formData = new FormData();
+            formData.append('invoicePdf', input.files[0]);
+            if (supplierId) formData.append('supplierId', supplierId);
+
+            try {
+                const resp = await fetch('/tank-receipts/parse-invoice', { method: 'POST', body: formData });
+                if (resp.status === 403) { statusEl.textContent = 'Permission denied.'; statusEl.className = 'text-danger small ml-3'; return; }
+                const json = await resp.json();
+                if (!json.success) {
+                    statusEl.textContent = json.error || 'Could not read invoice.';
+                    statusEl.className = 'text-danger small ml-3';
+                    return;
+                }
+                fuelInvoicePrefill(json.data, json.supplier, json.supplierId, json.products, json.mappings);
+                statusEl.textContent = 'Invoice read successfully.';
+                statusEl.className = 'text-success small ml-3';
+            } catch (e) {
+                statusEl.textContent = 'Error: ' + e.message;
+                statusEl.className = 'text-danger small ml-3';
+            }
+        }
+
+        function fuelInvoicePrefill(data, supplier, supplierId, products, mappings) {
+            const h = data.header || {};
+            if (!FI_EDIT_DISABLED) {
+                if (h.invoice_number) document.getElementById('fi_invoice_number').value = h.invoice_number;
+                if (h.invoice_date)   document.getElementById('fi_invoice_date').value   = h.invoice_date;
+                if (h.truck_number)   document.getElementById('fi_truck_number').value   = h.truck_number;
+                if (h.delivery_doc_no)document.getElementById('fi_delivery_doc_no').value= h.delivery_doc_no;
+                if (h.seal_lock_no)   document.getElementById('fi_seal_lock_no').value   = h.seal_lock_no;
+                if (h.total_invoice_amount) document.getElementById('fi_total_amount').value = h.total_invoice_amount;
+
+                if (supplierId) {
+                    const sel = document.getElementById('fi_supplier_id');
+                    for (let i = 0; i < sel.options.length; i++) {
+                        if (sel.options[i].value == supplierId) { sel.selectedIndex = i; break; }
+                    }
+                }
+            }
+
+            // Always clear and refill lines (mapping always allowed)
+            document.getElementById('fi_lines_body').innerHTML = '';
+            fi_lineCount = 0;
+            const lines = data.lines || [];
+            if (lines.length === 0) { fuelInvoiceAddLine(); return; }
+
+            lines.forEach(line => {
+                const mappedId = (mappings || {})[line.product_name] || '';
+                fuelInvoiceAddLine({
+                    product_name:      line.product_name,
+                    product_id:        mappedId,
+                    quantity:          line.quantity,
+                    rate_per_kl:       line.rate_per_kl,
+                    density:           line.density,
+                    hsn_code:          line.hsn_code,
+                    total_line_amount: line.total_line_amount,
+                    charges:           line.charges || []
+                });
+            });
+        }

--- a/views/lubes-invoice-home.pug
+++ b/views/lubes-invoice-home.pug
@@ -181,7 +181,11 @@ block content
                         button.btn.btn-sm.btn-primary(type='submit') Go
                     td &nbsp;
                     td
-                        a.btn.btn-sm.btn-primary(href='/lubes-invoice/new') Create New Invoice
+                        div.dropdown
+                            button.btn.btn-sm.btn-primary.dropdown-toggle(type='button' data-toggle='dropdown') New Purchase
+                            div.dropdown-menu
+                                a.dropdown-item(href='/purchases/fuel-invoice/new') Fuel Invoice
+                                a.dropdown-item(href='/lubes-invoice/new') Lube Invoice
             
             input(type='hidden' id='invoice_fromDate_hiddenValue' name='invoice_fromDate_hiddenValue' value=fromDate)
             input(type='hidden' id='invoice_toDate_hiddenValue' name='invoice_toDate_hiddenValue' value=toDate)
@@ -195,39 +199,55 @@ block content
                         th Invoice Number
                         th Supplier
                         th Date
+                        th Type
                         th.text-right Amount
-                        th.text-center Lines
+                        th.text-center Lines / Qty
                         th Status
                         th Actions
                 tbody
                     each val in invoiceValues
                         tr(class=val.closing_status.toLowerCase())
                             td
-                                button.btn.btn-sm.btn-link.p-0(
-                                    type='button'
-                                    onclick=`toggleInvoiceLines(${val.lubes_hdr_id}, this)`
-                                    aria-expanded='false'
-                                )
-                                    i.oi.oi-chevron-right.toggle-icon
+                                if val.type === 'LUBE'
+                                    button.btn.btn-sm.btn-link.p-0(
+                                        type='button'
+                                        onclick=`toggleInvoiceLines(${val.lubes_hdr_id}, this)`
+                                        aria-expanded='false'
+                                    )
+                                        i.oi.oi-chevron-right.toggle-icon
                             td= val.invoice_number
                             td= val.supplier_name
                             td= val.date
+                            td
+                                if val.type === 'FUEL'
+                                    span.badge.badge-warning Fuel
+                                else
+                                    span.badge.badge-info Lube
                             td.text-right= val.amount.toLocaleString('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
                             td.text-center
-                                span.badge.badge-info= val.total_lines
+                                if val.type === 'FUEL'
+                                    = val.qty_kl ? val.qty_kl + ' KL' : val.total_lines + ' lines'
+                                else
+                                    span.badge.badge-info= val.total_lines
                             td
-                                span(class=val.closing_status === 'DRAFT' ? 'badge badge-warning' : 'badge badge-success')
-                                    = val.closing_status
-                            if (val.closing_status === 'DRAFT')
-                                td
+                                if val.type === 'FUEL'
+                                    span.badge.badge-secondary= val.closing_status
+                                else
+                                    span(class=val.closing_status === 'DRAFT' ? 'badge badge-warning' : 'badge badge-success')
+                                        = val.closing_status
+                            td
+                                if val.type === 'FUEL'
+                                    a.btn.btn-sm.btn-info(href='/purchases/fuel-invoice/' + val.fuel_id)
+                                        span.oi.oi-envelope-open
+                                else if val.closing_status === 'DRAFT'
                                     a.btn.btn-sm.btn-info.mr-2(href='/lubes-invoice?id=' + val.lubes_hdr_id)
                                         span.oi.oi-pencil
                                     a.btn.btn-sm.btn-danger(onClick=`deleteInvoice(${val.lubes_hdr_id}, '${val.closing_status}')`)
                                         span.oi.oi-trash
-                            else
-                                td
+                                else
                                     a.btn.btn-sm.btn-info(href='/lubes-invoice?id=' + val.lubes_hdr_id)
                                         span.oi.oi-envelope-open
-                        tr.collapse-row
-                            td.line-details(colspan='8')
-                                div.collapse(id=`invoice-lines-${val.lubes_hdr_id}`)
+                        if val.type === 'LUBE'
+                            tr.collapse-row
+                                td.line-details(colspan='9')
+                                    div.collapse(id=`invoice-lines-${val.lubes_hdr_id}`)


### PR DESCRIPTION
## Summary
- New fuel invoice entry screen (`/purchases/fuel-invoice/new` and `/:id`) with PDF upload, header fields, per-line charges/tax table
- Back link to `/lubes-invoice-home`; `FUEL_INVOICE_EDIT_DISABLED` config disables all fields except product mapping
- `lubes-invoice-home` now shows combined fuel + lube invoices with Type badge, KL qty for fuel rows
- Charges (`charge_type`, `charge_pct`, `charge_amount`) saved per line to `t_tank_invoice_charges`

## Test plan
- [ ] Open `/lubes-invoice-home` — verify Fuel and Lube rows both appear with Type badge
- [ ] Click "New Purchase" → Fuel Invoice — verify form opens, back link goes to purchases list
- [ ] Save a new fuel invoice with charges — verify charges saved
- [ ] Set `FUEL_INVOICE_EDIT_DISABLED=Y` — verify header fields are read-only, product mapping dropdown still editable, button says "Save Mapping"
- [ ] Upload PDF on edit-disabled invoice — verify only lines/mappings are refreshed, header unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)