### PR TITLE
Tank variance: date range presets, testing deduction, group by tank

### DIFF
--- a/controllers/stock-reports-controller.js
+++ b/controllers/stock-reports-controller.js
@@ -352,11 +352,38 @@ getTankVarianceReport: async (req, res, next) => {
 
         let fromDate = req.body.fromDate || req.query.fromDate;
         let toDate = req.body.toDate || req.query.toDate;
+        const selectedRange = req.body.selectedRange || req.query.selectedRange || 'this_month';
         const selectedTank = req.body.tank_code || req.query.tank_code || '';
         const selectedProduct = req.body.product_code || req.query.product_code || '';
 
+        if (selectedRange !== 'custom') {
+            const today = moment();
+            if (selectedRange === 'this_month') {
+                fromDate = today.clone().startOf('month').format('YYYY-MM-DD');
+                toDate = today.clone().endOf('month').format('YYYY-MM-DD');
+            } else if (selectedRange === 'last_month') {
+                fromDate = today.clone().subtract(1, 'month').startOf('month').format('YYYY-MM-DD');
+                toDate = today.clone().subtract(1, 'month').endOf('month').format('YYYY-MM-DD');
+            } else if (selectedRange === 'this_financial_year') {
+                const fyStart = today.month() < 3
+                    ? moment({ year: today.year() - 1, month: 3, day: 1 })
+                    : moment({ year: today.year(), month: 3, day: 1 });
+                fromDate = fyStart.format('YYYY-MM-DD');
+                toDate = today.format('YYYY-MM-DD');
+            } else if (selectedRange === 'last_financial_year') {
+                const fyStartYear = today.month() < 3 ? today.year() - 2 : today.year() - 1;
+                fromDate = moment({ year: fyStartYear, month: 3, day: 1 }).format('YYYY-MM-DD');
+                toDate = moment({ year: fyStartYear + 1, month: 2, day: 31 }).format('YYYY-MM-DD');
+            }
+        }
+
         if (fromDate) fromDate = moment(fromDate).format('YYYY-MM-DD');
         if (toDate) toDate = moment(toDate).format('YYYY-MM-DD');
+
+        if (!fromDate || !toDate) {
+            fromDate = moment().startOf('month').format('YYYY-MM-DD');
+            toDate = moment().endOf('month').format('YYYY-MM-DD');
+        }
 
         let varianceRows = [];
         let tankOptions = [];
@@ -392,6 +419,7 @@ getTankVarianceReport: async (req, res, next) => {
             varianceRows,
             tankOptions,
             productOptions,
+            selectedRange,
             selectedTank,
             selectedProduct,
             caller
@@ -489,6 +517,16 @@ function buildTankVarianceRows(raw, fromDate, toDate) {
         });
     });
 
+    const testingByTank = {};
+    (raw.testings || []).forEach(t => {
+        const ts = new Date((t.testing_ts || '').replace(' ', 'T'));
+        if (!testingByTank[t.tank_id]) testingByTank[t.tank_id] = [];
+        testingByTank[t.tank_id].push({
+            ts,
+            qtyLiters: parseFloat(t.testing_liters || 0)
+        });
+    });
+
     const eventsByTank = {};
     [...raw.previousDips, ...raw.currentDips].forEach(d => {
         if (!eventsByTank[d.tank_id]) eventsByTank[d.tank_id] = [];
@@ -508,6 +546,7 @@ function buildTankVarianceRows(raw, fromDate, toDate) {
         const tankId = parseInt(tankIdStr, 10);
         const events = eventsByTank[tankId].sort((a, b) => a.ts - b.ts);
         const receipts = (receiptsByTank[tankId] || []).sort((a, b) => a.ts - b.ts);
+        const testings = (testingByTank[tankId] || []).sort((a, b) => a.ts - b.ts);
         const tank = tankById[tankId];
         const lookup = volumeMapByTank[tankId] || {};
 
@@ -524,18 +563,23 @@ function buildTankVarianceRows(raw, fromDate, toDate) {
                 .filter(r => r.ts > prev.ts && r.ts <= curr.ts)
                 .reduce((s, r) => s + r.qtyLiters, 0);
 
+            const testingLiters = testings
+                .filter(t => t.ts > prev.ts && t.ts <= curr.ts)
+                .reduce((s, t) => s + t.qtyLiters, 0);
+
             const pumpIds = Object.keys(curr.readings);
-            let sales = 0;
+            let grossSales = 0;
             pumpIds.forEach(pid => {
                 if (prev.readings[pid] !== undefined) {
                     const delta = curr.readings[pid] - prev.readings[pid];
-                    if (delta > 0) sales += delta;
+                    if (delta > 0) grossSales += delta;
                 }
             });
 
-            const expected = opening + receiptLiters - sales;
+            const netSales = grossSales - testingLiters;
+            const expected = opening + receiptLiters - netSales;
             const variance = actual - expected;
-            const variancePct = sales > 0 ? (variance / sales) * 100 : null;
+            const variancePct = netSales > 0 ? (variance / netSales) * 100 : null;
 
             rows.push({
                 date: curr.dip_date,
@@ -544,7 +588,9 @@ function buildTankVarianceRows(raw, fromDate, toDate) {
                 product_code: tank?.product_code || '-',
                 opening_liters: opening,
                 receipts_liters: receiptLiters,
-                sales_liters: sales,
+                gross_sales_liters: grossSales,
+                testing_liters: testingLiters,
+                sales_liters: netSales,
                 expected_liters: expected,
                 actual_liters: actual,
                 variance_liters: variance,

--- a/dao/stock-reports-dao.js
+++ b/dao/stock-reports-dao.js
@@ -342,13 +342,42 @@ getTankVarianceInputs: async (locationCode, fromDate, toDate) => {
             }
         );
 
+        const testings = await db.sequelize.query(
+            `SELECT mpt.tank_id,
+                    CONCAT(
+                        DATE_FORMAT(tc.closing_date, '%Y-%m-%d'),
+                        ' ',
+                        TIME_FORMAT(COALESCE(tc.close_reading_time, '00:00:00'), '%H:%i:%s')
+                    ) AS testing_ts,
+                    SUM(COALESCE(tr.testing, 0)) AS testing_liters
+             FROM t_reading tr
+             INNER JOIN t_closing tc ON tc.closing_id = tr.closing_id
+             INNER JOIN m_pump_tank mpt ON mpt.pump_id = tr.pump_id
+                AND mpt.location_code = tc.location_code
+                AND DATE(tc.closing_date) BETWEEN mpt.effective_start_date AND mpt.effective_end_date
+             WHERE tc.location_code = :locationCode
+               AND DATE(tc.closing_date) BETWEEN :fromDate AND :toDate
+               AND COALESCE(tr.testing, 0) > 0
+             GROUP BY mpt.tank_id,
+                      CONCAT(
+                        DATE_FORMAT(tc.closing_date, '%Y-%m-%d'),
+                        ' ',
+                        TIME_FORMAT(COALESCE(tc.close_reading_time, '00:00:00'), '%H:%i:%s')
+                      )`,
+            {
+                replacements: { locationCode, fromDate, toDate },
+                type: Sequelize.QueryTypes.SELECT
+            }
+        );
+
         return {
             tanks,
             dipChartLines,
             currentDips,
             previousDips,
             pumpReadings,
-            receipts
+            receipts,
+            testings
         };
     } catch (error) {
         console.error('Error fetching tank variance inputs:', error);

--- a/views/reports-tank-variance.pug
+++ b/views/reports-tank-variance.pug
@@ -4,12 +4,21 @@ block content
     form(method='POST' action='/reports/stock/tank-variance')
         table.center
             tr
-                td From Date:
+                td Date Range:
                 td
+                    select#dateRange.form-control(name='selectedRange', onchange='onDateRangeChange()')
+                        option(value='this_month' selected=(selectedRange==='this_month' || !selectedRange)) This Month
+                        option(value='last_month' selected=(selectedRange==='last_month')) Last Month
+                        option(value='this_financial_year' selected=(selectedRange==='this_financial_year')) This Financial Year
+                        option(value='last_financial_year' selected=(selectedRange==='last_financial_year')) Last Financial Year
+                        option(value='custom' selected=(selectedRange==='custom')) Custom Date
+                td &nbsp;
+                td#fromDateLabel(style=selectedRange==='custom' ? '' : 'display:none') From Date:
+                td(style=selectedRange==='custom' ? '' : 'display:none')
                     input#fromDate.form-control(type='date', name='fromDate', value=fromDate, max=currentDate, format='dd/mm/yyyy', required)
                 td &nbsp;
-                td To Date:
-                td
+                td#toDateLabel(style=selectedRange==='custom' ? '' : 'display:none') To Date:
+                td(style=selectedRange==='custom' ? '' : 'display:none')
                     input#toDate.form-control(type='date', name='toDate', value=toDate, max=currentDate, format='dd/mm/yyyy', required)
                 td &nbsp;
                 td Tank:
@@ -36,68 +45,128 @@ block content
             h6.text-center.text-muted= `${formattedFromDate} to ${formattedToDate}`
 
         if varianceRows && varianceRows.length > 0
-            .table-responsive
-                table.table.table-bordered.table-hover.table-sm
-                    thead.thead-light
-                        tr
-                            th Date
-                            th Time
-                            th Tank
-                            th Product
-                            th.text-right Opening (L)
-                            th.text-right Receipts (L)
-                            th.text-right Sales (L)
-                            th.text-right Expected (L)
-                            th.text-right Actual (L)
-                            th.text-right Variance (L)
-                            th.text-right Variance %
-                    tbody
-                        - var totalOpening = 0
-                        - var totalReceipts = 0
-                        - var totalSales = 0
-                        - var totalExpected = 0
-                        - var totalActual = 0
-                        - var totalVariance = 0
-                        each row in varianceRows
-                            - totalOpening += row.opening_liters || 0
-                            - totalReceipts += row.receipts_liters || 0
-                            - totalSales += row.sales_liters || 0
-                            - totalExpected += row.expected_liters || 0
-                            - totalActual += row.actual_liters || 0
-                            - totalVariance += row.variance_liters || 0
-                            tr(class=(Math.abs(row.variance_liters) >= 100 ? 'table-warning' : ''))
-                                td= row.date_display
-                                td= row.time
-                                td= row.tank_code
-                                td= row.product_code
-                                td.text-right= Number(row.opening_liters || 0).toFixed(2)
-                                td.text-right.text-success= Number(row.receipts_liters || 0).toFixed(2)
-                                td.text-right.text-danger= Number(row.sales_liters || 0).toFixed(2)
-                                td.text-right= Number(row.expected_liters || 0).toFixed(2)
-                                td.text-right= Number(row.actual_liters || 0).toFixed(2)
-                                td.text-right(class=(row.variance_liters < 0 ? 'text-danger font-weight-bold' : 'text-success font-weight-bold'))
-                                    = Number(row.variance_liters || 0).toFixed(2)
+            - var groupedByTank = {}
+            each row in varianceRows
+                - if (!groupedByTank[row.tank_code]) groupedByTank[row.tank_code] = []
+                - groupedByTank[row.tank_code].push(row)
+            - var tankCodes = Object.keys(groupedByTank).sort()
+
+            each tankCode in tankCodes
+                h6.font-weight-bold.mt-3.mb-2= `Tank: ${tankCode}`
+                .table-responsive
+                    table.table.table-bordered.table-hover.table-sm
+                        thead.thead-light
+                            tr
+                                th Date
+                                th Time
+                                th Tank
+                                th Product
+                                th.text-right Opening (L)
+                                th.text-right Receipts (L)
+                                th.text-right Gross Sales (L)
+                                th.text-right Testing (L)
+                                th.text-right Net Sales (L)
+                                th.text-right Expected (L)
+                                th.text-right Actual (L)
+                                th.text-right Variance (L)
+                                th.text-right Variance %
+                        tbody
+                            - var totalOpening = 0
+                            - var totalReceipts = 0
+                            - var totalGrossSales = 0
+                            - var totalTesting = 0
+                            - var totalSales = 0
+                            - var totalExpected = 0
+                            - var totalActual = 0
+                            - var totalVariance = 0
+                            each row in groupedByTank[tankCode]
+                                - totalOpening += row.opening_liters || 0
+                                - totalReceipts += row.receipts_liters || 0
+                                - totalGrossSales += row.gross_sales_liters || 0
+                                - totalTesting += row.testing_liters || 0
+                                - totalSales += row.sales_liters || 0
+                                - totalExpected += row.expected_liters || 0
+                                - totalActual += row.actual_liters || 0
+                                - totalVariance += row.variance_liters || 0
+                                tr(class=(Math.abs(row.variance_liters) >= 100 ? 'table-warning' : ''))
+                                    td= row.date_display
+                                    td= row.time
+                                    td= row.tank_code
+                                    td= row.product_code
+                                    td.text-right= Number(row.opening_liters || 0).toFixed(2)
+                                    td.text-right.text-success= Number(row.receipts_liters || 0).toFixed(2)
+                                    td.text-right= Number(row.gross_sales_liters || 0).toFixed(2)
+                                    td.text-right.text-info= Number(row.testing_liters || 0).toFixed(2)
+                                    td.text-right.text-danger= Number(row.sales_liters || 0).toFixed(2)
+                                    td.text-right= Number(row.expected_liters || 0).toFixed(2)
+                                    td.text-right= Number(row.actual_liters || 0).toFixed(2)
+                                    td.text-right(class=(row.variance_liters < 0 ? 'text-danger font-weight-bold' : 'text-success font-weight-bold'))
+                                        = Number(row.variance_liters || 0).toFixed(2)
+                                    td.text-right
+                                        if row.variance_pct !== null
+                                            = Number(row.variance_pct).toFixed(3) + '%'
+                                        else
+                                            | -
+                        tfoot.bg-light
+                            tr.font-weight-bold
+                                td(colspan='4') Total
+                                td.text-right= totalOpening.toFixed(2)
+                                td.text-right.text-success= totalReceipts.toFixed(2)
+                                td.text-right= totalGrossSales.toFixed(2)
+                                td.text-right.text-info= totalTesting.toFixed(2)
+                                td.text-right.text-danger= totalSales.toFixed(2)
+                                td.text-right= totalExpected.toFixed(2)
+                                td.text-right= totalActual.toFixed(2)
+                                td.text-right= totalVariance.toFixed(2)
                                 td.text-right
-                                    if row.variance_pct !== null
-                                        = Number(row.variance_pct).toFixed(3) + '%'
+                                    if totalSales > 0
+                                        = ((totalVariance / totalSales) * 100).toFixed(3) + '%'
                                     else
                                         | -
-                    tfoot.bg-light
-                        tr.font-weight-bold
-                            td(colspan='4') Total
-                            td.text-right= totalOpening.toFixed(2)
-                            td.text-right.text-success= totalReceipts.toFixed(2)
-                            td.text-right.text-danger= totalSales.toFixed(2)
-                            td.text-right= totalExpected.toFixed(2)
-                            td.text-right= totalActual.toFixed(2)
-                            td.text-right= totalVariance.toFixed(2)
-                            td.text-right
-                                if totalSales > 0
-                                    = ((totalVariance / totalSales) * 100).toFixed(3) + '%'
-                                else
-                                    | -
         else
             div.row &nbsp;
             div.alert.alert-info.text-center No records to display for selected range.
 
     include overlay.pug
+
+    script.
+        function onDateRangeChange() {
+            var range = document.getElementById('dateRange').value;
+            var fromInput = document.getElementById('fromDate');
+            var toInput = document.getElementById('toDate');
+            var today = new Date();
+            var from, to;
+
+            if (range === 'this_month') {
+                from = new Date(today.getFullYear(), today.getMonth(), 1);
+                to = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+            } else if (range === 'last_month') {
+                from = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+                to = new Date(today.getFullYear(), today.getMonth(), 0);
+            } else if (range === 'this_financial_year') {
+                var m = today.getMonth();
+                from = m < 3 ? new Date(today.getFullYear() - 1, 3, 1) : new Date(today.getFullYear(), 3, 1);
+                to = today;
+            } else if (range === 'last_financial_year') {
+                var m = today.getMonth();
+                from = m < 3 ? new Date(today.getFullYear() - 2, 3, 1) : new Date(today.getFullYear() - 1, 3, 1);
+                to = m < 3 ? new Date(today.getFullYear() - 1, 2, 31) : new Date(today.getFullYear(), 2, 31);
+            } else {
+                ['fromDateLabel','toDateLabel'].forEach(function(id) {
+                    document.getElementById(id).style.display = 'table-cell';
+                    document.getElementById(id).nextElementSibling.style.display = 'table-cell';
+                });
+                return;
+            }
+
+            function fmt(d) {
+                return new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate())).toISOString().split('T')[0];
+            }
+            fromInput.value = fmt(from);
+            toInput.value = fmt(to);
+            ['fromDateLabel','toDateLabel'].forEach(function(id) {
+                document.getElementById(id).style.display = 'none';
+                document.getElementById(id).nextElementSibling.style.display = 'none';
+            });
+            document.forms[0].submit();
+        }


### PR DESCRIPTION
## Summary
- Added date range presets (This Month / Last Month / This FY / Last FY / Custom) to tank variance report
- Testing liters now deducted from gross sales to compute net sales for variance calculation
- Results grouped by tank code with per-tank subtotals
- Custom date inputs hidden unless Custom range is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)