### PR TITLE
VAT report: fuel purchase invoice-wise with TIN, HSN code, VAT and addition VAT

### DIFF
--- a/app.js
+++ b/app.js
@@ -153,6 +153,7 @@ const reportsController = require("./controllers/reports-controller");
 const cashflowReportsController = require("./controllers/reports-cashflow-controller");
 const dsrReportsController = require("./controllers/reports-dsr-controller");
 const gstsummaryreportsController = require("./controllers/reports-gst-summary-controller");
+const vatReportsController = require("./controllers/reports-vat-controller");
 const digitalReconreportsController = require("./controllers/reports-digital-recon-controller");
 const digitalSalesCorrectionsRoutes = require('./routes/digital-sales-corrections-routes');   
 const decantEditController = require("./controllers/decant-edit-controller");
@@ -247,6 +248,7 @@ app.use(methodOverride('_method'));
 
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'pug');
+app.locals.CACHE_BUST = Date.now();
 
 app.use(flash());
 app.use(require('cookie-parser')('keyboard cat'));
@@ -415,7 +417,6 @@ app.use('/bowser', bowserRoutes);
 app.use((req, res, next) => {
     res.locals.APP_VERSION = process.env.APP_VERSION || 'stable';
     res.locals.SERVER_PORT = process.env.SERVER_PORT;
-    res.locals.CACHE_BUST = Date.now(); // Cache busting version
     next();
 });
 
@@ -896,6 +897,17 @@ app.post('/reports-gst-summary', isLoginEnsured, function (req, res, next) {
 // Excel export for GST Summary
 app.post('/reports-gst-summary/excel', isLoginEnsured, function (req, res, next) {
     gstsummaryreportsController.exportGstSummaryExcel(req, res, next);
+});
+
+app.get('/reports-vat', isLoginEnsured, function (req, res, next) {
+    req.body.caller = 'notpdf';
+    vatReportsController.getVatReport(req, res, next);
+});
+app.post('/reports-vat', isLoginEnsured, function (req, res, next) {
+    vatReportsController.getVatReport(req, res, next);
+});
+app.post('/reports-vat/excel', isLoginEnsured, function (req, res, next) {
+    vatReportsController.exportVatExcel(req, res, next);
 });
 
 app.get('/reports-sales-summary', isLoginEnsured, function (req, res, next) {   

--- a/controllers/reports-vat-controller.js
+++ b/controllers/reports-vat-controller.js
@@ -1,0 +1,155 @@
+const dateFormat = require('dateformat');
+const moment = require('moment');
+const VatDao = require('../dao/report-vat-dao');
+const locationdao = require('../dao/report-dao');
+const personDao = require('../dao/person-dao');
+const ExcelJS = require('exceljs');
+
+module.exports = {
+
+    getVatReport: async (req, res, next) => {
+        try {
+            let locationCode = req.body.locationCode || req.user.location_code;
+            const locationDetails = await locationdao.getLocationDetails(locationCode);
+
+            const today = new Date();
+            const firstDayOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+            let fromDate = dateFormat(firstDayOfMonth, 'yyyy-mm-dd');
+            let toDate = dateFormat(today, 'yyyy-mm-dd');
+            let caller = req.body.caller;
+
+            if (req.body.fromClosingDate) fromDate = req.body.fromClosingDate;
+            if (req.body.toClosingDate) toDate = req.body.toClosingDate;
+
+            const personId = req.user.Person_id;
+            const personLocationPromise = await personDao.findUserLocations(personId);
+            const personLocations = personLocationPromise.map(l => ({ LocationCodes: l.location_code }));
+
+            const [vatRows, vatTotals] = await Promise.all([
+                VatDao.getVatDetail(locationCode, fromDate, toDate),
+                VatDao.getVatTotals(locationCode, fromDate, toDate)
+            ]);
+
+            // Add serial numbers
+            const vatRowsWithSl = vatRows.map((row, idx) => ({ 'Sl No': idx + 1, ...row }));
+
+            const renderData = {
+                title: 'VAT Report',
+                user: req.user,
+                fromClosingDate: fromDate,
+                toClosingDate: toDate,
+                personLocations,
+                locationName: locationDetails.location_name,
+                locationCode,
+                formattedFromDate: moment(fromDate).format('DD/MM/YYYY'),
+                formattedToDate: moment(toDate).format('DD/MM/YYYY'),
+                vatRows: vatRowsWithSl,
+                vatTotals: {
+                    total_value: parseFloat(vatTotals.total_value || 0),
+                    total_vat: parseFloat(vatTotals.total_vat || 0),
+                    total_add_vat: parseFloat(vatTotals.total_add_vat || 0)
+                }
+            };
+
+            if (caller === 'notpdf') {
+                res.render('reports-vat', renderData);
+            } else {
+                return new Promise((resolve, reject) => {
+                    res.render('reports-vat', renderData, (err, html) => {
+                        if (err) { reject(err); } else { resolve(html); }
+                    });
+                });
+            }
+        } catch (error) {
+            console.error('Error generating VAT report:', error);
+            res.status(500).send('An error occurred while generating the VAT report.');
+        }
+    },
+
+    exportVatExcel: async (req, res, next) => {
+        try {
+            let locationCode = req.body.locationCode || req.user.location_code;
+            const locationDetails = await locationdao.getLocationDetails(locationCode);
+
+            const fromDate = req.body.fromClosingDate;
+            const toDate = req.body.toClosingDate;
+
+            const [vatRows, vatTotals] = await Promise.all([
+                VatDao.getVatDetail(locationCode, fromDate, toDate),
+                VatDao.getVatTotals(locationCode, fromDate, toDate)
+            ]);
+
+            const toNum = v => parseFloat(v || 0);
+
+            const workbook = new ExcelJS.Workbook();
+            const sheet = workbook.addWorksheet('VAT Report');
+
+            // Title rows
+            sheet.getCell('A1').value = 'VAT REPORT - FUEL PURCHASE';
+            sheet.getCell('A1').font = { bold: true, size: 14 };
+            sheet.getCell('A2').value = locationDetails.location_name;
+            sheet.getCell('A3').value = `Period: ${moment(fromDate).format('DD/MM/YYYY')} to ${moment(toDate).format('DD/MM/YYYY')}`;
+            let currentRow = 5;
+
+            const headerValues = ['Sl No', 'Name', 'TIN No', 'HSN Code', 'Invoice No', 'Invoice Date', 'Value', 'Tax Rate', 'VAT', 'Addition VAT'];
+            const headerRow = sheet.getRow(currentRow);
+            headerRow.values = headerValues;
+            headerRow.font = { bold: true };
+            headerRow.eachCell(cell => {
+                cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFD3D3D3' } };
+                cell.border = { top: { style: 'thin' }, left: { style: 'thin' }, bottom: { style: 'thin' }, right: { style: 'thin' } };
+                cell.alignment = { horizontal: 'center' };
+            });
+            currentRow++;
+
+            const numCols = [7, 8, 9, 10]; // Value, Tax Rate, VAT, Addition VAT (1-indexed)
+            vatRows.forEach((row, idx) => {
+                const dr = sheet.getRow(currentRow);
+                dr.getCell(1).value = idx + 1;
+                dr.getCell(2).value = row['Name'];
+                dr.getCell(3).value = row['TIN No'];
+                dr.getCell(4).value = row['HSN Code'];
+                dr.getCell(5).value = row['Invoice No'];
+                dr.getCell(6).value = row['Invoice Date'];
+                dr.getCell(7).value = toNum(row['Value']);
+                dr.getCell(8).value = toNum(row['Tax Rate']);
+                dr.getCell(9).value = toNum(row['VAT']);
+                dr.getCell(10).value = toNum(row['Addition VAT']);
+                numCols.forEach(c => { dr.getCell(c).numFmt = '#,##0.00'; });
+                dr.eachCell(cell => {
+                    cell.border = { top: { style: 'thin' }, left: { style: 'thin' }, bottom: { style: 'thin' }, right: { style: 'thin' } };
+                });
+                currentRow++;
+            });
+
+            // Total row
+            const totalRow = sheet.getRow(currentRow);
+            totalRow.getCell(1).value = 'Total';
+            totalRow.getCell(7).value = toNum(vatTotals.total_value);
+            totalRow.getCell(9).value = toNum(vatTotals.total_vat);
+            totalRow.getCell(10).value = toNum(vatTotals.total_add_vat);
+            [7, 9, 10].forEach(c => { totalRow.getCell(c).numFmt = '#,##0.00'; });
+            totalRow.font = { bold: true };
+            totalRow.eachCell(cell => {
+                cell.border = { top: { style: 'thin' }, left: { style: 'thin' }, bottom: { style: 'thin' }, right: { style: 'thin' } };
+                cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFFFF99' } };
+            });
+
+            sheet.columns = [
+                { width: 6 }, { width: 28 }, { width: 14 }, { width: 12 },
+                { width: 18 }, { width: 14 }, { width: 15 }, { width: 10 }, { width: 15 }, { width: 14 }
+            ];
+
+            const buffer = await workbook.xlsx.writeBuffer();
+            const filename = `VatReport_${locationCode}_${moment(fromDate).format('DDMMYYYY')}_${moment(toDate).format('DDMMYYYY')}.xlsx`;
+            res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+            res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+            res.send(buffer);
+
+        } catch (error) {
+            console.error('Error generating VAT Excel:', error);
+            res.status(500).send('An error occurred while generating the VAT Excel file.');
+        }
+    }
+
+};

--- a/dao/report-vat-dao.js
+++ b/dao/report-vat-dao.js
@@ -1,0 +1,63 @@
+const db = require("../db/db-connection");
+const Sequelize = require("sequelize");
+
+module.exports = {
+
+    getVatDetail: async (locationCode, reportFromDate, reportToDate) => {
+        const result = await db.sequelize.query(
+            `SELECT
+                COALESCE(ms.supplier_name, ti.supplier) AS Name,
+                COALESCE(ml.tin_number, '-') AS \`TIN No\`,
+                COALESCE(tid.hsn_code, '-') AS \`HSN Code\`,
+                ti.invoice_number AS \`Invoice No\`,
+                DATE_FORMAT(ti.invoice_date, '%d-%b-%Y') AS \`Invoice Date\`,
+                tid.total_line_amount AS Value,
+                COALESCE(vat.charge_pct, 0) AS \`Tax Rate\`,
+                COALESCE(vat.charge_amount, 0) AS VAT,
+                COALESCE(add_vat.charge_amount, 0) AS \`Addition VAT\`
+            FROM t_tank_invoice ti
+            JOIN t_tank_invoice_dtl tid ON ti.id = tid.invoice_id
+            JOIN m_product mp ON tid.product_id = mp.product_id
+            LEFT JOIN m_supplier ms ON ti.supplier_id = ms.supplier_id
+            LEFT JOIN m_location ml ON ml.location_code = ti.location_id
+            LEFT JOIN t_tank_invoice_charges vat
+                ON tid.id = vat.invoice_dtl_id AND vat.charge_type = 'VAT'
+            LEFT JOIN t_tank_invoice_charges add_vat
+                ON tid.id = add_vat.invoice_dtl_id AND add_vat.charge_type = 'ADDITIONAL_VAT'
+            WHERE ti.location_id = :locationCode
+              AND ti.invoice_date BETWEEN :reportFromDate AND :reportToDate
+              AND COALESCE(mp.is_lube_product, 0) = 0
+            ORDER BY ti.invoice_date, ti.invoice_number, mp.product_name`,
+            {
+                replacements: { locationCode, reportFromDate, reportToDate },
+                type: Sequelize.QueryTypes.SELECT
+            }
+        );
+        return result;
+    },
+
+    getVatTotals: async (locationCode, reportFromDate, reportToDate) => {
+        const result = await db.sequelize.query(
+            `SELECT
+                SUM(tid.total_line_amount) AS total_value,
+                SUM(COALESCE(vat.charge_amount, 0)) AS total_vat,
+                SUM(COALESCE(add_vat.charge_amount, 0)) AS total_add_vat
+            FROM t_tank_invoice ti
+            JOIN t_tank_invoice_dtl tid ON ti.id = tid.invoice_id
+            JOIN m_product mp ON tid.product_id = mp.product_id
+            LEFT JOIN t_tank_invoice_charges vat
+                ON tid.id = vat.invoice_dtl_id AND vat.charge_type = 'VAT'
+            LEFT JOIN t_tank_invoice_charges add_vat
+                ON tid.id = add_vat.invoice_dtl_id AND add_vat.charge_type = 'ADDITIONAL_VAT'
+            WHERE ti.location_id = :locationCode
+              AND ti.invoice_date BETWEEN :reportFromDate AND :reportToDate
+              AND COALESCE(mp.is_lube_product, 0) = 0`,
+            {
+                replacements: { locationCode, reportFromDate, reportToDate },
+                type: Sequelize.QueryTypes.SELECT
+            }
+        );
+        return result[0];
+    }
+
+};

--- a/public/javascripts/app-generate-pdf.js
+++ b/public/javascripts/app-generate-pdf.js
@@ -37,6 +37,12 @@ function generatePDF(currentPage,isPrint = 'N') {
     requestBody.fromClosingDate = document.getElementById('fromclosingDate').value;
     requestBody.toClosingDate = document.getElementById('toclosingDate').value;
     requestBody.supplier_id = document.getElementById('supplier_id').value;    
+    } else if (currentPage.includes('reports-vat')) {
+        requestBody.reportType = 'VatReport';
+        requestBody.fromClosingDate = document.getElementById('fromclosingDate').value;
+        requestBody.toClosingDate = document.getElementById('toclosingDate').value;
+        const locationCodeElement = document.getElementById('locationCode');
+        requestBody.locationCode = locationCodeElement ? locationCodeElement.value : '';
     }  else if (currentPage.includes('reports-gst-summary')) {
         requestBody.reportType = 'GstSummary';
         requestBody.fromClosingDate = document.getElementById('fromclosingDate').value;

--- a/utils/app-pdf-generator.js
+++ b/utils/app-pdf-generator.js
@@ -5,6 +5,7 @@ const reportsController = require("../controllers/reports-controller");
 const cashflowReportsController = require("../controllers/reports-cashflow-controller");
 const dsrReportsController = require("../controllers/reports-dsr-controller");
 const gstReportsController = require("../controllers/reports-gst-summary-controller");
+const vatReportsController = require("../controllers/reports-vat-controller");
 const digitalReconreportsController = require("../controllers/reports-digital-recon-controller");
 const tallyDaybookReportsController = require("../controllers/reports-tally-daybook-controller");
 const stockReportsController = require("../controllers/stock-reports-controller");
@@ -81,6 +82,10 @@ module.exports = {
         else if (req.body.reportType == 'GstSummary')
         {
             htmlContent = await gstReportsController.getgstsummaryReport(req, res, next);
+        }
+        else if (req.body.reportType == 'VatReport')
+        {
+            htmlContent = await vatReportsController.getVatReport(req, res, next);
         }
         else if (req.body.reportType == 'DigitalRecon')
         {
@@ -318,11 +323,18 @@ module.exports = {
             format: 'A4',
             printBackground: true,
             displayHeaderFooter: true,
-            headerTemplate: `<div style="width: 100%; padding: 10px 20px;">
-                                ${companyLogo ? `<img src="${companyLogo}" style="position: absolute; left: 20px; top: 10px; height: 60px; width: auto;" />` : ''}
-                                <div style="text-align: center; margin-bottom: 10px;">
-                                    <div style="font-size: 16px; font-weight: bold;">${locationDetails.location_name}</div>
-                                    <div style="font-size: 14px;">${locationDetails.address}</div>
+            headerTemplate: `<div style="width: 100%; padding: 8px 20px; box-sizing: border-box;">
+                                <div style="display: flex; align-items: center; margin-bottom: 6px;">
+                                    <div style="width: 120px; flex-shrink: 0; display: flex; align-items: center;">
+                                        ${companyLogo ? `<img src="${companyLogo}" style="max-height: 80px; width: auto; height: auto;" />` : ''}
+                                    </div>
+                                    <div style="flex: 1; text-align: center;">
+                                        <div style="font-size: 16px; font-weight: bold;">${locationDetails.location_name}</div>
+                                        ${locationDetails.company_name ? `<div style="font-size: 12px;">Dealer ${({'BPCL':'Bharat Petroleum Corporation Ltd','HPCL':'Hindustan Petroleum Corporation Ltd','IOCL':'Indian Oil Corporation Ltd'})[locationDetails.company_name] || locationDetails.company_name}</div>` : ''}
+                                        <div style="font-size: 12px;">${locationDetails.address}</div>
+                                        ${(locationDetails.gst_number || locationDetails.tin_number) ? `<div style="font-size: 12px;">${[locationDetails.gst_number ? 'GSTIN: ' + locationDetails.gst_number : '', locationDetails.tin_number ? 'TIN: ' + locationDetails.tin_number : ''].filter(Boolean).join(', ')}</div>` : ''}
+                                    </div>
+                                    <div style="width: 120px; flex-shrink: 0;"></div>
                                 </div>
                                 <div style="border-bottom: 2px solid #000; width: 100%;"></div>
                             </div>`,
@@ -335,7 +347,7 @@ module.exports = {
                 <span style="font-size: 12px;">Page <span class="pageNumber"></span> of <span class="totalPages"></span></span>
             </div>`,
             margin: {
-                top: '120px',    // Increased from 80px to give more space for header
+                top: '140px',    // Increased to accommodate dealer line + GSTIN/TIN in header
                 bottom: '90px',  // Increased from 60px to give more space for footer
                 left: '20px',
                 right: '20px'

--- a/views/reports-vat.pug
+++ b/views/reports-vat.pug
@@ -1,0 +1,155 @@
+extends layout
+
+block content
+    form(method='POST' action='/reports-vat')
+        script.
+            var vatRowsFromServer = !{JSON.stringify(vatRows)}
+            var vatTotalsFromServer = !{JSON.stringify(vatTotals)}
+
+            document.addEventListener('DOMContentLoaded', function() {
+                renderVatTable();
+            });
+
+            function renderVatTable() {
+                var rows = vatRowsFromServer;
+                var totals = vatTotalsFromServer;
+
+                if (!rows || rows.length === 0) {
+                    document.getElementById('vat-table-container').innerHTML =
+                        "<p class='text-center'><strong>*** No VAT Purchase data found for the selected period ***</strong></p>";
+                    return;
+                }
+
+                var fmt = function(v) {
+                    return new Intl.NumberFormat('en-IN', {
+                        style: 'decimal',
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2
+                    }).format(parseFloat(v) || 0);
+                };
+
+                var html = "<table class='table table-bordered table-sm' style='width:100%;border:1px solid #000;font-size:13px;'>";
+                html += "<thead class='thead-light'><tr>";
+                html += "<th style='border:1px solid #000;text-align:center;'>Sl No</th>";
+                html += "<th style='border:1px solid #000;'>Name</th>";
+                html += "<th style='border:1px solid #000;text-align:center;'>TIN No</th>";
+                html += "<th style='border:1px solid #000;text-align:center;'>HSN Code</th>";
+                html += "<th style='border:1px solid #000;'>Invoice No</th>";
+                html += "<th style='border:1px solid #000;text-align:center;'>Invoice Date</th>";
+                html += "<th style='border:1px solid #000;text-align:right;'>Value</th>";
+                html += "<th style='border:1px solid #000;text-align:center;'>Tax Rate</th>";
+                html += "<th style='border:1px solid #000;text-align:right;'>VAT</th>";
+                html += "<th style='border:1px solid #000;text-align:right;'>Addition VAT</th>";
+                html += "</tr></thead><tbody>";
+
+                rows.forEach(function(row) {
+                    html += "<tr>";
+                    html += "<td style='border:1px solid #000;text-align:center;'>" + row['Sl No'] + "</td>";
+                    html += "<td style='border:1px solid #000;'>" + (row['Name'] || '-') + "</td>";
+                    html += "<td style='border:1px solid #000;text-align:center;'>" + (row['TIN No'] || '-') + "</td>";
+                    html += "<td style='border:1px solid #000;text-align:center;'>" + (row['HSN Code'] || '-') + "</td>";
+                    html += "<td style='border:1px solid #000;'>" + (row['Invoice No'] || '-') + "</td>";
+                    html += "<td style='border:1px solid #000;text-align:center;'>" + (row['Invoice Date'] || '-') + "</td>";
+                    html += "<td style='border:1px solid #000;text-align:right;'>" + fmt(row['Value']) + "</td>";
+                    html += "<td style='border:1px solid #000;text-align:center;'>" + (row['Tax Rate'] || 0) + "</td>";
+                    html += "<td style='border:1px solid #000;text-align:right;'>" + fmt(row['VAT']) + "</td>";
+                    html += "<td style='border:1px solid #000;text-align:right;'>" + fmt(row['Addition VAT']) + "</td>";
+                    html += "</tr>";
+                });
+
+                // Total row
+                html += "<tr class='font-weight-bold' style='background-color:#ffffcc;'>";
+                html += "<td colspan='6' style='border:1px solid #000;text-align:right;'>Total</td>";
+                html += "<td style='border:1px solid #000;text-align:right;'>" + fmt(totals.total_value) + "</td>";
+                html += "<td style='border:1px solid #000;'></td>";
+                html += "<td style='border:1px solid #000;text-align:right;'>" + fmt(totals.total_vat) + "</td>";
+                html += "<td style='border:1px solid #000;text-align:right;'>" + fmt(totals.total_add_vat) + "</td>";
+                html += "</tr>";
+
+                html += "</tbody></table>";
+
+                document.getElementById('vat-table-container').innerHTML = html;
+            }
+
+            function exportExcel() {
+                var fromDate = document.getElementById('fromclosingDate').value;
+                var toDate = document.getElementById('toclosingDate').value;
+                var locationCode = document.getElementById('locationCode') ?
+                    document.getElementById('locationCode').value : '#{locationCode}';
+
+                var form = document.createElement('form');
+                form.method = 'POST';
+                form.action = '/reports-vat/excel';
+
+                var addField = function(name, value) {
+                    var input = document.createElement('input');
+                    input.type = 'hidden';
+                    input.name = name;
+                    input.value = value;
+                    form.appendChild(input);
+                };
+
+                addField('fromClosingDate', fromDate);
+                addField('toClosingDate', toDate);
+                addField('locationCode', locationCode);
+
+                document.body.appendChild(form);
+                form.submit();
+                document.body.removeChild(form);
+            }
+
+        table.center
+            tr
+                td Date Range:
+                td
+                    select#dateRange.form-control(onchange="updateDateRange()")
+                        option(value='this_month', selected=true) This Month
+                        option(value='last_month') Last Month
+                        option(value='this_financial_year') This Financial Year
+                        option(value='last_financial_year') Last Financial Year
+                        option(value='custom') Custom Date
+                td &nbsp;
+                td#fromDateLabel From Date:
+                td
+                    input#fromclosingDate.form-control(type='date', name='fromClosingDate', value=fromClosingDate, max=currentDate, required)
+                td &nbsp;
+                td#toDateLabel To Date:
+                td
+                    input#toclosingDate.form-control(type='date', name='toClosingDate', value=toClosingDate, max=currentDate, required)
+                td &nbsp;
+                if personLocations.length > 1
+                    td Location:
+                    td
+                        select#locationCode.form-control(name='locationCode', required)
+                            option(value='') Select Location
+                            each location in personLocations
+                                option(value=location.LocationCodes, selected=(location.LocationCodes === locationCode))= location.LocationCodes
+                td &nbsp;
+                td
+                    input(type='hidden', name='caller', value='notpdf')
+                td
+                    button.btn.btn-primary.mr-2(type='submit', id='goButton') Go
+                td
+                    button.btn.btn-success.mr-2(type='button', onClick='generatePDF(window.location.href,"N")')
+                        i.bi.bi-cloud-download
+                        |  Download PDF
+                td
+                    button.btn.btn-success.mr-2(type='button', onClick='exportExcel()')
+                        i.bi.bi-file-excel
+                        |  Export Excel
+                td
+                    button.btn.btn-info(type='button', onClick='generatePDF(window.location.href,"Y")')
+                        i.bi.bi-printer
+                        |  Print
+
+    div
+        div.row &nbsp;
+        h5.text-center.text-muted= locationName
+        h4.font-weight-bold.text-center VAT Report - Fuel Purchase
+        h6.text-center.text-muted= `${formattedFromDate}   to   ${formattedToDate}`
+        div.row &nbsp;
+
+    div.col-md-12
+        div(id='vat-table-container')
+
+    include overlay.pug


### PR DESCRIPTION
## Summary
- New VAT report at `/reports-vat` sourced from fuel purchase invoices (`t_tank_invoice`)
- Columns: Sl No, Name (supplier), TIN No (from `m_location.tin_number`), HSN Code (`t_tank_invoice_dtl.hsn_code`), Invoice No, Invoice Date, Value, Tax Rate, VAT, Addition VAT
- Total row at the bottom
- Download PDF and Export Excel supported

## Files
- `dao/report-vat-dao.js` — new
- `controllers/reports-vat-controller.js` — new
- `views/reports-vat.pug` — new
- `app.js` — routes added
- `utils/app-pdf-generator.js` — VatReport case added
- `public/javascripts/app-generate-pdf.js` — URL detection for reports-vat

🤖 Generated with [Claude Code](https://claude.com/claude-code)