### PR TITLE
Tank dip search: date range presets, view details modal, config-gated delete

### DIFF
--- a/app.js
+++ b/app.js
@@ -1376,6 +1376,10 @@ app.get('/tank-dip/validate', isLoginEnsured, function(req, res) {
     tankDipController.validateDip(req, res);
 });
 
+app.get('/tank-dip/details', isLoginEnsured, function(req, res, next) {
+    tankDipController.getDipDetails(req, res, next);
+});
+
 // Tank Dip Search Page
 app.get('/tank-dip/search', [isLoginEnsured], tankDipController.searchDipPage);
 

--- a/controllers/tank-dip-controller.js
+++ b/controllers/tank-dip-controller.js
@@ -7,28 +7,50 @@ const db = require("../db/db-connection");
 const TankDipDao = require("../dao/tank-dip-dao");
 const LocationConfigDao = require("../dao/location-config-dao"); 
 
+const ALLOW_PAST_DATE_TANK_DIP = 'ALLOW_PAST_DATE_TANK_DIP';
+const ALLOW_TANK_DIP_DELETE = 'ALLOW_TANK_DIP_DELETE';
+
+function getDateRangeFromSelection(selectedRange) {
+    const today = new Date();
+    let from;
+    let to;
+    if (selectedRange === 'this_month') {
+        from = new Date(today.getFullYear(), today.getMonth(), 1);
+        to = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+    } else if (selectedRange === 'last_month') {
+        from = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+        to = new Date(today.getFullYear(), today.getMonth(), 0);
+    } else if (selectedRange === 'financial_year') {
+        const m = today.getMonth();
+        from = m < 3 ? new Date(today.getFullYear() - 1, 3, 1) : new Date(today.getFullYear(), 3, 1);
+        to = today;
+    } else {
+        return { fromDate: null, toDate: null };
+    }
+    return {
+        fromDate: dateFormat(from, "yyyy-mm-dd"),
+        toDate: dateFormat(to, "yyyy-mm-dd")
+    };
+}
+
+function formatDipRows(dips) {
+    return (dips || []).map(dip => ({
+        ...dip,
+        dip_date_display: dip.dip_date ? dateFormat(new Date(dip.dip_date), "dd-mm-yyyy") : ""
+    }));
+}
+
 exports.getTankDipEntry = async function (req, res, next) {
     try {
         const locationCode = req.user.location_code;
         const today = dateFormat(new Date(), "yyyy-mm-dd");
 
-         // Get configuration for allowing past dates
-        const allowPastDateSetting = await LocationConfigDao.getSetting(
-            locationCode, 
-            'ALLOW_PAST_DATE_TANK_DIP'
-        );
-
-         // ADD THESE DEBUG LINES
-        console.log('=== TANK DIP DEBUG ===');
-        console.log('Location Code:', locationCode);
-        console.log('Setting from DB:', allowPastDateSetting);
-        console.log('Setting type:', typeof allowPastDateSetting);
-        
+        const [allowPastDateSetting, allowTankDipDeleteSetting] = await Promise.all([
+            LocationConfigDao.getSetting(locationCode, ALLOW_PAST_DATE_TANK_DIP),
+            LocationConfigDao.getSetting(locationCode, ALLOW_TANK_DIP_DELETE)
+        ]);
         const allowPastDate = allowPastDateSetting === 'Y';
-        
-        console.log('allowPastDate:', allowPastDate);
-        console.log('======================');
-        // END DEBUG
+        const allowTankDipDelete = req.user.isAdmin && allowTankDipDeleteSetting === 'Y';
         
 
         
@@ -101,6 +123,7 @@ exports.getTankDipEntry = async function (req, res, next) {
             lastReadings: lastReadings,
             searchDate: today,
             allowPastDate: allowPastDate,
+            allowTankDipDelete: allowTankDipDelete,
             currentDate: today  
         });
     } catch (error) {
@@ -204,6 +227,11 @@ exports.deleteTankDip = async function (req, res, next) {
     try {
         const tdip_id = req.body.tdip_id;
         const locationCode = req.user.location_code;
+        const allowTankDipDeleteSetting = await LocationConfigDao.getSetting(locationCode, ALLOW_TANK_DIP_DELETE);
+
+        if (allowTankDipDeleteSetting !== 'Y') {
+            return res.status(403).json({ success: false, error: 'Tank dip delete is disabled for this location' });
+        }
 
         // // Check if dip exists and belongs to user's location
         // const dip = await TankDipDao.findById(tdip_id);
@@ -298,21 +326,20 @@ exports.validateDip = async function (req, res) {
 
 exports.searchDipPage = async (req, res, next) => {
     try {
-
-        const today = new Date();
-        const firstDay = new Date(today.getFullYear(), today.getMonth(), 1);
-        const lastDay = new Date(today.getFullYear(), today.getMonth() + 1, 0);
-
-        const dateFormat = require("dateformat");
-        const fromDate = dateFormat(firstDay, "yyyy-mm-dd");
-        const toDate = dateFormat(lastDay, "yyyy-mm-dd");    
-
+        const locationCode = req.user.location_code;
+        const selectedRange = 'this_month';
+        const { fromDate, toDate } = getDateRangeFromSelection(selectedRange);
+        const dips = await TankDipDao.searchDipByDateRange(locationCode, fromDate, toDate);
+        const allowTankDipDeleteSetting = await LocationConfigDao.getSetting(locationCode, ALLOW_TANK_DIP_DELETE);
+        const allowTankDipDelete = req.user.isAdmin && allowTankDipDeleteSetting === 'Y';
 
         res.render("tank-dip-search", {
             title: "Tank Dip Search",
             fromDate: fromDate,
             toDate: toDate,
-            dips: [],
+            selectedRange,
+            dips: formatDipRows(dips),
+            allowTankDipDelete,
             user: req.user, 
             messages: req.flash() // optional but consistent with layout expectations
         });
@@ -323,25 +350,79 @@ exports.searchDipPage = async (req, res, next) => {
 
 exports.searchDipResults = async (req, res, next) => {
     try {
-        const fromDate = req.body.fromDate;
-        const toDate = req.body.toDate;
+        const locationCode = req.user.location_code;
+        const selectedRange = req.body.selectedRange || 'this_month';
+        let fromDate = req.body.fromDate;
+        let toDate = req.body.toDate;
+
+        if (selectedRange !== 'custom') {
+            const range = getDateRangeFromSelection(selectedRange);
+            fromDate = range.fromDate;
+            toDate = range.toDate;
+        }
+
+        if (!fromDate || !toDate) {
+            const fallback = getDateRangeFromSelection('this_month');
+            fromDate = fallback.fromDate;
+            toDate = fallback.toDate;
+        }
 
         const dips = await TankDipDao.searchDipByDateRange(
-            req.user.location_code,
+            locationCode,
             fromDate,
             toDate
         );
+        const allowTankDipDeleteSetting = await LocationConfigDao.getSetting(locationCode, ALLOW_TANK_DIP_DELETE);
+        const allowTankDipDelete = req.user.isAdmin && allowTankDipDeleteSetting === 'Y';
 
         res.render("tank-dip-search", {
             title: "Tank Dip Search",
             fromDate,
             toDate,
-            dips,
+            selectedRange,
+            dips: formatDipRows(dips),
+            allowTankDipDelete,
             user: req.user, 
             messages: req.flash()
         });
     } catch (err) {
         next(err);
+    }
+};
+
+exports.getDipDetails = async (req, res) => {
+    try {
+        const tdip_id = parseInt(req.query.tdip_id, 10);
+        if (!tdip_id) {
+            return res.status(400).json({ success: false, error: 'Invalid dip id' });
+        }
+
+        const rows = await TankDipDao.getDipDetailsById(req.user.location_code, tdip_id);
+        if (!rows || rows.length === 0) {
+            return res.status(404).json({ success: false, error: 'Dip not found' });
+        }
+
+        const base = rows[0];
+        const detail = {
+            tdip_id: base.tdip_id,
+            tank_code: base.tank_code,
+            product_code: base.product_code,
+            dip_date: base.dip_date ? dateFormat(new Date(base.dip_date), "dd-mm-yyyy") : "",
+            dip_time: base.dip_time,
+            dip_reading: base.dip_reading,
+            readings: rows
+                .filter(r => r.pump_id)
+                .map(r => ({
+                    pump_code: r.pump_code,
+                    pump_make: r.pump_make,
+                    reading: r.reading
+                }))
+        };
+
+        return res.json({ success: true, detail });
+    } catch (error) {
+        console.error('Error fetching dip details:', error);
+        return res.status(500).json({ success: false, error: 'Failed to fetch dip details' });
     }
 };
 

--- a/dao/tank-dip-dao.js
+++ b/dao/tank-dip-dao.js
@@ -255,6 +255,31 @@ function TankDipDao() {
             throw error;
         }
     };
+
+    this.getDipDetailsById = async function(location_code, tdip_id) {
+        try {
+            const results = await db.sequelize.query(
+                `SELECT d.tdip_id, d.tank_id, d.dip_date, d.dip_time, d.dip_reading,
+                        t.tank_code, t.product_code,
+                        tr.pump_id, tr.reading, p.pump_code, p.pump_make
+                 FROM t_tank_dip d
+                 JOIN m_tank t ON d.tank_id = t.tank_id
+                 LEFT JOIN t_tank_reading tr ON d.tdip_id = tr.tdip_id
+                 LEFT JOIN m_pump p ON tr.pump_id = p.pump_id
+                 WHERE d.location_code = :location_code
+                   AND d.tdip_id = :tdip_id
+                 ORDER BY p.pump_code`,
+                {
+                    replacements: { location_code, tdip_id },
+                    type: db.Sequelize.QueryTypes.SELECT
+                }
+            );
+            return results;
+        } catch (error) {
+            console.error("Error in getDipDetailsById:", error);
+            throw error;
+        }
+    };
     
 }
 

--- a/views/tank-dip-search.pug
+++ b/views/tank-dip-search.pug
@@ -1,9 +1,17 @@
 extends layout
 
 block content
-    form(method='POST', action='/tank-dip/search')
+    form#dipSearchForm(method='POST', action='/tank-dip/search')
         table.center
             tr
+                td Date Range:
+                td
+                    select#dateRange.form-control(name='selectedRange', onchange='onDateRangeChange()')
+                        option(value='this_month' selected=(selectedRange==='this_month' || !selectedRange)) This Month
+                        option(value='last_month' selected=(selectedRange==='last_month')) Last Month
+                        option(value='financial_year' selected=(selectedRange==='financial_year')) Financial Year
+                        option(value='custom' selected=(selectedRange==='custom')) Custom Date
+                td &nbsp;
                 td From Date:
                 td
                     input#dip_fromDate.form-control(
@@ -35,15 +43,129 @@ block content
                 th Tank Code
                 th Product
                 th Dip Reading
+                th Actions
             tbody
                 if dips.length
                     each dip, index in dips
                         tr
                             td #{index + 1}
-                            td #{dip.dip_date}
+                            td #{dip.dip_date_display || dip.dip_date}
                             td #{dip.dip_time}
                             td #{dip.tank_code}
                             td #{dip.product_code}
-                            td #{dip.dip_reading}                              
+                            td #{dip.dip_reading}
+                            td
+                                button.btn.btn-info.btn-sm.view-dip(type='button', data-dip-id=dip.tdip_id) View
+                                if allowTankDipDelete
+                                    | &nbsp;
+                                    button.btn.btn-danger.btn-sm.delete-dip(type='button', data-dip-id=dip.tdip_id) Delete
     div(align="center")
         button.btn.btn-primary(type="button", onclick="window.location.href='/tank-dip'") Add New
+
+    #dipDetailsModal.modal.fade(tabindex='-1', role='dialog', aria-labelledby='dipDetailsModalLabel', aria-hidden='true')
+        .modal-dialog.modal-lg(role='document')
+            .modal-content
+                .modal-header
+                    h5#dipDetailsModalLabel.modal-title Dip Details
+                    button.close(type='button', data-dismiss='modal', aria-label='Close')
+                        span(aria-hidden='true') ×
+                .modal-body
+                    .row.mb-2
+                        .col-md-4
+                            strong Tank:
+                            span#detailTank.ml-2
+                        .col-md-4
+                            strong Product:
+                            span#detailProduct.ml-2
+                        .col-md-4
+                            strong Dip:
+                            span#detailDip.ml-2
+                    .row.mb-3
+                        .col-md-6
+                            strong Date:
+                            span#detailDate.ml-2
+                        .col-md-6
+                            strong Time:
+                            span#detailTime.ml-2
+                    h6 Pump Readings
+                    .table-responsive
+                        table.table.table-bordered.table-sm
+                            thead.thead-light
+                                tr
+                                    th Pump
+                                    th Make
+                                    th Reading
+                            tbody#detailReadingsBody
+
+    script.
+        function onDateRangeChange() {
+            var range = document.getElementById('dateRange').value;
+            var fromInput = document.getElementById('dip_fromDate');
+            var toInput = document.getElementById('dip_toDate');
+            var today = new Date();
+            var from, to;
+
+            if (range === 'this_month') {
+                from = new Date(today.getFullYear(), today.getMonth(), 1);
+                to = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+            } else if (range === 'last_month') {
+                from = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+                to = new Date(today.getFullYear(), today.getMonth(), 0);
+            } else if (range === 'financial_year') {
+                var m = today.getMonth();
+                from = m < 3 ? new Date(today.getFullYear() - 1, 3, 1) : new Date(today.getFullYear(), 3, 1);
+                to = today;
+            } else {
+                return;
+            }
+
+            function fmt(d) {
+                return new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate())).toISOString().split('T')[0];
+            }
+            fromInput.value = fmt(from);
+            toInput.value = fmt(to);
+            document.getElementById('dipSearchForm').submit();
+        }
+
+        $(document).on('click', '.view-dip', async function() {
+            const dipId = $(this).data('dip-id');
+            try {
+                const res = await $.get('/tank-dip/details', { tdip_id: dipId });
+                if (!res.success) return alert(res.error || 'Failed to load dip details');
+                const d = res.detail;
+                $('#detailTank').text(d.tank_code || '-');
+                $('#detailProduct').text(d.product_code || '-');
+                $('#detailDip').text(d.dip_reading || '-');
+                $('#detailDate').text(d.dip_date || '-');
+                $('#detailTime').text(d.dip_time || '-');
+                const body = $('#detailReadingsBody');
+                body.empty();
+                if (d.readings && d.readings.length) {
+                    d.readings.forEach(function(r) {
+                        body.append('<tr><td>' + (r.pump_code || '-') + '</td><td>' + (r.pump_make || '-') + '</td><td>' + (r.reading || '-') + '</td></tr>');
+                    });
+                } else {
+                    body.append('<tr><td colspan="3" class="text-center">No pump readings available</td></tr>');
+                }
+                $('#dipDetailsModal').modal('show');
+            } catch (e) {
+                alert('Error loading dip details');
+            }
+        });
+
+        $(document).on('click', '.delete-dip', async function() {
+            if (!confirm('Are you sure you want to delete this dip reading?')) return;
+            const dipId = $(this).data('dip-id');
+            try {
+                const response = await $.ajax({
+                    url: '/tank-dip',
+                    method: 'DELETE',
+                    data: JSON.stringify({ tdip_id: dipId }),
+                    contentType: 'application/json'
+                });
+                if (response.success) location.reload();
+                else alert(response.error || 'Failed to delete dip reading');
+            } catch (error) {
+                alert('Error deleting dip reading');
+            }
+        });

--- a/views/tank-dip.pug
+++ b/views/tank-dip.pug
@@ -103,7 +103,7 @@ block content
                                                     th Time
                                                     th Dip (cm)
                                                     th Pumps
-                                                    if user.isAdmin
+                                                    if allowTankDipDelete
                                                         th Actions
                                             tbody
                                                 each dip in existingDips
@@ -118,7 +118,7 @@ block content
                                                                     div #{reading.pump_code}: #{reading.reading}
                                                             else
                                                                 p No readings available.        
-                                                        if user.isAdmin
+                                                        if allowTankDipDelete
                                                             td
                                                                 button.btn.btn-danger.btn-sm.delete-dip(
                                                                     type="button"


### PR DESCRIPTION
## Summary
- Added date range presets (This Month / Last Month / Financial Year / Custom) to tank dip search
- Added View button with details modal showing dip info and associated pump readings
- Delete button now gated by `ALLOW_TANK_DIP_DELETE` location config + isAdmin (instead of isAdmin alone)
- New API endpoint `GET /tank-dip/details?tdip_id=` for fetching dip details with pump readings
- Removed leftover debug console.log statements from tank dip controller

## Test plan
- [ ] Tank dip search loads with This Month pre-selected and results shown
- [ ] Changing date range preset auto-submits and reloads results
- [ ] View button opens modal with correct tank, product, dip reading, date, and pump readings
- [ ] Delete button visible only when `ALLOW_TANK_DIP_DELETE=Y` and user is admin
- [ ] Delete works from both search page and dip entry page

🤖 Generated with [Claude Code](https://claude.com/claude-code)