### PR TITLE
Stock summary: fuel invoice source + current-month default + date range dropdown

### DIFF
--- a/controllers/stock-reports-controller.js
+++ b/controllers/stock-reports-controller.js
@@ -39,11 +39,17 @@ getStockSummaryReport: async (req, res, next) => {
 
         let fromDate = req.body.fromDate || req.query.fromDate;
         let toDate   = req.body.toDate   || req.query.toDate;
+        const selectedRange = req.body.selectedRange || req.query.selectedRange || 'this_month';
 
         if (fromDate instanceof Date) fromDate = moment(fromDate).format('YYYY-MM-DD');
         else if (fromDate) fromDate = moment(fromDate).format('YYYY-MM-DD');
         if (toDate instanceof Date)   toDate   = moment(toDate).format('YYYY-MM-DD');
         else if (toDate)              toDate   = moment(toDate).format('YYYY-MM-DD');
+
+        if (!fromDate || !toDate) {
+            fromDate = moment().startOf('month').format('YYYY-MM-DD');
+            toDate   = moment().format('YYYY-MM-DD');
+        }
 
         let stockSummary = [];
 
@@ -65,7 +71,8 @@ getStockSummaryReport: async (req, res, next) => {
             formattedFromDate,
             formattedToDate,
             currentDate,
-            showValues
+            showValues,
+            selectedRange
         };
 
         if (caller === 'notpdf') {

--- a/db/migrations/fuel-stock-summary.sql
+++ b/db/migrations/fuel-stock-summary.sql
@@ -74,16 +74,29 @@ BEGIN
           AND DATE(hdr.invoice_date) >= l_stock_start_date
           AND DATE(hdr.invoice_date) <= p_closing_bal_date;
     ELSE
-        -- Tank stock receipts (fuel products only), qty stored in KL → convert to litres
-        SELECT COALESCE(SUM(trd.quantity * 1000), 0)
+        -- Tank stock receipts + fuel invoices (fuel products only), qty in KL → convert to litres
+        SELECT COALESCE(SUM(combined.qty), 0)
         INTO l_total_purchases
-        FROM t_tank_stk_rcpt_dtl trd
-        JOIN t_tank_stk_rcpt tr  ON trd.ttank_id  = tr.ttank_id
-        JOIN m_tank t            ON trd.tank_id   = t.tank_id
-        WHERE t.product_code   = (SELECT product_name FROM m_product WHERE product_id = p_product_id)
-          AND tr.location_code = p_location_code
-          AND DATE(tr.invoice_date) >= l_stock_start_date
-          AND DATE(tr.invoice_date) <= p_closing_bal_date;
+        FROM (
+            SELECT trd.quantity * 1000 AS qty
+            FROM t_tank_stk_rcpt_dtl trd
+            JOIN t_tank_stk_rcpt tr  ON trd.ttank_id  = tr.ttank_id
+            JOIN m_tank t            ON trd.tank_id   = t.tank_id
+            WHERE t.product_code   = (SELECT product_name FROM m_product WHERE product_id = p_product_id)
+              AND tr.location_code = p_location_code
+              AND DATE(tr.invoice_date) >= l_stock_start_date
+              AND DATE(tr.invoice_date) <= p_closing_bal_date
+
+            UNION ALL
+
+            SELECT tid.quantity * 1000 AS qty
+            FROM t_tank_invoice_dtl tid
+            JOIN t_tank_invoice ti ON tid.invoice_id = ti.id
+            WHERE tid.product_id  = p_product_id
+              AND ti.location_id  = p_location_code
+              AND DATE(ti.invoice_date) >= l_stock_start_date
+              AND DATE(ti.invoice_date) <= p_closing_bal_date
+        ) AS combined;
     END IF;
 
     -- ── Sales (lube-specific: cashsales, credits, 2T oil) ──────────────────────
@@ -280,6 +293,18 @@ BEGIN
 
                 UNION ALL
 
+                -- Fuel invoices (fuel only: is_tank_product=1, is_lube_product=0)
+                SELECT tid.quantity * 1000 AS qty
+                FROM t_tank_invoice_dtl tid
+                JOIN t_tank_invoice ti ON tid.invoice_id = ti.id
+                WHERE tid.product_id   = p.product_id
+                  AND ti.location_id   = p_location_code
+                  AND p.is_tank_product = 1
+                  AND p.is_lube_product = 0
+                  AND DATE(ti.invoice_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
                 -- Adjustments IN (all products)
                 SELECT qty
                 FROM t_lubes_stock_adjustment
@@ -316,6 +341,18 @@ BEGIN
                   AND p.is_tank_product = 1
                   AND p.is_lube_product = 0
                   AND DATE(tr.invoice_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- Fuel invoice amounts (fuel only)
+                SELECT tid.total_line_amount AS amt
+                FROM t_tank_invoice_dtl tid
+                JOIN t_tank_invoice ti ON tid.invoice_id = ti.id
+                WHERE tid.product_id   = p.product_id
+                  AND ti.location_id   = p_location_code
+                  AND p.is_tank_product = 1
+                  AND p.is_lube_product = 0
+                  AND DATE(ti.invoice_date) BETWEEN p_from_date AND p_to_date
 
             ) AS purch_amts
         ), 0) AS purchase_value,

--- a/db/migrations/stock-summary-opening-price.sql
+++ b/db/migrations/stock-summary-opening-price.sql
@@ -155,6 +155,18 @@ BEGIN
 
                 UNION ALL
 
+                -- Fuel invoices (fuel only: is_tank_product=1, is_lube_product=0)
+                SELECT tid.quantity * 1000 AS qty
+                FROM t_tank_invoice_dtl tid
+                JOIN t_tank_invoice ti ON tid.invoice_id = ti.id
+                WHERE tid.product_id   = p.product_id
+                  AND ti.location_id   = p_location_code
+                  AND p.is_tank_product = 1
+                  AND p.is_lube_product = 0
+                  AND DATE(ti.invoice_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
                 SELECT qty
                 FROM t_lubes_stock_adjustment
                 WHERE product_id     = p.product_id
@@ -188,6 +200,18 @@ BEGIN
                   AND p.is_tank_product = 1
                   AND p.is_lube_product = 0
                   AND DATE(tr.invoice_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- Fuel invoice amounts (fuel only)
+                SELECT tid.total_line_amount AS amt
+                FROM t_tank_invoice_dtl tid
+                JOIN t_tank_invoice ti ON tid.invoice_id = ti.id
+                WHERE tid.product_id   = p.product_id
+                  AND ti.location_id   = p_location_code
+                  AND p.is_tank_product = 1
+                  AND p.is_lube_product = 0
+                  AND DATE(ti.invoice_date) BETWEEN p_from_date AND p_to_date
 
             ) AS purch_amts
         ), 0) AS purchase_value,

--- a/routes/stock-reports-routes.js
+++ b/routes/stock-reports-routes.js
@@ -7,8 +7,9 @@ const stockReportsController = require('../controllers/stock-reports-controller'
 
 // Stock Summary Report - GET (initial load)
 router.get('/summary', isLoginEnsured, function (req, res, next) {
-    req.body.fromDate = new Date(Date.now());
-    req.body.toDate = new Date(Date.now());
+    const now = new Date();
+    req.body.fromDate = new Date(now.getFullYear(), now.getMonth(), 1);
+    req.body.toDate = now;
     req.body.caller = 'notpdf';
     stockReportsController.getStockSummaryReport(req, res, next);
 });

--- a/views/reports-stock-summary.pug
+++ b/views/reports-stock-summary.pug
@@ -3,22 +3,32 @@ extends layout
 block content
     form#summaryForm(method='POST' action='/reports/stock/summary')
         input(type='hidden' name='showValues' id='showValuesInput' value=showValues ? 'true' : 'false')
+        input(type='hidden' name='selectedRange' id='selectedRangeInput' value=selectedRange || 'this_month')
         table.center
             tr
-                td From Date:
+                td Date Range:
                 td
-                    input#fromDate.form-control(type='date', name='fromDate', value=fromDate, max=currentDate, required)
+                    select#dateRange.form-control(onchange="onDateRangeChange()")
+                        option(value='this_month' selected=(selectedRange==='this_month' || !selectedRange)) This Month
+                        option(value='last_month' selected=(selectedRange==='last_month')) Last Month
+                        option(value='this_financial_year' selected=(selectedRange==='this_financial_year')) This Financial Year
+                        option(value='last_financial_year' selected=(selectedRange==='last_financial_year')) Last Financial Year
+                        option(value='custom' selected=(selectedRange==='custom')) Custom Date
                 td &nbsp;
-                td To Date:
-                td
-                    input#toDate.form-control(type='date', name='toDate', value=toDate, max=currentDate, required)
+                td#fromDateLabel(style=selectedRange==='custom' ? '' : 'display:none') From Date:
+                td(style=selectedRange==='custom' ? '' : 'display:none')
+                    input#fromDate.form-control(type='date', name='fromDate', value=fromDate, max=currentDate)
+                td &nbsp;
+                td#toDateLabel(style=selectedRange==='custom' ? '' : 'display:none') To Date:
+                td(style=selectedRange==='custom' ? '' : 'display:none')
+                    input#toDate.form-control(type='date', name='toDate', value=toDate, max=currentDate)
                 td &nbsp;
                 td
                     .form-check.d-inline-flex.align-items-center.ml-3
                         input#showValuesCheck.form-check-input(
                             type='checkbox'
                             checked=showValues
-                            onchange="document.getElementById('showValuesInput').value = this.checked ? 'true' : 'false';"
+                            onchange="document.getElementById('showValuesInput').value = this.checked ? 'true' : 'false'; document.getElementById('summaryForm').submit();"
                             style="margin-top:0"
                         )
                         label.form-check-label.ml-2(for='showValuesCheck') Show Values
@@ -161,6 +171,38 @@ block content
         .table-success-light { background-color: #f0f9ff !important; }
 
     script.
+        function onDateRangeChange() {
+            var range = document.getElementById('dateRange').value;
+            document.getElementById('selectedRangeInput').value = range;
+            var fromInput = document.getElementById('fromDate');
+            var toInput   = document.getElementById('toDate');
+            var today = new Date();
+            var from, to;
+            if (range === 'this_month') {
+                from = new Date(today.getFullYear(), today.getMonth(), 1);
+                to   = today;
+            } else if (range === 'last_month') {
+                from = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+                to   = new Date(today.getFullYear(), today.getMonth(), 0);
+            } else if (range === 'this_financial_year') {
+                var m = today.getMonth();
+                from = m < 3 ? new Date(today.getFullYear()-1, 3, 1) : new Date(today.getFullYear(), 3, 1);
+                to   = today;
+            } else if (range === 'last_financial_year') {
+                var m = today.getMonth();
+                from = m < 3 ? new Date(today.getFullYear()-2, 3, 1) : new Date(today.getFullYear()-1, 3, 1);
+                to   = m < 3 ? new Date(today.getFullYear()-1, 2, 31) : new Date(today.getFullYear(), 2, 31);
+            } else {
+                ['fromDateLabel','toDateLabel'].forEach(function(id) { document.getElementById(id).style.display = 'table-cell'; document.getElementById(id).nextElementSibling.style.display = 'table-cell'; });
+                return;
+            }
+            function fmt(d) { return new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate())).toISOString().split('T')[0]; }
+            fromInput.value = fmt(from);
+            toInput.value   = fmt(to);
+            ['fromDateLabel','toDateLabel'].forEach(function(id) { document.getElementById(id).style.display = 'none'; document.getElementById(id).nextElementSibling.style.display = 'none'; });
+            document.getElementById('summaryForm').submit();
+        }
+
         function exportExcel() {
             const form = document.createElement('form');
             form.method = 'POST';


### PR DESCRIPTION
## Summary
- Adds `t_tank_invoice_dtl` as a purchase IN source for fuel products in the stock summary stored procedures (both `get_all_products_stock_summary` and `get_closing_product_stock_balance`)
- Stock summary report now defaults to current month on page load instead of current date
- Added This Month / Last Month / This Financial Year / Last Financial Year / Custom dropdown — auto-submits on selection

## Test plan
- [ ] Open Stock Summary report — should load with This Month data automatically
- [ ] Change dropdown to Last Month — should reload with last month data
- [ ] Change dropdown to Custom — from/to date inputs should appear
- [ ] Toggle Show Values checkbox — should reload report
- [ ] Verify fuel product purchase quantities include both tank receipts and fuel invoices