### PR TITLE
Add CNG invoice support and fuel invoice enhancements

### DIFF
--- a/config/invoice-parsers/BPCL_CNG.json
+++ b/config/invoice-parsers/BPCL_CNG.json
@@ -1,0 +1,58 @@
+{
+  "supplier": "BPCL",
+  "dateFormats": ["DD.MM.YYYY", "DD-MM-YYYY", "DD/MM/YYYY"],
+  "header": {
+    "invoice_number": {
+      "keyword": "INVOICE No.:",
+      "strategy": "value_after_keyword",
+      "pattern": "\\d+"
+    },
+    "invoice_date": {
+      "keyword": "DATE/TIME:",
+      "strategy": "value_after_keyword",
+      "pattern": "\\d{2}\\.\\d{2}\\.\\d{4}"
+    },
+    "delivery_doc_no": {
+      "keyword": "DELIVERY No",
+      "strategy": "value_after_keyword",
+      "pattern": "\\d+"
+    }
+  },
+  "lines": {
+    "product_block_start": "VAT/LST",
+    "product_block_end": "VAT/STAX/CESS",
+    "fields": {
+      "product_name": {
+        "keyword": "VAT/LST",
+        "strategy": "value_at_keyword",
+        "pattern": "(?:\\d{2}\\.)([A-Za-z][A-Za-z\\s()/.-]*)(?=\\d)"
+      },
+      "quantity": {
+        "keyword": " kg",
+        "strategy": "number_before_keyword"
+      },
+      "rate_per_kl": {
+        "keyword": "/KG",
+        "strategy": "number_before_keyword"
+      },
+      "total_line_amount": {
+        "keyword": "VAT/LST",
+        "strategy": "number_before_keyword"
+      },
+      "vat_pct": {
+        "keyword": "VAT/LST",
+        "strategy": "value_after_keyword",
+        "pattern": "\\d+"
+      },
+      "vat_amount": {
+        "keyword": "VAT/LST",
+        "strategy": "last_number_on_line"
+      }
+    }
+  },
+  "total_amount": {
+    "keyword": "TOTAL VALUE : Rs",
+    "strategy": "value_after_keyword",
+    "pattern": "[\\d,]+\\.?\\d*"
+  }
+}

--- a/controllers/location-controller.js
+++ b/controllers/location-controller.js
@@ -46,8 +46,8 @@ module.exports = {
      */
     createLocation: async (req, res, next) => {
         try {
-            const { location_code, location_name, address, company_name, 
-                    gst_number, phone, start_date } = req.body;
+            const { location_code, location_name, address, company_name,
+                    gst_number, oil_co_dealer_code, phone, start_date } = req.body;
 
             // Validate location code format
             if (!locationDao.validateLocationCode(location_code)) {
@@ -75,6 +75,7 @@ module.exports = {
                 address: address.toUpperCase().trim(),
                 company_name: company_name.toUpperCase().trim(),
                 gst_number: gst_number ? gst_number.toUpperCase().trim() : null,
+                oil_co_dealer_code: oil_co_dealer_code ? oil_co_dealer_code.trim() : null,
                 phone: phone.trim(),
                 start_date: start_date ? new Date(start_date + 'T00:00:00') : new Date(new Date().setHours(0,0,0,0)),
                 created_by: req.user.Person_id.toString()
@@ -96,7 +97,7 @@ module.exports = {
    updateLocation: async (req, res, next) => {
     try {
         const locationId = req.params.id;
-        const { location_name, company_name, gst_number, phone, start_date } = req.body;
+        const { location_name, company_name, gst_number, oil_co_dealer_code, phone, start_date } = req.body;
 
         // Validate phone number (10 digits)
         if (!phone || !/^\d{10}$/.test(phone)) {
@@ -105,14 +106,15 @@ module.exports = {
 
         // Update location
         await locationDao.update(locationId, {
-        location_name: location_name.toUpperCase().trim(),
-        company_name: company_name.toUpperCase().trim(),
-        gst_number: gst_number ? gst_number.toUpperCase().trim() : null,
-        phone: phone.trim(),
-        start_date: start_date ? new Date(start_date + 'T00:00:00') : new Date(new Date().setHours(0,0,0,0)),
-        effective_end_date: '9999-12-31',
-        updated_by: req.user.Person_id.toString()
-    });
+            location_name: location_name.toUpperCase().trim(),
+            company_name: company_name.toUpperCase().trim(),
+            gst_number: gst_number ? gst_number.toUpperCase().trim() : null,
+            oil_co_dealer_code: oil_co_dealer_code ? oil_co_dealer_code.trim() : null,
+            phone: phone.trim(),
+            start_date: start_date ? new Date(start_date + 'T00:00:00') : new Date(new Date().setHours(0,0,0,0)),
+            effective_end_date: '9999-12-31',
+            updated_by: req.user.Person_id.toString()
+        });
 
         res.json({ success: true, message: 'Location updated successfully' });
     } catch (error) {

--- a/controllers/purchases-controller.js
+++ b/controllers/purchases-controller.js
@@ -5,6 +5,7 @@ const SupplierDao = require('../dao/supplier-dao');
 const locationConfig = require('../utils/location-config');
 const utils = require('../utils/app-utils');
 const dateFormat = require('dateformat');
+const DocumentStoreDao = require('../dao/document-store-dao');
 
 module.exports = {
 
@@ -84,12 +85,13 @@ module.exports = {
     getNewFuelInvoice: async (req, res, next) => {
         try {
             const locationCode = req.user.location_code;
-            const [suppliers, products] = await Promise.all([
+            const [suppliers, products, editDisabledCfg] = await Promise.all([
                 SupplierDao.findSuppliers(locationCode),
                 db.sequelize.query(
                     `SELECT product_id, product_name FROM m_product WHERE location_code = :locationCode AND is_tank_product = 1`,
                     { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT }
-                )
+                ),
+                locationConfig.getLocationConfigValue(locationCode, 'FUEL_INVOICE_EDIT_DISABLED', 'N')
             ]);
             res.render('fuel-invoice', {
                 user: req.user,
@@ -98,7 +100,7 @@ module.exports = {
                 products,
                 currentDate: utils.currentDate(),
                 isNew: true,
-                editDisabled: false
+                editDisabled: String(editDisabledCfg).toUpperCase() === 'Y'
             });
         } catch (err) {
             next(err);
@@ -130,6 +132,41 @@ module.exports = {
             });
         } catch (err) {
             next(err);
+        }
+    },
+
+    getFuelInvoicePdf: async (req, res, next) => {
+        try {
+            const id = req.params.id;
+            const invoice = await TankInvoiceDao.findById(id);
+            if (!invoice) return res.status(404).send('Invoice not found.');
+            if (invoice.location_id.toUpperCase() !== req.user.location_code.toUpperCase()) {
+                return res.status(403).send('Access denied.');
+            }
+            const docs = await DocumentStoreDao.findByEntity('TANK_INVOICE', id);
+            if (!docs || docs.length === 0) return res.status(404).send('No PDF attached to this invoice.');
+            const doc = await DocumentStoreDao.findById(docs[0].doc_id);
+            res.set('Content-Type', 'application/pdf');
+            res.set('Content-Disposition', `inline; filename="${doc.file_name}"`);
+            res.send(doc.file_data);
+        } catch (err) {
+            next(err);
+        }
+    },
+
+    deleteFuelInvoice: async (req, res, next) => {
+        try {
+            const id = req.params.id;
+            const invoice = await TankInvoiceDao.findById(id);
+            if (!invoice) return res.status(404).json({ success: false, error: 'Invoice not found.' });
+            if (invoice.location_id.toUpperCase() !== req.user.location_code.toUpperCase()) {
+                return res.status(403).json({ success: false, error: 'Access denied.' });
+            }
+            await TankInvoiceDao.deleteById(id);
+            return res.json({ success: true });
+        } catch (err) {
+            console.error('deleteFuelInvoice error:', err);
+            return res.status(500).json({ success: false, error: err.message });
         }
     },
 

--- a/controllers/tank-receipt-controller.js
+++ b/controllers/tank-receipt-controller.js
@@ -139,6 +139,15 @@ module.exports = {
 
             const result = await InvoiceParserService.parseInvoice(pdfBuffer, companyName);
 
+            // Validate dealer code if configured — catches wrong-location uploads (e.g. MC invoice at MC2)
+            const dealerCode = location.oil_co_dealer_code ? String(location.oil_co_dealer_code).trim() : null;
+            if (dealerCode && !result.rawText.includes(dealerCode)) {
+                return res.status(400).json({
+                    success: false,
+                    error: `Invoice does not belong to this outlet. Expected dealer code ${dealerCode} not found in the PDF.`
+                });
+            }
+
             // Resolve supplier_id — mandatory
             const supplierRow = await db.sequelize.query(
                 `SELECT supplier_id, supplier_name FROM m_supplier WHERE UPPER(supplier_short_name) = UPPER(:code) AND location_code = :loc LIMIT 1`,
@@ -163,6 +172,17 @@ module.exports = {
                 InvoiceProductMapDao.getMappings(locationCode, supplierRow.supplier_id)
             ]);
 
+            const linesWithCharges = result.lines.map(l => {
+                const charges = [];
+                if (l.vat_pct != null || l.vat_amount != null)
+                    charges.push({ charge_type: 'VAT', charge_pct: l.vat_pct || null, charge_amount: l.vat_amount || null });
+                if (l.additional_vat_amount != null)
+                    charges.push({ charge_type: 'ADDITIONAL_VAT', charge_pct: null, charge_amount: l.additional_vat_amount });
+                if (l.delivery_charge != null)
+                    charges.push({ charge_type: 'DELIVERY_CHARGE', charge_pct: null, charge_amount: l.delivery_charge });
+                return { ...l, charges };
+            });
+
             return res.json({
                 success: true,
                 supplier: result.supplier,
@@ -171,7 +191,7 @@ module.exports = {
                 tempId,
                 products,
                 mappings,
-                data: { header: result.header, lines: result.lines }
+                data: { header: result.header, lines: linesWithCharges }
             });
         } catch (err) {
             console.error('Error parsing invoice PDF:', err);

--- a/dao/tank-invoice-dao.js
+++ b/dao/tank-invoice-dao.js
@@ -31,6 +31,20 @@ module.exports = {
         });
     },
 
+    deleteById: async (id) => {
+        return db.sequelize.transaction(async (t) => {
+            const lines = await TankInvoiceDtl.findAll({ where: { invoice_id: id }, transaction: t });
+            for (const line of lines) {
+                await TankInvoiceCharges.destroy({ where: { invoice_dtl_id: line.id }, transaction: t });
+            }
+            await TankInvoiceDtl.destroy({ where: { invoice_id: id }, transaction: t });
+            await TankInvoice.destroy({ where: { id }, transaction: t });
+        }).then(async () => {
+            const docs = await DocumentStoreDao.findByEntity('TANK_INVOICE', id);
+            for (const doc of docs) await DocumentStoreDao.deleteById(doc.doc_id);
+        });
+    },
+
     findByInvoiceNumber: (locationId, invoiceNumber) => {
         return TankInvoice.findOne({
             where: { location_id: locationId, invoice_number: invoiceNumber },

--- a/db/location.js
+++ b/db/location.js
@@ -28,6 +28,14 @@ module.exports = function(sequelize, DataTypes) {
             type: DataTypes.STRING(50),
             allowNull: true
         },
+        tin_number: {
+            type: DataTypes.STRING(50),
+            allowNull: true
+        },
+        oil_co_dealer_code: {
+            type: DataTypes.STRING(50),
+            allowNull: true
+        },
         phone: {
             type: DataTypes.STRING(50),
             allowNull: false

--- a/db/migrations/oil-co-dealer-code.sql
+++ b/db/migrations/oil-co-dealer-code.sql
@@ -1,0 +1,6 @@
+-- Add oil company dealer/customer code to m_location
+-- IOCL calls this SAP No; BPCL calls it CC No (Customer Code)
+-- Used to validate that an uploaded invoice belongs to the correct outlet
+
+ALTER TABLE m_location
+    ADD COLUMN oil_co_dealer_code VARCHAR(50) NULL AFTER tin_number;

--- a/routes/purchases-routes.js
+++ b/routes/purchases-routes.js
@@ -7,7 +7,9 @@ const isLoginEnsured = login.ensureLoggedIn({});
 
 router.get('/',                  isLoginEnsured, (req, res, next) => purchasesController.getList(req, res, next));
 router.get('/fuel-invoice/new',  isLoginEnsured, (req, res, next) => purchasesController.getNewFuelInvoice(req, res, next));
-router.get('/fuel-invoice/:id',  isLoginEnsured, (req, res, next) => purchasesController.getFuelInvoice(req, res, next));
-router.post('/fuel-invoice/save',isLoginEnsured, (req, res, next) => purchasesController.saveFuelInvoice(req, res, next));
+router.get('/fuel-invoice/:id/pdf', isLoginEnsured, (req, res, next) => purchasesController.getFuelInvoicePdf(req, res, next));
+router.get('/fuel-invoice/:id',     isLoginEnsured, (req, res, next) => purchasesController.getFuelInvoice(req, res, next));
+router.post('/fuel-invoice/save',      isLoginEnsured, (req, res, next) => purchasesController.saveFuelInvoice(req, res, next));
+router.post('/fuel-invoice/:id/delete', isLoginEnsured, (req, res, next) => purchasesController.deleteFuelInvoice(req, res, next));
 
 module.exports = router;

--- a/services/invoice-parser-service.js
+++ b/services/invoice-parser-service.js
@@ -18,6 +18,22 @@ function resolveSupplier(companyName) {
     return SUPPLIER_MAP[companyName.toUpperCase().trim()] || null;
 }
 
+const SUPPLIER_DETECT_PATTERNS = [
+    { pattern: /INDIAN OIL CORPORATION/i,       supplier: 'IOCL' },
+    { pattern: /BHARAT PETROLEUM CORPORATION/i,  supplier: 'BPCL' },
+    { pattern: /HINDUSTAN PETROLEUM CORPORATION/i, supplier: 'HPCL' },
+    { pattern: /\bINDIAN OIL\b/i,               supplier: 'IOCL' },
+    { pattern: /\bBHARAT PETROLEUM\b/i,          supplier: 'BPCL' },
+    { pattern: /\bHINDUSTAN PETROLEUM\b/i,       supplier: 'HPCL' },
+];
+
+function detectSupplierFromText(text) {
+    for (const { pattern, supplier } of SUPPLIER_DETECT_PATTERNS) {
+        if (pattern.test(text)) return supplier;
+    }
+    return null;
+}
+
 function loadConfig(supplierKey) {
     const configPath = path.join(__dirname, '..', 'config', 'invoice-parsers', `${supplierKey}.json`);
     if (!fs.existsSync(configPath)) {
@@ -293,12 +309,25 @@ async function parseInvoice(pdfBuffer, companyName) {
         throw new Error(`Unknown supplier: "${companyName}". Add to SUPPLIER_MAP in invoice-parser-service.js`);
     }
 
-    const config = loadConfig(supplierKey);
     const rawText = await extractText(pdfBuffer);
 
     if (!rawText || rawText.trim().length < 50) {
         throw new Error('No readable text found in PDF. File may be a scanned image or password-protected.');
     }
+
+    // Reject if PDF is from a different oil company than this location
+    const detectedSupplier = detectSupplierFromText(rawText);
+    if (detectedSupplier && detectedSupplier !== supplierKey) {
+        throw new Error(`This PDF is a ${detectedSupplier} invoice but this location uses ${supplierKey}. Please upload the correct invoice.`);
+    }
+
+    // Auto-detect CNG variant for BPCL
+    let configKey = supplierKey;
+    if (supplierKey === 'BPCL' && /COMPRESSED NATURAL GAS|CNG/i.test(rawText)) {
+        configKey = 'BPCL_CNG';
+    }
+
+    const config = loadConfig(configKey);
 
     const lines = getLines(rawText);
 

--- a/views/fuel-invoice.pug
+++ b/views/fuel-invoice.pug
@@ -12,13 +12,20 @@ block content
                 if !isNew && invoice
                     span.badge.badge-secondary.mr-2 ##{invoice.id}
 
-        //- PDF Upload card (always shown even when edit is disabled — for remapping)
-        div.card.mb-3
-            div.card-body.py-2
-                div.d-flex.align-items-center
-                    label.font-weight-bold.mb-0.mr-3 Upload Invoice PDF
-                    input#fuelInvoicePdfUpload.form-control-file(type='file' accept='.pdf' style='max-width:320px' onchange='fuelInvoiceUploadAndParse()')
-                    span#fuelParseStatus.text-muted.small.ml-3
+        //- PDF Upload card (new invoice only)
+        if isNew
+            div.card.mb-3
+                div.card-body.py-2
+                    div.d-flex.align-items-center
+                        label.font-weight-bold.mb-0.mr-3 Upload Invoice PDF
+                        input#fuelInvoicePdfUpload.form-control-file(type='file' accept='.pdf' style='max-width:320px' onchange='fuelInvoiceUploadAndParse()')
+                        span#fuelParseStatus.text-muted.small.ml-3
+        else
+            div.mb-3.d-flex.align-items-center
+                a.btn.btn-outline-secondary.btn-sm(href='/purchases/fuel-invoice/new') + Upload Another Invoice
+                a.btn.btn-outline-danger.btn-sm.ml-2(href=`/purchases/fuel-invoice/${invoice.id}/pdf` target='_blank' title='View PDF')
+                    span.oi.oi-document
+                    |  View PDF
 
         //- Header card
         div.card.mb-3
@@ -77,12 +84,15 @@ block content
             button.btn.btn-primary(type='button' onclick='fuelInvoiceSave()')
                 = editDisabled ? 'Save Mapping' : 'Save Invoice'
             a.btn.btn-secondary.ml-2(href='/lubes-invoice-home') Cancel
+            if !isNew && invoice
+                button.btn.btn-danger.ml-4(type='button' onclick='fuelInvoiceDelete()')  Delete Invoice
             span#fi_save_status.text-muted.small.ml-3
 
     script.
         const FI_PRODUCTS = !{JSON.stringify(products)};
         const FI_EXISTING_LINES = !{JSON.stringify(invoice ? (invoice.lines || []) : [])};
         const FI_EDIT_DISABLED = !{JSON.stringify(editDisabled)};
+        const FI_INVOICE_ID = !{JSON.stringify(invoice ? invoice.id : null)};
 
         document.addEventListener('DOMContentLoaded', function() {
             if (FI_EXISTING_LINES.length > 0) {
@@ -279,19 +289,17 @@ block content
 
         function fuelInvoicePrefill(data, supplier, supplierId, products, mappings) {
             const h = data.header || {};
-            if (!FI_EDIT_DISABLED) {
-                if (h.invoice_number) document.getElementById('fi_invoice_number').value = h.invoice_number;
-                if (h.invoice_date)   document.getElementById('fi_invoice_date').value   = h.invoice_date;
-                if (h.truck_number)   document.getElementById('fi_truck_number').value   = h.truck_number;
-                if (h.delivery_doc_no)document.getElementById('fi_delivery_doc_no').value= h.delivery_doc_no;
-                if (h.seal_lock_no)   document.getElementById('fi_seal_lock_no').value   = h.seal_lock_no;
-                if (h.total_invoice_amount) document.getElementById('fi_total_amount').value = h.total_invoice_amount;
+            if (h.invoice_number) document.getElementById('fi_invoice_number').value = h.invoice_number;
+            if (h.invoice_date)   document.getElementById('fi_invoice_date').value   = h.invoice_date;
+            if (h.truck_number)   document.getElementById('fi_truck_number').value   = h.truck_number;
+            if (h.delivery_doc_no)document.getElementById('fi_delivery_doc_no').value= h.delivery_doc_no;
+            if (h.seal_lock_no)   document.getElementById('fi_seal_lock_no').value   = h.seal_lock_no;
+            if (h.total_invoice_amount) document.getElementById('fi_total_amount').value = h.total_invoice_amount;
 
-                if (supplierId) {
-                    const sel = document.getElementById('fi_supplier_id');
-                    for (let i = 0; i < sel.options.length; i++) {
-                        if (sel.options[i].value == supplierId) { sel.selectedIndex = i; break; }
-                    }
+            if (supplierId) {
+                const sel = document.getElementById('fi_supplier_id');
+                for (let i = 0; i < sel.options.length; i++) {
+                    if (sel.options[i].value == supplierId) { sel.selectedIndex = i; break; }
                 }
             }
 
@@ -314,4 +322,17 @@ block content
                     charges:           line.charges || []
                 });
             });
+        }
+
+        async function fuelInvoiceDelete() {
+            if (!FI_INVOICE_ID) return;
+            if (!confirm('Delete this invoice? This cannot be undone.')) return;
+            try {
+                const resp = await fetch('/purchases/fuel-invoice/' + FI_INVOICE_ID + '/delete', { method: 'POST' });
+                const json = await resp.json();
+                if (!json.success) { alert(json.error || 'Delete failed.'); return; }
+                window.location.href = '/lubes-invoice-home';
+            } catch (e) {
+                alert('Error: ' + e.message);
+            }
         }

--- a/views/location-master.pug
+++ b/views/location-master.pug
@@ -54,6 +54,7 @@ block content
                             th(scope="col") Company
                             th(scope="col") Phone
                             th(scope="col") GST
+                            th(scope="col") Dealer Code
                             th(scope="col") Start Date
                             th(scope="col") Status
                             th(scope="col") Actions
@@ -88,14 +89,22 @@ block content
                                     )
                                 td(scope="row")
                                     input.form-control.form-control-sm(
-                                        type="text", 
-                                        id=`location-gst-${index}`, 
-                                        value=location.gst_number || '', 
+                                        type="text",
+                                        id=`location-gst-${index}`,
+                                        value=location.gst_number || '',
                                         readonly
                                     )
                                 td(scope="row")
                                     input.form-control.form-control-sm(
-                                        type="date", 
+                                        type="text",
+                                        id=`location-dealer-code-${index}`,
+                                        value=location.oil_co_dealer_code || '',
+                                        readonly,
+                                        placeholder="SAP No / CC No"
+                                    )
+                                td(scope="row")
+                                    input.form-control.form-control-sm(
+                                        type="date",
                                         id=`location-start-${index}`, 
                                         value=new Date(location.start_date).toISOString().split('T')[0], 
                                         readonly
@@ -195,6 +204,17 @@ block content
                                             )
                                     .col-12
                                         .location-detail
+                                            small.text-muted Dealer Code (SAP No / CC No)
+                                            input.mobile-input.fw-bold(
+                                                type="text",
+                                                id=`mobile-dealer-code-${index}`,
+                                                value=location.oil_co_dealer_code || '',
+                                                readonly,
+                                                placeholder="SAP No / CC No",
+                                                style="border: none; background: transparent; padding: 0; font-weight: bold;"
+                                            )
+                                    .col-12
+                                        .location-detail
                                             small.text-muted Address
                                             textarea.mobile-input.fw-bold(
                                                 id=`mobile-address-${index}`,
@@ -264,6 +284,10 @@ block content
                             .col-md-6.mb-3
                                 label.form-label GST Number
                                 input.form-control(type="text", name="gst_number", maxlength="50")
+                            .col-md-6.mb-3
+                                label.form-label Dealer Code
+                                    small.text-muted.ml-1 (SAP No for IOCL / CC No for BPCL)
+                                input.form-control(type="text", name="oil_co_dealer_code", maxlength="50", placeholder="e.g. 1016730 or 111090")
                             .col-md-6.mb-3
                                 label.form-label Start Date *
                                 input.form-control(
@@ -462,6 +486,7 @@ block content
                 company_name: document.getElementById(`location-company-${index}`).value,
                 phone: document.getElementById(`location-phone-${index}`).value,
                 gst_number: document.getElementById(`location-gst-${index}`).value,
+                oil_co_dealer_code: document.getElementById(`location-dealer-code-${index}`).value,
                 start_date: document.getElementById(`location-start-${index}`).value
             };
             
@@ -494,6 +519,7 @@ block content
                 company_name: document.getElementById(`mobile-company-${index}`).value,
                 phone: document.getElementById(`mobile-phone-${index}`).value,
                 gst_number: document.getElementById(`mobile-gst-${index}`).value,
+                oil_co_dealer_code: document.getElementById(`mobile-dealer-code-${index}`).value,
                 address: document.getElementById(`mobile-address-${index}`).value,
                 start_date: new Date().toISOString().split('T')[0]
             };

--- a/views/lubes-invoice-home.pug
+++ b/views/lubes-invoice-home.pug
@@ -237,8 +237,10 @@ block content
                                         = val.closing_status
                             td
                                 if val.type === 'FUEL'
-                                    a.btn.btn-sm.btn-info(href='/purchases/fuel-invoice/' + val.fuel_id)
+                                    a.btn.btn-sm.btn-info.mr-1(href='/purchases/fuel-invoice/' + val.fuel_id)
                                         span.oi.oi-envelope-open
+                                    a.btn.btn-sm.btn-danger(href='/purchases/fuel-invoice/' + val.fuel_id + '/pdf' target='_blank' title='View PDF')
+                                        span.oi.oi-document
                                 else if val.closing_status === 'DRAFT'
                                     a.btn.btn-sm.btn-info.mr-2(href='/lubes-invoice?id=' + val.lubes_hdr_id)
                                         span.oi.oi-pencil


### PR DESCRIPTION
## Summary
- BPCL CNG invoice parser (auto-detected from PDF text; handles kg unit, /KG rate)
- Gate checks: reject wrong oil company invoice; validate dealer code (oil_co_dealer_code) against PDF
- Fix: charges not pre-filling in UI after PDF parse (affected all suppliers)
- Fix: FUEL_INVOICE_EDIT_DISABLED config not applied on new invoice screen
- Fix: header fields not populating when edit-disabled mode is on
- Invoice detail UX: hide upload card, show "Upload Another Invoice" + "View PDF" buttons
- Delete Invoice with confirmation (hard delete — no accounting entries yet)
- PDF viewer endpoint opens stored invoice PDF in browser new tab (list + detail pages)
- oil_co_dealer_code column added to m_location — migration + location master UI (SAP No / CC No)

## Test plan
- [ ] Upload BPCL CNG invoice PDF — verify header, qty (kg), rate, VAT charge all populate
- [ ] Upload IOCL invoice at BPCL location — verify rejection error
- [ ] Set oil_co_dealer_code for SFS (111090) and re-upload — verify dealer code check passes/fails correctly
- [ ] Verify charges prefill for BPCL/IOCL liquid fuel invoices
- [ ] New fuel invoice screen: confirm fields are read-only when FUEL_INVOICE_EDIT_DISABLED=Y
- [ ] Saved invoice: confirm Upload card is replaced by Upload Another + View PDF buttons
- [ ] View PDF opens invoice PDF in new browser tab
- [ ] Delete invoice — confirm prompt, confirm redirect to list
- [ ] Location master: verify Dealer Code column visible and editable

🤖 Generated with [Claude Code](https://claude.com/claude-code)