### PR TITLE
Stock summary: use fuel invoice as sole purchase source, fix purchase value

### DIFF
--- a/config/invoice-parsers/IOCL.json
+++ b/config/invoice-parsers/IOCL.json
@@ -71,9 +71,9 @@
         "strategy": "hsn_from_prev_line"
       },
       "total_line_amount": {
-        "keyword": "Total for material",
+        "keyword": "BASIC DESTINATION PRICE",
         "strategy": "nth_number_on_line",
-        "position": 1
+        "position": 3
       }
     }
   },

--- a/controllers/menu-management-controller.js
+++ b/controllers/menu-management-controller.js
@@ -9,7 +9,8 @@ const menuManagementController = {
             res.render('menu-management', {
                 title: 'Menu Management',
                 user: req.user,
-                location: req.user.location_code
+                location: req.user.location_code,
+                isSuperUser: req.user.Role === 'SuperUser'
             });
         } catch (error) {
             console.error('Error rendering menu management page:', error);
@@ -269,6 +270,100 @@ const menuManagementController = {
                 success: false,
                 error: 'Failed to update menu access: ' + error.message
             });
+        }
+    },
+
+    // GET: Raw global access rules
+    getGlobalAccess: async (req, res, next) => {
+        try {
+            const [roles, menuItems, access] = await Promise.all([
+                menuManagementDao.getAllRoles(),
+                menuManagementDao.getAllMenuItems(),
+                menuManagementDao.getAllGlobalAccess()
+            ]);
+            res.json({ success: true, roles, menuItems, access });
+        } catch (error) {
+            console.error('Error fetching global access:', error);
+            res.status(500).json({ success: false, error: error.message });
+        }
+    },
+
+    // POST: Create/upsert a global access rule
+    createGlobalAccess: async (req, res, next) => {
+        try {
+            const { role, menu_code, allowed } = req.body;
+            await menuManagementDao.updateGlobalMenuAccess(role, menu_code, allowed, req.user.User_Name);
+            res.json({ success: true, message: 'Global access rule saved' });
+        } catch (error) {
+            console.error('Error creating global access:', error);
+            res.status(500).json({ success: false, error: error.message });
+        }
+    },
+
+    // DELETE: Soft-delete a global access rule
+    deleteGlobalAccess: async (req, res, next) => {
+        try {
+            await menuManagementDao.deleteGlobalAccess(req.params.id, req.user.User_Name);
+            res.json({ success: true, message: 'Global access rule removed' });
+        } catch (error) {
+            console.error('Error deleting global access:', error);
+            res.status(500).json({ success: false, error: error.message });
+        }
+    },
+
+    // GET: Raw override rules — all locations for SuperUser, own location otherwise
+    getOverrides: async (req, res, next) => {
+        try {
+            const isSuperUser = req.user.Role === 'SuperUser';
+            const [roles, menuItems, access] = await Promise.all([
+                menuManagementDao.getAllRoles(),
+                menuManagementDao.getAllMenuItems(),
+                isSuperUser
+                    ? menuManagementDao.getAllOverridesAll()
+                    : menuManagementDao.getAllOverrides(req.user.location_code)
+            ]);
+            res.json({ success: true, roles, menuItems, access, location: req.user.location_code, isSuperUser });
+        } catch (error) {
+            console.error('Error fetching overrides:', error);
+            res.status(500).json({ success: false, error: error.message });
+        }
+    },
+
+    // POST: Create/upsert a location override
+    createOverride: async (req, res, next) => {
+        try {
+            const { role, menu_code, allowed, location_code } = req.body;
+            const isSuperUser = req.user.Role === 'SuperUser';
+            const targetLocation = (isSuperUser && location_code) ? location_code : req.user.location_code;
+            await menuManagementDao.updateOverrideMenuAccess(
+                role, targetLocation, menu_code, allowed, req.user.User_Name
+            );
+            res.json({ success: true, message: 'Override saved' });
+        } catch (error) {
+            console.error('Error creating override:', error);
+            res.status(500).json({ success: false, error: error.message });
+        }
+    },
+
+    // DELETE: Soft-delete a location override
+    deleteOverride: async (req, res, next) => {
+        try {
+            await menuManagementDao.deleteOverride(req.params.id, req.user.User_Name);
+            res.json({ success: true, message: 'Override removed' });
+        } catch (error) {
+            console.error('Error deleting override:', error);
+            res.status(500).json({ success: false, error: error.message });
+        }
+    },
+
+    // GET: Cache stats
+    getCacheStats: async (req, res, next) => {
+        try {
+            const stats = await menuManagementDao.getCacheStats();
+            res.json({ success: true, stats });
+        } catch (error) {
+            console.error('Error fetching cache stats:', error);
+            res.status(500).json({ success: false, error: error.message });
         }
     },
 

--- a/dao/menu-management-dao.js
+++ b/dao/menu-management-dao.js
@@ -212,6 +212,71 @@ const menuManagementDao = {
 },
 
 
+getAllGlobalAccess: async () => {
+    const query = `
+        SELECT g.access_id, g.role, g.menu_code, g.allowed,
+               COALESCE(mi.menu_name, g.menu_code) AS menu_name
+        FROM m_menu_access_global g
+        LEFT JOIN m_menu_items mi ON g.menu_code = mi.menu_code
+        WHERE g.effective_start_date <= CURDATE()
+          AND (g.effective_end_date IS NULL OR g.effective_end_date >= CURDATE())
+        ORDER BY g.role, menu_name
+    `;
+    return await db.sequelize.query(query, { type: QueryTypes.SELECT });
+},
+
+deleteGlobalAccess: async (accessId, updatedBy) => {
+    return await db.menu_access_global.update(
+        { effective_end_date: new Date(), updated_by: updatedBy },
+        { where: { access_id: accessId } }
+    );
+},
+
+getAllOverrides: async (locationCode) => {
+    const query = `
+        SELECT o.access_id, o.role, o.location_code, o.menu_code, o.allowed,
+               COALESCE(mi.menu_name, o.menu_code) AS menu_name
+        FROM m_menu_access_override o
+        LEFT JOIN m_menu_items mi ON o.menu_code = mi.menu_code
+        WHERE o.location_code = ?
+          AND o.effective_start_date <= CURDATE()
+          AND (o.effective_end_date IS NULL OR o.effective_end_date >= CURDATE())
+        ORDER BY o.role, menu_name
+    `;
+    return await db.sequelize.query(query, { replacements: [locationCode], type: QueryTypes.SELECT });
+},
+
+getAllOverridesAll: async () => {
+    const query = `
+        SELECT o.access_id, o.role, o.location_code, o.menu_code, o.allowed,
+               COALESCE(mi.menu_name, o.menu_code) AS menu_name
+        FROM m_menu_access_override o
+        LEFT JOIN m_menu_items mi ON o.menu_code = mi.menu_code
+        WHERE o.effective_start_date <= CURDATE()
+          AND (o.effective_end_date IS NULL OR o.effective_end_date >= CURDATE())
+        ORDER BY o.location_code, o.role, menu_name
+    `;
+    return await db.sequelize.query(query, { type: QueryTypes.SELECT });
+},
+
+deleteOverride: async (accessId, updatedBy) => {
+    return await db.menu_access_override.update(
+        { effective_end_date: new Date(), updated_by: updatedBy },
+        { where: { access_id: accessId } }
+    );
+},
+
+getCacheStats: async () => {
+    const query = `
+        SELECT refresh_time, records_refreshed, duration_ms
+        FROM menu_cache_refresh_log
+        ORDER BY refresh_time DESC
+        LIMIT 1
+    `;
+    const rows = await db.sequelize.query(query, { type: QueryTypes.SELECT });
+    return rows[0] || null;
+},
+
 checkSequenceInGroup: async (groupCode, sequence, excludeMenuId = null) => {
     const whereClause = {
         group_code: groupCode,

--- a/db/migrations/stock-summary-fuel-invoice-only.sql
+++ b/db/migrations/stock-summary-fuel-invoice-only.sql
@@ -1,0 +1,428 @@
+-- Migration: Use t_tank_invoice_dtl as sole source for fuel purchase qty/value
+-- Removes t_tank_stk_rcpt_dtl from all stock calculations.
+-- That table tracks physical decant (tank-wise receipt) and was a stopgap
+-- before t_tank_invoice was introduced. All purchase records now live in
+-- t_tank_invoice / t_tank_invoice_dtl.
+--
+-- Objects updated:
+--   1. get_closing_product_stock_balance  (function)
+--   2. get_all_products_stock_summary     (procedure)
+
+-- ─── 1. get_closing_product_stock_balance ─────────────────────────────────────
+
+DROP FUNCTION IF EXISTS `get_closing_product_stock_balance`;
+
+DELIMITER ;;
+CREATE DEFINER=`petromath_prod`@`%` FUNCTION `get_closing_product_stock_balance`(
+    p_product_id    INT,
+    p_location_code VARCHAR(50),
+    p_closing_bal_date DATE
+) RETURNS decimal(15,2)
+BEGIN
+    DECLARE l_stock_start_date  DATE;
+    DECLARE l_is_tank_product   TINYINT DEFAULT 0;
+    DECLARE l_is_lube_product   TINYINT DEFAULT 0;
+    DECLARE l_total_purchases   DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_total_adj_in      DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_total_adj_out     DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_cashsales         DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_creditsales       DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_2toil             DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_metersales        DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_total_sales       DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_balance           DECIMAL(15,2) DEFAULT 0;
+
+    SELECT is_tank_product, is_lube_product
+    INTO l_is_tank_product, l_is_lube_product
+    FROM m_product
+    WHERE product_id = p_product_id;
+
+    SELECT MIN(adjustment_date) INTO l_stock_start_date
+    FROM t_lubes_stock_adjustment
+    WHERE product_id = p_product_id
+      AND location_code = p_location_code;
+
+    IF l_stock_start_date IS NULL OR p_closing_bal_date < l_stock_start_date THEN
+        RETURN NULL;
+    END IF;
+
+    -- ── Purchases ──────────────────────────────────────────────────────────────
+
+    IF l_is_lube_product = 1 THEN
+        SELECT COALESCE(SUM(li.qty), 0)
+        INTO l_total_purchases
+        FROM t_lubes_inv_lines li
+        JOIN t_lubes_inv_hdr hdr ON li.lubes_hdr_id = hdr.lubes_hdr_id
+        WHERE li.product_id = p_product_id
+          AND hdr.location_code = p_location_code
+          AND DATE(hdr.invoice_date) >= l_stock_start_date
+          AND DATE(hdr.invoice_date) <= p_closing_bal_date;
+    ELSE
+        -- Fuel invoices only (qty in KL → convert to litres)
+        SELECT COALESCE(SUM(tid.quantity * 1000), 0)
+        INTO l_total_purchases
+        FROM t_tank_invoice_dtl tid
+        JOIN t_tank_invoice ti ON tid.invoice_id = ti.id
+        WHERE tid.product_id  = p_product_id
+          AND ti.location_id  = p_location_code
+          AND DATE(ti.invoice_date) >= l_stock_start_date
+          AND DATE(ti.invoice_date) <= p_closing_bal_date;
+    END IF;
+
+    -- ── Sales (lube-specific: cashsales, credits, 2T oil) ──────────────────────
+
+    IF l_is_lube_product = 1 THEN
+        SELECT COALESCE(SUM(cs.qty), 0)
+        INTO l_cashsales
+        FROM t_cashsales cs
+        JOIN t_closing c ON cs.closing_id = c.closing_id
+        WHERE cs.product_id = p_product_id
+          AND c.location_code = p_location_code
+          AND DATE(c.closing_date) >= l_stock_start_date
+          AND DATE(c.closing_date) <= p_closing_bal_date;
+
+        SELECT COALESCE(SUM(tc.qty), 0)
+        INTO l_creditsales
+        FROM t_credits tc
+        JOIN t_closing c ON tc.closing_id = c.closing_id
+        WHERE tc.product_id = p_product_id
+          AND c.location_code = p_location_code
+          AND DATE(c.closing_date) >= l_stock_start_date
+          AND DATE(c.closing_date) <= p_closing_bal_date;
+
+        SELECT COALESCE(SUM(o.given_qty - o.returned_qty), 0)
+        INTO l_2toil
+        FROM t_2toil o
+        JOIN t_closing c ON o.closing_id = c.closing_id
+        WHERE o.product_id = p_product_id
+          AND c.location_code = p_location_code
+          AND DATE(c.closing_date) >= l_stock_start_date
+          AND DATE(c.closing_date) <= p_closing_bal_date;
+    END IF;
+
+    -- ── Meter sales (fuel + metered lubes, i.e. is_tank_product=1) ─────────────
+
+    IF l_is_tank_product = 1 THEN
+        SELECT COALESCE(SUM(r.closing_reading - r.opening_reading - COALESCE(r.testing, 0)), 0)
+        INTO l_metersales
+        FROM t_reading r
+        JOIN t_closing c  ON r.closing_id  = c.closing_id
+        JOIN m_pump mp    ON r.pump_id     = mp.pump_id AND mp.location_code = p_location_code
+        JOIN m_product pr ON mp.product_code = pr.product_name AND pr.product_id = p_product_id
+        WHERE c.location_code = p_location_code
+          AND DATE(c.closing_date) >= l_stock_start_date
+          AND DATE(c.closing_date) <= p_closing_bal_date
+          AND (r.closing_reading - r.opening_reading - COALESCE(r.testing, 0)) > 0;
+    END IF;
+
+    SET l_total_sales = l_cashsales + l_creditsales + l_2toil + l_metersales;
+
+    -- ── Adjustments ────────────────────────────────────────────────────────────
+
+    SELECT COALESCE(SUM(qty), 0)
+    INTO l_total_adj_in
+    FROM t_lubes_stock_adjustment
+    WHERE product_id = p_product_id
+      AND location_code = p_location_code
+      AND adjustment_type IN ('IN', 'OPENING')
+      AND DATE(adjustment_date) >= l_stock_start_date
+      AND DATE(adjustment_date) <= p_closing_bal_date;
+
+    SELECT COALESCE(SUM(qty), 0)
+    INTO l_total_adj_out
+    FROM t_lubes_stock_adjustment
+    WHERE product_id = p_product_id
+      AND location_code = p_location_code
+      AND adjustment_type = 'OUT'
+      AND DATE(adjustment_date) >= l_stock_start_date
+      AND DATE(adjustment_date) <= p_closing_bal_date;
+
+    SET l_balance = l_total_purchases + l_total_adj_in - l_total_sales - l_total_adj_out;
+
+    RETURN l_balance;
+END ;;
+
+DELIMITER ;
+
+
+-- ─── 2. get_all_products_stock_summary ───────────────────────────────────────
+
+DROP PROCEDURE IF EXISTS `get_all_products_stock_summary`;
+
+DELIMITER ;;
+CREATE DEFINER=`petromath_prod`@`%` PROCEDURE `get_all_products_stock_summary`(
+    IN p_location_code VARCHAR(50),
+    IN p_from_date     DATE,
+    IN p_to_date       DATE
+)
+BEGIN
+    DECLARE l_opening_date DATE;
+    SET l_opening_date = DATE_SUB(p_from_date, INTERVAL 1 DAY);
+
+    SELECT
+        p.product_id,
+        p.product_name,
+        p.unit,
+        p.is_tank_product,
+        p.is_lube_product,
+
+        -- ── Opening balance ───────────────────────────────────────────────────
+        COALESCE(
+            get_closing_product_stock_balance(p.product_id, p_location_code, l_opening_date),
+            (SELECT SUM(qty)
+             FROM t_lubes_stock_adjustment
+             WHERE product_id = p.product_id
+               AND location_code = p_location_code
+               AND adjustment_type = 'OPENING'
+               AND DATE(adjustment_date) = p_from_date)
+        ) AS opening_balance,
+
+        -- ── Closing balance ───────────────────────────────────────────────────
+        get_closing_product_stock_balance(p.product_id, p_location_code, p_to_date) AS closing_balance,
+
+        -- ── Opening price ─────────────────────────────────────────────────────
+        COALESCE(
+            CASE WHEN p.is_lube_product = 0 AND p.is_tank_product = 1 THEN
+                (SELECT r.price
+                 FROM t_reading r
+                 JOIN t_closing c  ON r.closing_id = c.closing_id
+                 JOIN m_pump mp    ON r.pump_id = mp.pump_id AND mp.location_code = p_location_code
+                 WHERE mp.product_code = p.product_name
+                   AND c.location_code = p_location_code
+                   AND DATE(c.closing_date) <= l_opening_date
+                 ORDER BY c.closing_date DESC, r.reading_id DESC
+                 LIMIT 1)
+            ELSE
+                (SELECT li.net_rate
+                 FROM t_lubes_inv_lines li
+                 JOIN t_lubes_inv_hdr hdr ON li.lubes_hdr_id = hdr.lubes_hdr_id
+                 WHERE li.product_id = p.product_id
+                   AND hdr.location_code = p_location_code
+                   AND DATE(hdr.invoice_date) <= l_opening_date
+                 ORDER BY hdr.invoice_date DESC
+                 LIMIT 1)
+            END
+        , 0) AS opening_price,
+
+        -- ── Closing price ─────────────────────────────────────────────────────
+        COALESCE(
+            CASE WHEN p.is_lube_product = 0 AND p.is_tank_product = 1 THEN
+                (SELECT r.price
+                 FROM t_reading r
+                 JOIN t_closing c  ON r.closing_id = c.closing_id
+                 JOIN m_pump mp    ON r.pump_id = mp.pump_id AND mp.location_code = p_location_code
+                 WHERE mp.product_code = p.product_name
+                   AND c.location_code = p_location_code
+                   AND DATE(c.closing_date) <= p_to_date
+                 ORDER BY c.closing_date DESC, r.reading_id DESC
+                 LIMIT 1)
+            ELSE
+                (SELECT li.net_rate
+                 FROM t_lubes_inv_lines li
+                 JOIN t_lubes_inv_hdr hdr ON li.lubes_hdr_id = hdr.lubes_hdr_id
+                 WHERE li.product_id = p.product_id
+                   AND hdr.location_code = p_location_code
+                   AND DATE(hdr.invoice_date) <= p_to_date
+                 ORDER BY hdr.invoice_date DESC
+                 LIMIT 1)
+            END
+        , 0) AS closing_price,
+
+        -- ── Total IN (qty) ────────────────────────────────────────────────────
+        COALESCE((
+            SELECT SUM(qty) FROM (
+
+                -- Lube invoices (is_lube_product=1)
+                SELECT li.qty AS qty
+                FROM t_lubes_inv_lines li
+                JOIN t_lubes_inv_hdr hdr ON li.lubes_hdr_id = hdr.lubes_hdr_id
+                WHERE li.product_id = p.product_id
+                  AND hdr.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(hdr.invoice_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- Fuel invoices (fuel only: is_tank_product=1, is_lube_product=0)
+                SELECT tid.quantity * 1000 AS qty
+                FROM t_tank_invoice_dtl tid
+                JOIN t_tank_invoice ti ON tid.invoice_id = ti.id
+                WHERE tid.product_id   = p.product_id
+                  AND ti.location_id   = p_location_code
+                  AND p.is_tank_product = 1
+                  AND p.is_lube_product = 0
+                  AND DATE(ti.invoice_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- Adjustments IN (all products)
+                SELECT qty
+                FROM t_lubes_stock_adjustment
+                WHERE product_id     = p.product_id
+                  AND location_code  = p_location_code
+                  AND adjustment_type = 'IN'
+                  AND DATE(adjustment_date) BETWEEN p_from_date AND p_to_date
+
+            ) AS ins
+        ), 0) AS total_in,
+
+        -- ── Purchase value ────────────────────────────────────────────────────
+        COALESCE((
+            SELECT SUM(amt) FROM (
+
+                -- Lube invoice amounts
+                SELECT (li.qty * li.net_rate) AS amt
+                FROM t_lubes_inv_lines li
+                JOIN t_lubes_inv_hdr hdr ON li.lubes_hdr_id = hdr.lubes_hdr_id
+                WHERE li.product_id = p.product_id
+                  AND hdr.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(hdr.invoice_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- Fuel invoice amounts: base + all line charges (VAT, Additional VAT, Delivery etc.)
+                -- total_line_amount stores base (qty × rate) for all suppliers.
+                -- IOCL parser was fixed to read BASIC DESTINATION PRICE amount (position 3)
+                -- instead of "Total for material", making it consistent with BPCL.
+                SELECT (
+                    COALESCE(tid.total_line_amount, 0)
+                    + COALESCE((
+                        SELECT SUM(tic.charge_amount)
+                        FROM t_tank_invoice_charges tic
+                        WHERE tic.invoice_dtl_id = tid.id
+                    ), 0)
+                ) AS amt
+                FROM t_tank_invoice_dtl tid
+                JOIN t_tank_invoice ti ON tid.invoice_id = ti.id
+                WHERE tid.product_id   = p.product_id
+                  AND ti.location_id   = p_location_code
+                  AND p.is_tank_product = 1
+                  AND p.is_lube_product = 0
+                  AND DATE(ti.invoice_date) BETWEEN p_from_date AND p_to_date
+
+            ) AS purch_amts
+        ), 0) AS purchase_value,
+
+        -- ── Total OUT (qty) ───────────────────────────────────────────────────
+        COALESCE((
+            SELECT SUM(qty) FROM (
+
+                -- Cash sales (lube products only)
+                SELECT cs.qty
+                FROM t_cashsales cs
+                JOIN t_closing c ON cs.closing_id = c.closing_id
+                WHERE cs.product_id   = p.product_id
+                  AND c.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- Credit sales (lube products only)
+                SELECT cr.qty
+                FROM t_credits cr
+                JOIN t_closing c ON cr.closing_id = c.closing_id
+                WHERE cr.product_id   = p.product_id
+                  AND c.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- 2T oil (lube products only)
+                SELECT (o.given_qty - o.returned_qty)
+                FROM t_2toil o
+                JOIN t_closing c ON o.closing_id = c.closing_id
+                WHERE o.product_id    = p.product_id
+                  AND c.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+                  AND (o.given_qty - o.returned_qty) > 0
+
+                UNION ALL
+
+                -- Meter sales (fuel + metered lubes: is_tank_product=1)
+                SELECT (r.closing_reading - r.opening_reading - COALESCE(r.testing, 0))
+                FROM t_reading r
+                JOIN t_closing c ON r.closing_id = c.closing_id
+                JOIN m_pump mp   ON r.pump_id = mp.pump_id AND mp.location_code = p_location_code
+                WHERE mp.product_code  = p.product_name
+                  AND c.location_code  = p_location_code
+                  AND p.is_tank_product = 1
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+                  AND (r.closing_reading - r.opening_reading - COALESCE(r.testing, 0)) > 0
+
+                UNION ALL
+
+                -- Adjustments OUT (all products)
+                SELECT qty
+                FROM t_lubes_stock_adjustment
+                WHERE product_id     = p.product_id
+                  AND location_code  = p_location_code
+                  AND adjustment_type = 'OUT'
+                  AND DATE(adjustment_date) BETWEEN p_from_date AND p_to_date
+
+            ) AS outs
+        ), 0) AS total_out,
+
+        -- ── Sales value ───────────────────────────────────────────────────────
+        COALESCE((
+            SELECT SUM(amt) FROM (
+
+                -- Cash sale amounts (lube only)
+                SELECT cs.amount AS amt
+                FROM t_cashsales cs
+                JOIN t_closing c ON cs.closing_id = c.closing_id
+                WHERE cs.product_id   = p.product_id
+                  AND c.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- Credit sale amounts (lube only)
+                SELECT cr.amount AS amt
+                FROM t_credits cr
+                JOIN t_closing c ON cr.closing_id = c.closing_id
+                WHERE cr.product_id   = p.product_id
+                  AND c.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- 2T oil amounts (lube only)
+                SELECT ((o.given_qty - o.returned_qty) * o.price) AS amt
+                FROM t_2toil o
+                JOIN t_closing c ON o.closing_id = c.closing_id
+                WHERE o.product_id    = p.product_id
+                  AND c.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+                  AND (o.given_qty - o.returned_qty) > 0
+
+                UNION ALL
+
+                -- Meter sale amounts (fuel + metered lubes)
+                SELECT ((r.closing_reading - r.opening_reading - COALESCE(r.testing, 0)) * r.price) AS amt
+                FROM t_reading r
+                JOIN t_closing c ON r.closing_id = c.closing_id
+                JOIN m_pump mp   ON r.pump_id = mp.pump_id AND mp.location_code = p_location_code
+                WHERE mp.product_code  = p.product_name
+                  AND c.location_code  = p_location_code
+                  AND p.is_tank_product = 1
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+                  AND (r.closing_reading - r.opening_reading - COALESCE(r.testing, 0)) > 0
+
+            ) AS sale_amts
+        ), 0) AS sales_value
+
+    FROM m_product p
+    WHERE p.location_code = p_location_code
+      AND (p.is_lube_product = 1 OR (p.is_tank_product = 1 AND p.is_lube_product = 0))
+    ORDER BY p.is_lube_product ASC, p.product_name;
+
+END ;;
+
+DELIMITER ;

--- a/public/javascripts/menu-management.js
+++ b/public/javascripts/menu-management.js
@@ -1,694 +1,473 @@
-// public/javascripts/menu-management.js
+$(document).ready(function () {
 
-$(document).ready(function() {
-    console.log('Menu Management JavaScript initialized');
-    console.log('User Location:', typeof userLocationCode !== 'undefined' ? userLocationCode : 'undefined');
-    console.log('User Name:', typeof userName !== 'undefined' ? userName : 'undefined');
-    
-    // Global variables
-    let currentEditingItem = null;
-    let currentEditingGroup = null;
+    let menuItems  = [];
     let menuGroups = [];
-    let menuItems = [];
+    let allRoles   = [];
+    let isSuperUser = false;
+    let editingMenuItem  = null;
+    let editingMenuGroup = null;
 
-    // Initialize the page
-    init();
+    // ── tab events ─────────────────────────────────────────────────────────
+    $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+        const target = $(e.target).attr('href');
+        if (target === '#pane-menu-items')    loadMenuItems();
+        if (target === '#pane-menu-groups')   loadMenuGroups();
+        if (target === '#pane-global-access') loadGlobalAccess();
+        if (target === '#pane-overrides')     loadOverrides();
+        if (target === '#pane-cache')         loadCacheStats();
+    });
 
-    function init() {
-        console.log('init() function called');
-        
-        // Load initial data
+    // ── init ───────────────────────────────────────────────────────────────
+    isSuperUser = (typeof pageIsSuperUser !== 'undefined') && pageIsSuperUser;
+    if (isSuperUser) {
         loadMenuItems();
         loadMenuGroups();
-        loadMenuAccess();
-        loadCacheStats();
-        
-        // Set up event listeners
-        setupEventListeners();
-        
-        // Set up tab change events
-        setupTabEvents();
+    } else {
+        loadOverrides();
     }
 
-    function setupEventListeners() {
-        // Menu Items - Fixed IDs to match template
-        $('#add-menu-item-btn').click(() => openMenuItemModal());
-        $('#save-menu-item-btn').click(saveMenuItem);
-        
-        // Menu Groups - Fixed IDs to match template
-        $('#add-menu-group-btn').click(() => openMenuGroupModal());
-        $('#save-menu-group-btn').click(saveMenuGroup);
-        
-        // Cache Management - Fixed IDs to match template
-        $('#refresh-cache-btn, #refresh-cache-btn-tab').click(refreshCache);
-        
-        // Form submissions - Fixed IDs to match template
-        $('#menu-item-form').submit((e) => {
-            e.preventDefault();
-            saveMenuItem();
-        });
-        
-        $('#menu-group-form').submit((e) => {
-            e.preventDefault();
-            saveMenuGroup();
-        });
-    }
-
-    function setupTabEvents() {
-        // Load data when tabs are activated - Fixed target IDs
-        $('a[data-toggle="tab"], button[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-            const target = $(e.target).attr('data-bs-target') || $(e.target).attr('href');
-            
-            switch(target) {
-                case '#menu-items-pane':
-                    if (menuItems.length === 0) loadMenuItems();
-                    break;
-                case '#menu-groups-pane':
-                    if (menuGroups.length === 0) loadMenuGroups();
-                    break;
-                case '#menu-access-pane':
-                    loadMenuAccess();
-                    break;
-                case '#cache-pane':
-                    loadCacheStats();
-                    break;
-            }
-        });
-    }
-
-    // =============================================
-    // MENU ITEMS FUNCTIONS
-    // =============================================
+    // ══════════════════════════════════════════════════════════════════════
+    // MENU ITEMS
+    // ══════════════════════════════════════════════════════════════════════
 
     function loadMenuItems() {
-        console.log('loadMenuItems() function called');
-        
-        $.get('/menu-management/api/menu-items')
-            .done(function(response) {
-                console.log('Menu Items API Success:', response);
-                if (response.success) {
-                    console.log('Menu items data:', response.data);
-                    console.log('Number of menu items:', response.data.length);
-                    menuItems = response.data;
-                    renderMenuItemsTable(response.data);
-                } else {
-                    console.log('API returned error:', response.error);
-                    showError('Failed to load menu items: ' + response.error);
-                }
-            })
-            .fail(function(xhr) {
-                console.log('Menu Items API Failed:', xhr.status, xhr.responseText);
-                showError('Failed to load menu items: ' + xhr.responseText);
-            });
+        $.get('/menu-management/api/menu-items').done(function (r) {
+            if (!r.success) { tableError('#tbody-menu-items', 5, r.error); return; }
+            menuItems = r.data;
+            filterMenuItems();
+        }).fail(function (xhr) { tableError('#tbody-menu-items', 5, xhr.status + ' ' + xhr.responseText.substring(0, 100)); });
     }
+
+    function filterMenuItems() {
+        const q = ($('#search-menu-items').val() || '').toLowerCase().trim();
+        const filtered = q ? menuItems.filter(i =>
+            (i.menu_code  || '').toLowerCase().includes(q) ||
+            (i.menu_name  || '').toLowerCase().includes(q) ||
+            (i.url_path   || '').toLowerCase().includes(q) ||
+            (i.group_code || '').toLowerCase().includes(q)
+        ) : menuItems;
+        renderMenuItemsTable(filtered);
+    }
+
+    $('#search-menu-items').on('input', filterMenuItems);
 
     function renderMenuItemsTable(items) {
-        const tbody = $('#menu-items-table tbody');
-        tbody.empty();
+        const tbody = $('#tbody-menu-items').empty();
+        if (!items.length) { tbody.html('<tr><td colspan="5" class="text-center text-muted">No menu items</td></tr>'); return; }
 
-        if (items.length === 0) {
-            tbody.html('<tr><td colspan="6" class="text-center text-muted">No menu items found</td></tr>');
-            return;
-        }
-
+        const groups = {};
         items.forEach(item => {
-            const row = `
-                <tr>
-                    <td><code>${item.menu_code}</code></td>
-                    <td>${item.menu_name}</td>
-                    <td><small class="text-muted">${item.url_path || '-'}</small></td>
-                    <td><span class="badge bg-secondary">${item.group_code || 'None'}</span></td>
-                    <td>${item.sequence}</td>
-                    <td class="text-center">
-                        <div class="btn-group btn-group-sm" role="group">
-                            <button class="btn btn-outline-primary btn-sm" onclick="editMenuItem(${item.menu_id})"
-                                    title="Edit">
-                                <i class="bi bi-pencil"></i>
-                            </button>
-                            <button class="btn btn-outline-danger btn-sm" onclick="deleteMenuItem(${item.menu_id}, '${item.menu_name.replace(/'/g, "\\'")}')"
-                                    title="Delete">
-                                <i class="bi bi-trash"></i>
-                            </button>
-                        </div>
-                    </td>
-                </tr>
-            `;
-            tbody.append(row);
+            const key = item.group_code || '__NONE__';
+            if (!groups[key]) groups[key] = { label: item.group_code || 'Ungrouped', items: [] };
+            groups[key].items.push(item);
+        });
+
+        Object.values(groups).forEach(g => {
+            tbody.append(`<tr class="table-secondary"><td colspan="5" class="font-weight-bold small text-uppercase py-1"><i class="bi bi-collection mr-1"></i>${escHtml(g.label)}</td></tr>`);
+            g.items.forEach(item => {
+                const indent = item.parent_code ? '<span class="text-muted mr-1">↳</span>' : '';
+                tbody.append(`
+                    <tr>
+                      <td><code>${escHtml(item.menu_code)}</code></td>
+                      <td>${indent}${escHtml(item.menu_name)}</td>
+                      <td><small class="text-muted">${escHtml(item.url_path || '—')}</small></td>
+                      <td class="text-center">${item.sequence}</td>
+                      <td class="text-center text-nowrap">
+                        <button class="btn btn-outline-primary btn-xs mr-1" onclick="editMenuItem(${item.menu_id})" title="Edit"><i class="bi bi-pencil"></i></button>
+                        <button class="btn btn-outline-secondary btn-xs" onclick="deleteMenuItem(${item.menu_id},'${escAttr(item.menu_name)}')" title="Disable"><i class="bi bi-slash-circle mr-1"></i>Disable</button>
+                      </td>
+                    </tr>`);
+            });
         });
     }
 
-    function openMenuItemModal(item = null) {
-        currentEditingItem = item;
-        
-        // Reset form - Fixed ID to match template
-        const form = document.getElementById('menu-item-form');
-        if (form) {
-            form.reset();
-        }
-        
-        // Populate dropdowns
-        populateGroupDropdown();
-        populateParentMenuDropdown();
-        
+    $('#btn-add-menu-item').click(() => openMenuItemModal(null));
+    $('#btn-save-menu-item').click(saveMenuItem);
+    $('#form-menu-item').submit(e => { e.preventDefault(); saveMenuItem(); });
+
+    function openMenuItemModal(item) {
+        editingMenuItem = item;
+        document.getElementById('form-menu-item').reset();
+
+        const groupSel = $('#fi-group-code').empty().append('<option value="">Select group</option>');
+        menuGroups.forEach(g => groupSel.append(`<option value="${escAttr(g.group_code)}">${escHtml(g.group_name)}</option>`));
+
+        const parentSel = $('#fi-parent-code').empty().append('<option value="">None (top level)</option>');
+        menuItems.forEach(m => parentSel.append(`<option value="${escAttr(m.menu_code)}">${escHtml(m.menu_name)}</option>`));
+
         if (item) {
-            // Edit mode - Fixed IDs to match template
-            $('#menu-item-modal-title').text('Edit Menu Item');
-            $('#menu-code').val(item.menu_code);
-            $('#menu-name').val(item.menu_name);
-            $('#url-path').val(item.url_path || '');
-            $('#group-code').val(item.group_code || '');
-            $('#parent-code').val(item.parent_code || '');
-            $('#sequence').val(item.sequence);
+            $('#modal-menu-item-title').text('Edit Menu Item');
+            $('#fi-menu-code').val(item.menu_code).prop('readonly', true);
+            $('#fi-menu-name').val(item.menu_name);
+            $('#fi-url-path').val(item.url_path || '');
+            $('#fi-group-code').val(item.group_code || '');
+            $('#fi-parent-code').val(item.parent_code || '');
+            $('#fi-sequence').val(item.sequence);
         } else {
-            // Add mode
-            $('#menu-item-modal-title').text('Add Menu Item');
+            $('#modal-menu-item-title').text('Add Menu Item');
+            $('#fi-menu-code').prop('readonly', false);
         }
-        
-        // Show modal - Fixed ID to match template
-        $('#menu-item-modal').modal('show');
-    }
-
-    function populateGroupDropdown() {
-        const select = $('#group-code');
-        select.find('option:not(:first)').remove();
-        
-        menuGroups.forEach(group => {
-            select.append(`<option value="${group.group_code}">${group.group_name}</option>`);
-        });
-    }
-
-    function populateParentMenuDropdown() {
-        const select = $('#parent-code');
-        select.find('option:not(:first)').remove();
-        
-        menuItems.forEach(item => {
-            select.append(`<option value="${item.menu_code}">${item.menu_name}</option>`);
-        });
+        $('#modal-menu-item').modal('show');
     }
 
     function saveMenuItem() {
+        const form = document.getElementById('form-menu-item');
+        if (!form.checkValidity()) { form.reportValidity(); return; }
 
-         // Check if form is valid
-        const form = document.getElementById('menu-item-form');
-        if (!form.checkValidity()) {
-            form.reportValidity(); // This will show browser validation messages
-            return;
-        }
+        const groupCode = $('#fi-group-code').val();
+        const sequence  = parseInt($('#fi-sequence').val());
+        const menuCode  = $('#fi-menu-code').val();
 
-         // Get form values
-        const groupCode = $('#group-code').val();
-        const sequence = parseInt($('#sequence').val());
-        const menuCode = $('#menu-code').val();
-        
-        // Check for duplicate sequence within the same group
-        const duplicateSequence = menuItems.find(item => 
-            item.group_code === groupCode && 
-            parseInt(item.sequence) === sequence &&
-            item.menu_code !== menuCode // Exclude current item when editing
-        );
-        
-        if (duplicateSequence) {
-            showError(`Sequence ${sequence} is already used by "${duplicateSequence.menu_name}" in this group. Please use a different sequence number.`);
-            $('#sequence').focus();
-            return;
-        }
+        const dup = menuItems.find(i => i.group_code === groupCode && parseInt(i.sequence) === sequence && i.menu_code !== menuCode);
+        if (dup) { showError(`Sequence ${sequence} already used by "${dup.menu_name}" in this group.`); return; }
 
-        // Fixed IDs to match template
-        const formData = {
-            menu_code: $('#menu-code').val(),
-            menu_name: $('#menu-name').val(),
-            url_path: $('#url-path').val() || null,
-            group_code: $('#group-code').val() || null,
-            parent_code: $('#parent-code').val() || null,
-            sequence: parseInt($('#sequence').val()) || 1
+        const data = {
+            menu_code:   menuCode,
+            menu_name:   $('#fi-menu-name').val(),
+            url_path:    $('#fi-url-path').val() || null,
+            group_code:  groupCode || null,
+            parent_code: $('#fi-parent-code').val() || null,
+            sequence:    sequence || 1
         };
 
-        const url = currentEditingItem 
-            ? `/menu-management/api/menu-items/${currentEditingItem.menu_id}`
-            : '/menu-management/api/menu-items';
-            
-        const method = currentEditingItem ? 'PUT' : 'POST';
+        const url    = editingMenuItem ? `/menu-management/api/menu-items/${editingMenuItem.menu_id}` : '/menu-management/api/menu-items';
+        const method = editingMenuItem ? 'PUT' : 'POST';
 
-        $.ajax({
-            url: url,
-            method: method,
-            data: JSON.stringify(formData),
-            contentType: 'application/json',
-            success: function(response) {
-                if (response.success) {
-                    $('#menu-item-modal').modal('hide');
-                    showSuccess(response.message);
-                    loadMenuItems(); // Reload the table
-                } else {
-                    showError(response.error);
-                }
-            },
-            error: function(xhr) {
-                showError('Failed to save menu item: ' + xhr.responseText);
-            }
-        });
+        $.ajax({ url, method, data: JSON.stringify(data), contentType: 'application/json' })
+            .done(r => { if (r.success) { $('#modal-menu-item').modal('hide'); showSuccess(r.message); loadMenuItems(); } else showError(r.error); })
+            .fail(xhr => showError('Save failed: ' + xhr.responseText));
     }
 
-    // Global functions for table actions
-    window.editMenuItem = function(menuId) {
-        const item = menuItems.find(i => i.menu_id === menuId);
-        if (item) {
-            openMenuItemModal(item);
-        }
+    window.editMenuItem = id => { const item = menuItems.find(i => i.menu_id === id); if (item) openMenuItemModal(item); };
+
+    window.deleteMenuItem = (id, name) => {
+        if (!confirm(`Disable menu item "${name}"?\nIt will be hidden but can be re-enabled via SQL.`)) return;
+        $.ajax({ url: `/menu-management/api/menu-items/${id}`, method: 'DELETE' })
+            .done(r => { if (r.success) { showSuccess(r.message); loadMenuItems(); } else showError(r.error); })
+            .fail(xhr => showError('Disable failed: ' + xhr.responseText));
     };
 
-    window.deleteMenuItem = function(menuId, menuName) {
-        if (confirm(`Are you sure you want to delete the menu item "${menuName}"?`)) {
-            $.ajax({
-                url: `/menu-management/api/menu-items/${menuId}`,
-                method: 'DELETE',
-                success: function(response) {
-                    if (response.success) {
-                        showSuccess(response.message);
-                        loadMenuItems();
-                    } else {
-                        showError(response.error);
-                    }
-                },
-                error: function(xhr) {
-                    showError('Failed to delete menu item: ' + xhr.responseText);
-                }
-            });
-        }
-    };
-
-    // =============================================
-    // MENU GROUPS FUNCTIONS
-    // =============================================
+    // ══════════════════════════════════════════════════════════════════════
+    // MENU GROUPS
+    // ══════════════════════════════════════════════════════════════════════
 
     function loadMenuGroups() {
-        $.get('/menu-management/api/menu-groups')
-            .done(function(response) {
-                if (response.success) {
-                    menuGroups = response.data;
-                    renderMenuGroupsTable(response.data);
-                } else {
-                    showError('Failed to load menu groups: ' + response.error);
-                }
-            })
-            .fail(function(xhr) {
-                showError('Failed to load menu groups: ' + xhr.responseText);
-            });
+        $.get('/menu-management/api/menu-groups').done(function (r) {
+            if (!r.success) { tableError('#tbody-menu-groups', 5, r.error); return; }
+            menuGroups = r.data;
+            renderMenuGroupsTable(menuGroups);
+        }).fail(xhr => tableError('#tbody-menu-groups', 5, xhr.status));
     }
 
     function renderMenuGroupsTable(groups) {
-        const tbody = $('#menu-groups-table tbody');
-        tbody.empty();
-
-        if (groups.length === 0) {
-            tbody.html('<tr><td colspan="5" class="text-center text-muted">No menu groups found</td></tr>');
-            return;
-        }
-
-        groups.forEach(group => {
-            const row = `
+        const tbody = $('#tbody-menu-groups').empty();
+        if (!groups.length) { tbody.html('<tr><td colspan="5" class="text-center text-muted">No groups</td></tr>'); return; }
+        groups.forEach(g => {
+            tbody.append(`
                 <tr>
-                    <td><code>${group.group_code}</code></td>
-                    <td>${group.group_name}</td>
-                    <td>${group.group_sequence}</td>
-                    <td>${group.group_icon ? `<i class="bi ${group.group_icon}"></i> ${group.group_icon}` : '-'}</td>
-                    <td class="text-center">
-                        <div class="btn-group btn-group-sm" role="group">
-                            <button class="btn btn-outline-primary btn-sm" onclick="editMenuGroup(${group.group_id})"
-                                    title="Edit">
-                                <i class="bi bi-pencil"></i>
-                            </button>
-                            <button class="btn btn-outline-danger btn-sm" onclick="deleteMenuGroup(${group.group_id}, '${group.group_name.replace(/'/g, "\\'")}')"
-                                    title="Delete">
-                                <i class="bi bi-trash"></i>
-                            </button>
-                        </div>
-                    </td>
-                </tr>
-            `;
-            tbody.append(row);
+                  <td><code>${escHtml(g.group_code)}</code></td>
+                  <td>${escHtml(g.group_name)}</td>
+                  <td class="text-center">${g.group_sequence}</td>
+                  <td>${g.group_icon ? `<i class="bi ${escAttr(g.group_icon)}"></i> <small class="text-muted">${escHtml(g.group_icon)}</small>` : '—'}</td>
+                  <td class="text-center text-nowrap">
+                    <button class="btn btn-outline-primary btn-xs mr-1" onclick="editMenuGroup(${g.group_id})" title="Edit"><i class="bi bi-pencil"></i></button>
+                    <button class="btn btn-outline-secondary btn-xs" onclick="deleteMenuGroup(${g.group_id},'${escAttr(g.group_name)}')" title="Disable"><i class="bi bi-slash-circle mr-1"></i>Disable</button>
+                  </td>
+                </tr>`);
         });
     }
 
-    function openMenuGroupModal(group = null) {
-        currentEditingGroup = group;
-        
-        // Reset form - Fixed ID to match template
-        const form = document.getElementById('menu-group-form');
-        if (form) {
-            form.reset();
-        }
-        
+    $('#btn-add-menu-group').click(() => openMenuGroupModal(null));
+    $('#btn-save-menu-group').click(saveMenuGroup);
+    $('#form-menu-group').submit(e => { e.preventDefault(); saveMenuGroup(); });
+
+    function openMenuGroupModal(group) {
+        editingMenuGroup = group;
+        document.getElementById('form-menu-group').reset();
         if (group) {
-            // Edit mode - Fixed IDs to match template
-            $('#menu-group-modal-title').text('Edit Menu Group');
-            $('#group-code-input').val(group.group_code);
-            $('#group-name-input').val(group.group_name);
-            $('#group-sequence-input').val(group.group_sequence);
-            $('#group-icon-input').val(group.group_icon || '');
+            $('#modal-menu-group-title').text('Edit Menu Group');
+            $('#fg-code').val(group.group_code).prop('readonly', true);
+            $('#fg-name').val(group.group_name);
+            $('#fg-sequence').val(group.group_sequence);
+            $('#fg-icon').val(group.group_icon || '');
         } else {
-            // Add mode
-            $('#menu-group-modal-title').text('Add Menu Group');
+            $('#modal-menu-group-title').text('Add Menu Group');
+            $('#fg-code').prop('readonly', false);
         }
-        
-        // Show modal - Fixed ID to match template
-        $('#menu-group-modal').modal('show');
+        $('#modal-menu-group').modal('show');
     }
 
     function saveMenuGroup() {
-        // Fixed IDs to match template
-        const formData = {
-            group_code: $('#group-code-input').val(),
-            group_name: $('#group-name-input').val(),
-            group_sequence: parseInt($('#group-sequence-input').val()) || 1,
-            group_icon: $('#group-icon-input').val() || null
-        };
-
-        const url = currentEditingGroup 
-            ? `/menu-management/api/menu-groups/${currentEditingGroup.group_id}`
-            : '/menu-management/api/menu-groups';
-            
-        const method = currentEditingGroup ? 'PUT' : 'POST';
-
-        $.ajax({
-            url: url,
-            method: method,
-            data: JSON.stringify(formData),
-            contentType: 'application/json',
-            success: function(response) {
-                if (response.success) {
-                    $('#menu-group-modal').modal('hide');
-                    showSuccess(response.message);
-                    loadMenuGroups();
-                } else {
-                    showError(response.error);
-                }
-            },
-            error: function(xhr) {
-                showError('Failed to save menu group: ' + xhr.responseText);
-            }
-        });
+        const form = document.getElementById('form-menu-group');
+        if (!form.checkValidity()) { form.reportValidity(); return; }
+        const data = { group_code: $('#fg-code').val(), group_name: $('#fg-name').val(), group_sequence: parseInt($('#fg-sequence').val()) || 1, group_icon: $('#fg-icon').val() || null };
+        const url    = editingMenuGroup ? `/menu-management/api/menu-groups/${editingMenuGroup.group_id}` : '/menu-management/api/menu-groups';
+        const method = editingMenuGroup ? 'PUT' : 'POST';
+        $.ajax({ url, method, data: JSON.stringify(data), contentType: 'application/json' })
+            .done(r => { if (r.success) { $('#modal-menu-group').modal('hide'); showSuccess(r.message); loadMenuGroups(); } else showError(r.error); })
+            .fail(xhr => showError('Save failed: ' + xhr.responseText));
     }
 
-    // Global functions for group table actions
-    window.editMenuGroup = function(groupId) {
-        const group = menuGroups.find(g => g.group_id === groupId);
-        if (group) {
-            openMenuGroupModal(group);
-        }
+    window.editMenuGroup = id => { const g = menuGroups.find(g => g.group_id === id); if (g) openMenuGroupModal(g); };
+    window.deleteMenuGroup = (id, name) => {
+        if (!confirm(`Disable group "${name}"? (Soft delete — reversible via SQL)`)) return;
+        $.ajax({ url: `/menu-management/api/menu-groups/${id}`, method: 'DELETE' })
+            .done(r => { if (r.success) { showSuccess(r.message); loadMenuGroups(); } else showError(r.error); })
+            .fail(xhr => showError('Disable failed: ' + xhr.responseText));
     };
 
-    window.deleteMenuGroup = function(groupId, groupName) {
-        if (confirm(`Are you sure you want to delete the menu group "${groupName}"?`)) {
-            $.ajax({
-                url: `/menu-management/api/menu-groups/${groupId}`,
-                method: 'DELETE',
-                success: function(response) {
-                    if (response.success) {
-                        showSuccess(response.message);
-                        loadMenuGroups();
-                    } else {
-                        showError(response.error);
-                    }
-                },
-                error: function(xhr) {
-                    showError('Failed to delete menu group: ' + xhr.responseText);
-                }
-            });
-        }
+    // ══════════════════════════════════════════════════════════════════════
+    // GLOBAL ACCESS
+    // ══════════════════════════════════════════════════════════════════════
+
+    let allGlobalAccessRows = [];
+
+    function loadGlobalAccess() {
+        tableLoading('#tbody-global-access', 4);
+        $.get('/menu-management/api/global-access').done(function (r) {
+            if (!r.success) { tableError('#tbody-global-access', 4, r.error); return; }
+            allRoles = r.roles;
+            allGlobalAccessRows = r.access;
+            filterGlobalAccess();
+        }).fail(xhr => tableError('#tbody-global-access', 4, xhr.status));
+    }
+
+    function filterGlobalAccess() {
+        const q = ($('#search-global-access').val() || '').toLowerCase().trim();
+        const filtered = q ? allGlobalAccessRows.filter(row =>
+            (row.role      || '').toLowerCase().includes(q) ||
+            (row.menu_name || '').toLowerCase().includes(q) ||
+            (row.menu_code || '').toLowerCase().includes(q)
+        ) : allGlobalAccessRows;
+        renderGlobalAccessTable(filtered);
+    }
+
+    $('#search-global-access').on('input', filterGlobalAccess);
+
+    function renderGlobalAccessTable(rows) {
+        const tbody = $('#tbody-global-access').empty();
+        if (!rows.length) { tbody.html('<tr><td colspan="4" class="text-center text-muted">No global rules defined</td></tr>'); return; }
+        rows.forEach(row => {
+            const badge = row.allowed ? '<span class="badge badge-success">Allow</span>' : '<span class="badge badge-danger">Deny</span>';
+            tbody.append(`
+                <tr>
+                  <td>${escHtml(row.role)}</td>
+                  <td>${escHtml(row.menu_name)} <small class="text-muted">(${escHtml(row.menu_code)})</small></td>
+                  <td class="text-center">${badge}</td>
+                  <td class="text-center">
+                    <button class="btn btn-outline-secondary btn-xs" onclick="deleteGlobalAccess(${row.access_id})" title="Disable"><i class="bi bi-slash-circle mr-1"></i>Disable</button>
+                  </td>
+                </tr>`);
+        });
+    }
+
+    $('#btn-add-global').click(() => openAccessModal('global'));
+    $('#btn-save-global').click(() => saveAccessRule('global'));
+    $('#form-global-access').submit(e => { e.preventDefault(); saveAccessRule('global'); });
+    $('#ga-select-all').click(e => { e.preventDefault(); $('#ga-roles-checkboxes input[type=checkbox]').prop('checked', true); });
+    $('#ga-deselect-all').click(e => { e.preventDefault(); $('#ga-roles-checkboxes input[type=checkbox]').prop('checked', false); });
+
+    window.deleteGlobalAccess = id => {
+        if (!confirm('Disable this global access rule? (Soft delete — reversible via SQL)')) return;
+        $.ajax({ url: `/menu-management/api/global-access/${id}`, method: 'DELETE' })
+            .done(r => { if (r.success) { showSuccess(r.message); loadGlobalAccess(); } else showError(r.error); })
+            .fail(xhr => showError('Delete failed: ' + xhr.responseText));
     };
 
-    // =============================================
-    // MENU ACCESS FUNCTIONS
-    // =============================================
+    // ══════════════════════════════════════════════════════════════════════
+    // LOCATION OVERRIDES
+    // ══════════════════════════════════════════════════════════════════════
 
-    function loadMenuAccess() {
-        // Fixed container ID - create the container if it doesn't exist in template
-        let container = $('#menu-access-table tbody');
-        if (container.length === 0) {
-            container = $('#menu-access-pane .table-responsive');
-        }
-        
-        container.html(`
-            <div class="text-center p-4">
-                <div class="spinner-border me-2" role="status"></div>
-                Loading access matrix...
-            </div>
-        `);
+    let allOverrideRows = [];
 
-        $.get('/menu-management/api/menu-access')
-            .done(function(response) {
-                if (response.success) {
-                    renderAccessMatrix(response.roles, response.access);
-                } else {
-                    showError('Failed to load menu access: ' + response.error);
-                }
-            })
-            .fail(function(xhr) {
-                showError('Failed to load menu access: ' + xhr.responseText);
-            });
-    }
-
-    function renderAccessMatrix(roles, accessData) {
-        // Group access data by role and menu
-        const accessMap = {};
-        accessData.forEach(item => {
-            const key = `${item.role}-${item.menu_code}`;
-            accessMap[key] = item;
-        });
-
-        // Get unique menu items
-        const menus = [...new Set(accessData.map(item => ({ code: item.menu_code, name: item.menu_name })))];
-
-        let html = `
-            <table class="table table-sm table-bordered">
-                <thead class="table-dark">
-                    <tr>
-                        <th class="sticky-left">Menu Item</th>
-        `;
-
-        roles.forEach(role => {
-            html += `<th class="text-center" style="min-width: 80px;">${role.role_name}</th>`;
-        });
-
-        html += `</tr></thead><tbody>`;
-
-        menus.forEach(menu => {
-            html += `<tr><td class="sticky-left"><small>${menu.name}</small></td>`;
-            
-            roles.forEach(role => {
-                const key = `${role.role_name}-${menu.code}`;
-                const access = accessMap[key];
-                const isAllowed = access && access.allowed;
-                
-                html += `
-                    <td class="text-center">
-                        <div class="form-check form-switch d-flex justify-content-center">
-                            <input class="form-check-input access-toggle" type="checkbox" 
-                                   ${isAllowed ? 'checked' : ''} 
-                                   data-role="${role.role_name}" 
-                                   data-menu="${menu.code}">
-                        </div>
-                    </td>
-                `;
-            });
-            
-            html += '</tr>';
-        });
-
-        html += '</tbody></table>';
-
-        // Replace the container content
-        $('#menu-access-pane .table-responsive').html(html);
-
-        // Set up toggle event handlers
-        $('.access-toggle').change(function() {
-            const $this = $(this);
-            const role = $this.data('role');
-            const menuCode = $this.data('menu');
-            const allowed = $this.is(':checked');
-
-            updateMenuAccess(role, menuCode, allowed);
-        });
-    }
-
-    function updateMenuAccess(role, menuCode, allowed) {
-        const data = {
-            role: role,
-            menu_code: menuCode,
-            allowed: allowed,
-            isOverride: false // For now, we'll use global permissions
-        };
-
-        $.ajax({
-            url: '/menu-management/api/menu-access',
-            method: 'PUT',
-            data: JSON.stringify(data),
-            contentType: 'application/json',
-            success: function(response) {
-                if (response.success) {
-                    showSuccess(`Access updated for ${role} - ${menuCode}`, 2000);
-                } else {
-                    showError(response.error);
-                    // Revert the checkbox state
-                    $(`.access-toggle[data-role="${role}"][data-menu="${menuCode}"]`).prop('checked', !allowed);
-                }
-            },
-            error: function(xhr) {
-                showError('Failed to update access: ' + xhr.responseText);
-                // Revert the checkbox state
-                $(`.access-toggle[data-role="${role}"][data-menu="${menuCode}"]`).prop('checked', !allowed);
+    function loadOverrides() {
+        tableLoading('#tbody-overrides', 5);
+        $.get('/menu-management/api/overrides').done(function (r) {
+            if (!r.success) { tableError('#tbody-overrides', 5, r.error); return; }
+            allRoles = r.roles;
+            isSuperUser = r.isSuperUser;
+            allOverrideRows = r.access;
+            if (r.isSuperUser) {
+                $('#override-location-label').text('All Locations');
+                $('#th-override-location').removeClass('d-none');
+                buildLocationFilter(r.access);
+                $('#override-filter-row').removeClass('d-none');
+            } else {
+                $('#override-location-label').text(r.location || userLocationCode);
+                $('#th-override-location').addClass('d-none');
+                $('#override-filter-row').addClass('d-none');
             }
+            filterOverrides();
+        }).fail(xhr => tableError('#tbody-overrides', 5, xhr.status));
+    }
+
+    function filterOverrides() {
+        const q   = ($('#search-overrides').val() || '').toLowerCase().trim();
+        const loc = $('#override-location-filter').val();
+        let filtered = allOverrideRows;
+        if (loc) filtered = filtered.filter(r => r.location_code === loc);
+        if (q)   filtered = filtered.filter(r =>
+            (r.role          || '').toLowerCase().includes(q) ||
+            (r.menu_name     || '').toLowerCase().includes(q) ||
+            (r.menu_code     || '').toLowerCase().includes(q) ||
+            (r.location_code || '').toLowerCase().includes(q)
+        );
+        renderOverridesTable(filtered, isSuperUser);
+    }
+
+    $('#search-overrides').on('input', filterOverrides);
+
+    function buildLocationFilter(rows) {
+        const locs = [...new Set(rows.map(r => r.location_code))].sort();
+        const sel = $('#override-location-filter').empty().append('<option value="">All Locations</option>');
+        locs.forEach(l => sel.append(`<option value="${escAttr(l)}">${escHtml(l)}</option>`));
+    }
+
+    $('#override-location-filter').change(filterOverrides);
+
+    $('#btn-add-override').click(() => openAccessModal('override'));
+    $('#btn-save-override').click(() => saveAccessRule('override'));
+    $('#form-override').submit(e => { e.preventDefault(); saveAccessRule('override'); });
+    $('#ov-select-all').click(e => { e.preventDefault(); $('#ov-roles-checkboxes input[type=checkbox]').prop('checked', true); });
+    $('#ov-deselect-all').click(e => { e.preventDefault(); $('#ov-roles-checkboxes input[type=checkbox]').prop('checked', false); });
+
+    window.deleteOverride = id => {
+        if (!confirm('Disable this override? (Soft delete — reversible via SQL)')) return;
+        $.ajax({ url: `/menu-management/api/overrides/${id}`, method: 'DELETE' })
+            .done(r => { if (r.success) { showSuccess(r.message); loadOverrides(); } else showError(r.error); })
+            .fail(xhr => showError('Delete failed: ' + xhr.responseText));
+    };
+
+    function renderOverridesTable(rows, showLocation) {
+        const cols = showLocation ? 5 : 4;
+        const tbody = $('#tbody-overrides').empty();
+        if (!rows.length) { tbody.html(`<tr><td colspan="${cols}" class="text-center text-muted">No overrides defined</td></tr>`); return; }
+        rows.forEach(row => {
+            const badge = row.allowed ? '<span class="badge badge-success">Allow</span>' : '<span class="badge badge-danger">Deny</span>';
+            const locCell = showLocation ? `<td><code>${escHtml(row.location_code)}</code></td>` : '';
+            tbody.append(`
+                <tr>
+                  ${locCell}
+                  <td>${escHtml(row.role)}</td>
+                  <td>${escHtml(row.menu_name)} <small class="text-muted">(${escHtml(row.menu_code)})</small></td>
+                  <td class="text-center">${badge}</td>
+                  <td class="text-center">
+                    <button class="btn btn-outline-secondary btn-xs" onclick="deleteOverride(${row.access_id})" title="Disable"><i class="bi bi-slash-circle mr-1"></i>Disable</button>
+                  </td>
+                </tr>`);
         });
     }
 
-    // =============================================
-    // CACHE MANAGEMENT FUNCTIONS
-    // =============================================
+    // ══════════════════════════════════════════════════════════════════════
+    // SHARED ACCESS MODAL (Global + Override) — multi-select roles
+    // ══════════════════════════════════════════════════════════════════════
+
+    function openAccessModal(type) {
+        const prefix  = type === 'global' ? 'ga' : 'ov';
+        const menuSel = $(`#${prefix}-menu`).empty().append('<option value="">Select menu item</option>');
+
+        menuItems.forEach(m => menuSel.append(`<option value="${escAttr(m.menu_code)}">${escHtml(m.menu_name)} (${escHtml(m.menu_code)})</option>`));
+
+        // Build role checkboxes
+        const box = $(`#${prefix}-roles-checkboxes`).empty();
+        allRoles.forEach(r => {
+            box.append(`
+                <div class="custom-control custom-checkbox">
+                  <input class="custom-control-input" type="checkbox" id="${prefix}-role-${escAttr(r.role_name)}" value="${escAttr(r.role_name)}">
+                  <label class="custom-control-label" for="${prefix}-role-${escAttr(r.role_name)}">${escHtml(r.role_display_name || r.role_name)}</label>
+                </div>`);
+        });
+
+        $(`input[name="${prefix}-allowed"][value="1"]`).prop('checked', true);
+
+        if (type === 'override') {
+            $('#ov-location').val('');
+            isSuperUser ? $('#ov-location-group').removeClass('d-none') : $('#ov-location-group').addClass('d-none');
+        }
+
+        $(`#modal-${type === 'global' ? 'global-access' : 'override'}`).modal('show');
+    }
+
+    function saveAccessRule(type) {
+        const prefix   = type === 'global' ? 'ga' : 'ov';
+        const menuCode = $(`#${prefix}-menu`).val();
+        const allowed  = $(`input[name="${prefix}-allowed"]:checked`).val() === '1';
+        const checkedRoles = $(`#${prefix}-roles-checkboxes input[type=checkbox]:checked`).map((_, el) => el.value).get();
+
+        if (!checkedRoles.length || !menuCode) { showError('Please select at least one role and a menu item.'); return; }
+
+        const url = type === 'global' ? '/menu-management/api/global-access' : '/menu-management/api/overrides';
+
+        const calls = checkedRoles.map(role => {
+            const payload = { role, menu_code: menuCode, allowed };
+            if (type === 'override' && isSuperUser) {
+                const loc = $('#ov-location').val().trim();
+                if (loc) payload.location_code = loc;
+            }
+            return $.ajax({ url, method: 'POST', data: JSON.stringify(payload), contentType: 'application/json' });
+        });
+
+        $.when(...calls).then(function () {
+            $(`#modal-${type === 'global' ? 'global-access' : 'override'}`).modal('hide');
+            showSuccess(`Saved ${checkedRoles.length} rule(s) for ${escHtml(menuCode)}`);
+            if (type === 'global') loadGlobalAccess(); else loadOverrides();
+        }).fail(xhr => showError('Save failed: ' + (xhr.responseJSON && xhr.responseJSON.error ? xhr.responseJSON.error : xhr.responseText)));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // CACHE
+    // ══════════════════════════════════════════════════════════════════════
 
     function loadCacheStats() {
-        // Fixed ID to match template
-        $('#cache-info').html(`
-            <p class="text-center">
-                <div class="spinner-border spinner-border-sm me-2" role="status"></div>
-                Loading cache stats...
-            </p>
-        `);
-
-        // For now, show basic info. This can be enhanced later with actual cache statistics
-        $('#cache-info').html(`
-            <div class="row text-center">
-                <div class="col-12">
-                    <p class="mb-2"><strong>Cache Status:</strong> <span class="badge bg-success">Active</span></p>
-                    <p class="mb-2"><strong>Last Refresh:</strong> <span id="last-refresh-time">Not available</span></p>
-                    <p class="mb-0"><strong>Records Cached:</strong> <span id="cached-records">Not available</span></p>
-                </div>
-            </div>
-        `);
+        $('#cache-stats-body').html('<p class="text-muted small mb-0">Loading...</p>');
+        $.get('/menu-management/api/cache-stats').done(function (r) {
+            if (!r.success || !r.stats) { $('#cache-stats-body').html('<p class="text-muted small mb-0">No refresh history.</p>'); return; }
+            const s = r.stats;
+            $('#cache-stats-body').html(`
+                <table class="table table-sm table-borderless mb-0">
+                  <tr><th class="pl-0">Last Refresh</th><td>${escHtml(String(s.refresh_time))}</td></tr>
+                  <tr><th class="pl-0">Records Cached</th><td>${s.records_refreshed}</td></tr>
+                  <tr><th class="pl-0">Duration</th><td>${s.duration_ms} ms</td></tr>
+                </table>`);
+        }).fail(() => $('#cache-stats-body').html('<p class="text-danger small mb-0">Could not load stats.</p>'));
     }
 
-    function refreshCache() {
-        const $button = $(this);
-        const originalHtml = $button.html();
-        
-        // Show loading state
-        $button.prop('disabled', true)
-               .html('<span class="spinner-border spinner-border-sm me-2" role="status"></span>Refreshing...');
-
+    $('#btn-refresh-cache').click(function () {
+        const $btn = $(this).prop('disabled', true).html('<span class="spinner-border spinner-border-sm mr-1"></span>Refreshing...');
         $.post('/menu-management/api/refresh-cache')
-            .done(function(response) {
-                if (response.success) {
-                    showSuccess('Menu cache refreshed successfully!');
-                    
-                    // Update cache stats if on that tab
-                    loadCacheStats();
-                } else {
-                    showError('Failed to refresh cache: ' + response.error);
-                }
-            })
-            .fail(function(xhr) {
-                showError('Failed to refresh cache: ' + xhr.responseText);
-            })
-            .always(function() {
-                // Restore button state
-                $button.prop('disabled', false).html(originalHtml);
-            });
+            .done(r => { if (r.success) { showSuccess('Cache refreshed'); loadCacheStats(); } else showError(r.error); })
+            .fail(xhr => showError('Refresh failed: ' + xhr.responseText))
+            .always(() => $btn.prop('disabled', false).html('<i class="bi bi-arrow-clockwise mr-1"></i>Refresh Cache Now'));
+    });
+
+    // ══════════════════════════════════════════════════════════════════════
+    // UTILITIES
+    // ══════════════════════════════════════════════════════════════════════
+
+    function tableLoading(sel, cols) { $(sel).html(`<tr><td colspan="${cols}" class="text-center text-muted">Loading...</td></tr>`); }
+    function tableError(sel, cols, msg) { $(sel).html(`<tr><td colspan="${cols}" class="text-center text-danger"><i class="bi bi-exclamation-triangle mr-1"></i>${escHtml(String(msg))}</td></tr>`); }
+
+    function escHtml(str) {
+        if (str == null) return '';
+        return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
+    function escAttr(str) { return str == null ? '' : String(str).replace(/'/g, "\\'"); }
 
-    // =============================================
-    // UTILITY FUNCTIONS
-    // =============================================
+    function showSuccess(msg) { showToast(msg, 'bg-success'); }
+    function showError(msg)   { showToast(msg, 'bg-danger'); }
 
-    function showSuccess(message, duration = 5000) {
-        const toast = $(`
-            <div class="toast align-items-center text-white bg-success border-0" role="alert" style="position: fixed; top: 20px; right: 20px; z-index: 9999;">
-                <div class="d-flex">
-                    <div class="toast-body">
-                        <i class="bi bi-check-circle me-2"></i>${message}
-                    </div>
-                    <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button>
-                </div>
-            </div>
-        `);
-        
-        $('body').append(toast);
-        const bsToast = new bootstrap.Toast(toast[0], { delay: duration });
-        bsToast.show();
-        
-        toast.on('hidden.bs.toast', function() {
-            $(this).remove();
-        });
+    function showToast(msg, cls) {
+        const t = $(`
+            <div class="toast text-white ${cls} border-0"
+                 style="position:fixed;top:20px;right:20px;z-index:9999;min-width:300px"
+                 data-delay="5000" data-autohide="true">
+              <div class="d-flex align-items-center p-2">
+                <div class="toast-body flex-grow-1">${msg}</div>
+                <button type="button" class="close text-white ml-2" data-dismiss="toast"><span>&times;</span></button>
+              </div>
+            </div>`);
+        $('body').append(t);
+        t.toast('show');
+        t.on('hidden.bs.toast', () => t.remove());
     }
-
-    function showError(message, duration = 8000) {
-        const toast = $(`
-            <div class="toast align-items-center text-white bg-danger border-0" role="alert" style="position: fixed; top: 20px; right: 20px; z-index: 9999;">
-                <div class="d-flex">
-                    <div class="toast-body">
-                        <i class="bi bi-exclamation-triangle me-2"></i>${message}
-                    </div>
-                    <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button>
-                </div>
-            </div>
-        `);
-        
-        $('body').append(toast);
-        const bsToast = new bootstrap.Toast(toast[0], { delay: duration });
-        bsToast.show();
-        
-        toast.on('hidden.bs.toast', function() {
-            $(this).remove();
-        });
-    }
-
-    // Add responsive CSS for better mobile experience
-    $('<style>')
-        .prop('type', 'text/css')
-        .html(`
-            .sticky-left {
-                position: sticky;
-                left: 0;
-                background-color: #f8f9fa;
-                z-index: 10;
-                min-width: 150px;
-            }
-            
-            @media (max-width: 768px) {
-                .table-responsive table {
-                    font-size: 0.875rem;
-                }
-                
-                .sticky-left {
-                    min-width: 120px;
-                    font-size: 0.8rem;
-                }
-                
-                .form-check-input {
-                    transform: scale(0.9);
-                }
-                
-                .btn-group-sm > .btn {
-                    padding: 0.125rem 0.25rem;
-                    font-size: 0.75rem;
-                }
-            }
-            
-            @media (max-width: 576px) {
-                .nav-tabs .nav-link {
-                    padding: 0.5rem 0.25rem;
-                    font-size: 0.875rem;
-                }
-                
-                .modal-dialog {
-                    margin: 0.5rem;
-                }
-                
-                .toast {
-                    min-width: calc(100vw - 40px);
-                    left: 20px !important;
-                    right: 20px !important;
-                }
-            }
-        `)
-        .appendTo('head');
 });

--- a/routes/menu-management-routes.js
+++ b/routes/menu-management-routes.js
@@ -62,8 +62,35 @@ router.put('/api/menu-access', [isLoginEnsured, security.hasPermission('MANAGE_M
 );
 
 // API: Refresh menu cache
-router.post('/api/refresh-cache', [isLoginEnsured, security.hasPermission('MANAGE_MENU_SYSTEM')], 
+router.post('/api/refresh-cache', [isLoginEnsured, security.hasPermission('MANAGE_MENU_SYSTEM')],
     menuManagementController.refreshCache
+);
+
+// API: Global access rules (raw m_menu_access_global)
+router.get('/api/global-access', [isLoginEnsured, security.hasPermission('MANAGE_MENU_SYSTEM')],
+    menuManagementController.getGlobalAccess
+);
+router.post('/api/global-access', [isLoginEnsured, security.hasPermission('MANAGE_MENU_SYSTEM')],
+    menuManagementController.createGlobalAccess
+);
+router.delete('/api/global-access/:id', [isLoginEnsured, security.hasPermission('MANAGE_MENU_SYSTEM')],
+    menuManagementController.deleteGlobalAccess
+);
+
+// API: Location overrides (raw m_menu_access_override, scoped to current user location)
+router.get('/api/overrides', [isLoginEnsured, security.hasPermission('MANAGE_MENU_SYSTEM')],
+    menuManagementController.getOverrides
+);
+router.post('/api/overrides', [isLoginEnsured, security.hasPermission('MANAGE_MENU_SYSTEM')],
+    menuManagementController.createOverride
+);
+router.delete('/api/overrides/:id', [isLoginEnsured, security.hasPermission('MANAGE_MENU_SYSTEM')],
+    menuManagementController.deleteOverride
+);
+
+// API: Cache stats
+router.get('/api/cache-stats', [isLoginEnsured, security.hasPermission('MANAGE_MENU_SYSTEM')],
+    menuManagementController.getCacheStats
 );
 
 

--- a/views/menu-management.pug
+++ b/views/menu-management.pug
@@ -2,238 +2,325 @@ extends layout
 
 block content
   .container-fluid.mt-3
-    .row
+
+    .row.mb-3
       .col-12
-        .card
-          .card-header.d-flex.justify-content-between.align-items-center
-            h4.mb-0
-              i.bi.bi-gear.me-2
-              | Menu Management System
-            button.btn.btn-success.btn-sm#refresh-cache-btn
-              i.bi.bi-arrow-clockwise.me-1
-              | Refresh Cache
+        h4.mb-0
+          i.bi.bi-gear.mr-2
+          | Menu Management
 
-          .card-body
-            // Alert for messages
-            .alert.alert-info.d-none#alert-message
+    .card
+      .card-body
 
-            // Tab Navigation
-            ul.nav.nav-tabs.mb-3#menu-tabs(role="tablist")
-              li.nav-item(role="presentation")
-                a.nav-link.active#menu-items-tab(data-toggle="tab" href="#menu-items-pane" role="tab") 
-                  i.bi.bi-list-ul.me-1
-                  | Menu Items
-              li.nav-item(role="presentation")
-                a.nav-link#menu-groups-tab(data-toggle="tab" href="#menu-groups-pane" role="tab")
-                  i.bi.bi-collection.me-1
-                  | Menu Groups
-              li.nav-item(role="presentation")
-                a.nav-link#menu-access-tab(data-toggle="tab" href="#menu-access-pane" role="tab")
-                  i.bi.bi-shield-lock.me-1
-                  | Access Control
-              li.nav-item(role="presentation")
-                a.nav-link#cache-tab(data-toggle="tab" href="#cache-pane" role="tab")
-                  i.bi.bi-hdd-stack.me-1
-                  | Cache Status
+        ul.nav.nav-tabs.mb-3#menu-tabs(role="tablist")
+          if isSuperUser
+            li.nav-item
+              a.nav-link.active#tab-menu-items(data-toggle="tab" href="#pane-menu-items" role="tab")
+                i.bi.bi-list-ul.mr-1
+                | Menu Items
+            li.nav-item
+              a.nav-link#tab-menu-groups(data-toggle="tab" href="#pane-menu-groups" role="tab")
+                i.bi.bi-collection.mr-1
+                | Menu Groups
+            li.nav-item
+              a.nav-link#tab-global-access(data-toggle="tab" href="#pane-global-access" role="tab")
+                i.bi.bi-shield-check.mr-1
+                | Global Access
+          li.nav-item
+            a.nav-link(class=isSuperUser ? '' : 'active' data-toggle="tab" href="#pane-overrides" role="tab")#tab-overrides
+              i.bi.bi-shield-exclamation.mr-1
+              | Location Overrides
+          if isSuperUser
+            li.nav-item
+              a.nav-link#tab-cache(data-toggle="tab" href="#pane-cache" role="tab")
+                i.bi.bi-hdd-stack.mr-1
+                | Cache
 
-            // Tab Content
-            .tab-content#menu-tab-content
+        .tab-content
 
-              // ===============================
-              // MENU ITEMS TAB
-              // ===============================
-              .tab-pane.fade.show.active#menu-items-pane(role="tabpanel")
-                .row.mb-3
-                  .col-md-8
-                    h5.mb-0 Manage Menu Items
-                  .col-md-4.text-end
-                    button.btn.btn-primary.btn-sm#add-menu-item-btn
-                      i.bi.bi-plus-circle.me-1
-                      | Add New Item
+          //- ===== TAB 1: MENU ITEMS (SuperUser only) =====
+          if isSuperUser
+            .tab-pane.fade.show.active#pane-menu-items(role="tabpanel")
+              .d-flex.justify-content-between.align-items-center.mb-3
+                h6.mb-0.font-weight-bold Menu Items
+                button.btn.btn-primary.btn-sm#btn-add-menu-item
+                  i.bi.bi-plus-circle.mr-1
+                  | Add Item
+              .mb-3
+                .input-group.input-group-sm(style="max-width:360px")
+                  .input-group-prepend
+                    span.input-group-text
+                      i.bi.bi-search
+                  input.form-control#search-menu-items(type="text" placeholder="Search by name, code, path, group…")
+              .table-responsive
+                table.table.table-sm.table-hover.table-bordered#tbl-menu-items
+                  thead.thead-dark
+                    tr
+                      th Code
+                      th Name
+                      th URL Path
+                      th(style="width:50px") Seq
+                      th.text-center(style="width:120px") Actions
+                  tbody#tbody-menu-items
+                    tr
+                      td.text-center.text-muted(colspan="5") Loading...
 
-                // Menu Items Table
-                .table-responsive
-                  table.table.table-striped.table-hover#menu-items-table
-                    thead.table-dark
-                      tr
-                        th Menu Code
-                        th Menu Name
-                        th URL Path
-                        th Group
-                        th Sequence
-                        th.text-center Actions
-                    tbody
-                      // Dynamic content loaded via JavaScript
+          //- ===== TAB 2: MENU GROUPS (SuperUser only) =====
+          if isSuperUser
+            .tab-pane.fade#pane-menu-groups(role="tabpanel")
+              .d-flex.justify-content-between.align-items-center.mb-3
+                h6.mb-0.font-weight-bold Menu Groups
+                button.btn.btn-primary.btn-sm#btn-add-menu-group
+                  i.bi.bi-plus-circle.mr-1
+                  | Add Group
+              .table-responsive
+                table.table.table-sm.table-hover.table-bordered#tbl-menu-groups
+                  thead.thead-dark
+                    tr
+                      th Code
+                      th Name
+                      th(style="width:60px") Seq
+                      th Icon
+                      th.text-center(style="width:100px") Actions
+                  tbody#tbody-menu-groups
+                    tr
+                      td.text-center.text-muted(colspan="5") Loading...
 
-              // ===============================
-              // MENU GROUPS TAB
-              // ===============================
-              .tab-pane.fade#menu-groups-pane(role="tabpanel")
-                .row.mb-3
-                  .col-md-8
-                    h5.mb-0 Manage Menu Groups
-                  .col-md-4.text-end
-                    button.btn.btn-primary.btn-sm#add-menu-group-btn
-                      i.bi.bi-plus-circle.me-1
-                      | Add New Group
+          //- ===== TAB 3: GLOBAL ACCESS (SuperUser only) =====
+          if isSuperUser
+            .tab-pane.fade#pane-global-access(role="tabpanel")
+              .d-flex.justify-content-between.align-items-center.mb-3
+                div
+                  h6.mb-0.font-weight-bold Global Access Rules
+                  small.text-muted Applies to all locations unless overridden
+                button.btn.btn-primary.btn-sm#btn-add-global
+                  i.bi.bi-plus-circle.mr-1
+                  | Add Rule
+              .mb-3
+                .input-group.input-group-sm(style="max-width:360px")
+                  .input-group-prepend
+                    span.input-group-text
+                      i.bi.bi-search
+                  input.form-control#search-global-access(type="text" placeholder="Search by role, menu name, code…")
+              .table-responsive
+                table.table.table-sm.table-hover.table-bordered#tbl-global-access
+                  thead.thead-dark
+                    tr
+                      th Role
+                      th Menu Item
+                      th.text-center(style="width:80px") Access
+                      th.text-center(style="width:70px") Actions
+                  tbody#tbody-global-access
+                    tr
+                      td.text-center.text-muted(colspan="4") Loading...
 
-                // Menu Groups Table
-                .table-responsive
-                  table.table.table-striped.table-hover#menu-groups-table
-                    thead.table-dark
-                      tr
-                        th Group Code
-                        th Group Name
-                        th Sequence
-                        th Icon
-                        th.text-center Actions
-                    tbody
-                      // Dynamic content loaded via JavaScript
+          //- ===== TAB 4: LOCATION OVERRIDES =====
+          .tab-pane.fade(class=isSuperUser ? '' : 'show active' role="tabpanel")#pane-overrides
+            .d-flex.justify-content-between.align-items-center.mb-3
+              div
+                h6.mb-0.font-weight-bold Location Overrides
+                small.text-muted
+                  | Location:&nbsp;
+                  strong#override-location-label ...
+              button.btn.btn-primary.btn-sm#btn-add-override
+                i.bi.bi-plus-circle.mr-1
+                | Add Override
+            .mb-3.d-flex.flex-wrap.align-items-center(style="gap:8px")
+              .input-group.input-group-sm(style="max-width:360px")
+                .input-group-prepend
+                  span.input-group-text
+                    i.bi.bi-search
+                input.form-control#search-overrides(type="text" placeholder="Search by role, menu name, location…")
+              .d-none#override-filter-row
+                .form-inline
+                  label.mr-2.small.font-weight-bold Location:
+                  select.custom-select.custom-select-sm#override-location-filter(style="width:auto")
+                    option(value="") All Locations
+            .table-responsive
+              table.table.table-sm.table-hover.table-bordered#tbl-overrides
+                thead.thead-dark
+                  tr
+                    th.d-none#th-override-location Location
+                    th Role
+                    th Menu Item
+                    th.text-center(style="width:80px") Access
+                    th.text-center(style="width:70px") Actions
+                tbody#tbody-overrides
+                  tr
+                    td.text-center.text-muted(colspan="5") Loading...
 
-              // ===============================
-              // MENU ACCESS TAB
-              // ===============================
-              .tab-pane.fade#menu-access-pane(role="tabpanel")
-                .row.mb-3
-                  .col-12
-                    h5.mb-3 Menu Access Control Matrix
-                    p.text-muted Configure which roles can access which menu items. Changes apply immediately.
+          //- ===== TAB 5: CACHE (SuperUser only) =====
+          if isSuperUser
+            .tab-pane.fade#pane-cache(role="tabpanel")
+              h6.mb-3.font-weight-bold Cache Status
+              .row
+                .col-md-5
+                  .card.border
+                    .card-body#cache-stats-body
+                      p.text-muted.mb-0 Loading...
+                .col-md-4.mt-3.mt-md-0
+                  .card.border
+                    .card-body
+                      p.text-muted.small Rebuild the menu cache after making changes to items, groups, or access rules.
+                      button.btn.btn-warning.btn-sm.btn-block#btn-refresh-cache
+                        i.bi.bi-arrow-clockwise.mr-1
+                        | Refresh Cache Now
 
-                // Access Control Matrix
-                .table-responsive
-                  table.table.table-sm.table-bordered#menu-access-table
-                    thead.table-dark
-                      tr
-                        th.sticky-left Menu Item
-                        // Role columns will be added dynamically
-                    tbody
-                      // Dynamic content loaded via JavaScript
-
-              // ===============================
-              // CACHE STATUS TAB
-              // ===============================
-              .tab-pane.fade#cache-pane(role="tabpanel")
-                .row
-                  .col-md-6
-                    .card.h-100
-                      .card-header
-                        h6.mb-0
-                          i.bi.bi-info-circle.me-1
-                          | Cache Information
-                      .card-body
-                        #cache-info
-                          p.text-muted Loading cache information...
-
-                  .col-md-6
-                    .card.h-100
-                      .card-header
-                        h6.mb-0
-                          i.bi.bi-tools.me-1
-                          | Cache Actions
-                      .card-body
-                        p.mb-3 Use this to refresh the menu cache after making changes to menu items or permissions.
-                        button.btn.btn-warning.w-100#refresh-cache-btn-tab
-                          i.bi.bi-arrow-clockwise.me-1
-                          | Refresh Menu Cache Now
-
-  // ===============================
-  // MODAL: Add/Edit Menu Item
-  // ===============================
-  .modal.fade#menu-item-modal(tabindex="-1")
-    .modal-dialog.modal-lg
+  //- ===== MODAL: Add / Edit Menu Item =====
+  .modal.fade#modal-menu-item(tabindex="-1" role="dialog")
+    .modal-dialog.modal-lg(role="document")
       .modal-content
         .modal-header
-          h5.modal-title#menu-item-modal-title Add Menu Item
-          button.btn.btn-close(type="button" data-dismiss="modal" aria-label="Close")
-            span(aria-hidden="true") ×
-        .modal-body
-          form#menu-item-form
-            .row
-              .col-md-6
-                .mb-3
-                  label.form-label Menu Code *
-                  input.form-control#menu-code(type="text" required maxlength="100")
-                  .form-text Unique identifier for this menu item
-              .col-md-6
-                .mb-3
-                  label.form-label Menu Name *
-                  input.form-control#menu-name(type="text" required maxlength="100")
-                  .form-text Display name shown in the menu
-            .row
-              .col-md-6
-                .mb-3
-                  label.form-label URL Path
-                  input.form-control#url-path(type="text" required maxlength="255")
-                  .form-text e.g., /dashboard or /reports/sales
-              .col-md-6
-                .mb-3
-                  label.form-label Parent Code
-                  select.form-select#parent-code
-                    option(value="") None (Top Level)
-                    // Options loaded dynamically
-            .row
-              .col-md-4
-                .mb-3
-                  label.form-label Group Code *
-                  select.form-select#group-code(required)
-                    option(value="") Select Group
-                    // Options loaded dynamically
-              .col-md-4
-                .mb-3
-                  label.form-label Sequence
-                  input.form-control#sequence(type="number" value="1")
-                  .form-text Display order
-              .col-md-4
-                .mb-3
-                  label.form-label Status
-                  select.form-select#status
-                    option(value="active") Active
-                    option(value="inactive") Inactive
-
-        .modal-footer
-          button.btn.btn-secondary(type="button" data-dismiss="modal") Cancel
-          button.btn.btn-primary#save-menu-item-btn Save Menu Item
-
-  // ===============================
-  // MODAL: Add/Edit Menu Group
-  // ===============================
-  .modal.fade#menu-group-modal(tabindex="-1")
-    .modal-dialog
-      .modal-content
-        .modal-header
-          h5.modal-title#menu-group-modal-title Add Menu Group
+          h5.modal-title#modal-menu-item-title Add Menu Item
           button.close(type="button" data-dismiss="modal" aria-label="Close")
             span(aria-hidden="true") &times;
         .modal-body
-          form#menu-group-form
-            .mb-3
-              label.form-label Group Code *
-              input.form-control#group-code-input(type="text" required maxlength="50")
-              .form-text Unique identifier (e.g., DAILY_OPS, REPORTS)
-            .mb-3
-              label.form-label Group Name *
-              input.form-control#group-name-input(type="text" required maxlength="100")
-              .form-text Display name (e.g., Daily Operations, Reports)
-            .row
+          form#form-menu-item
+            .form-row
               .col-md-6
-                .mb-3
-                  label.form-label Sequence *
-                  input.form-control#group-sequence-input(type="number" required value="1")
-                  .form-text Display order
+                .form-group
+                  label Menu Code *
+                  input.form-control.form-control-sm#fi-menu-code(type="text" required maxlength="100")
+                  small.form-text.text-muted Unique identifier
               .col-md-6
-                .mb-3
-                  label.form-label Icon
-                  input.form-control#group-icon-input(type="text" maxlength="50")
-                  .form-text Bootstrap icon class (e.g., bi-clock)
-
+                .form-group
+                  label Menu Name *
+                  input.form-control.form-control-sm#fi-menu-name(type="text" required maxlength="100")
+            .form-row
+              .col-md-6
+                .form-group
+                  label URL Path
+                  input.form-control.form-control-sm#fi-url-path(type="text" maxlength="255" placeholder="/dashboard")
+              .col-md-6
+                .form-group
+                  label Parent
+                  select.custom-select.custom-select-sm#fi-parent-code
+                    option(value="") None (top level)
+            .form-row
+              .col-md-4
+                .form-group
+                  label Group *
+                  select.custom-select.custom-select-sm#fi-group-code(required)
+                    option(value="") Select group
+              .col-md-4
+                .form-group
+                  label Sequence
+                  input.form-control.form-control-sm#fi-sequence(type="number" value="1")
         .modal-footer
-          button.btn.btn-secondary(type="button" data-dismiss="modal") Cancel
-          button.btn.btn-primary#save-menu-group-btn Save Menu Group
-          
-  script.
-        const userLocationCode = '#{user.location_code}';
-        const userName = '#{user.User_Name}';
-            
-  script(src=`/javascripts/menu-management.js?v=${CACHE_BUST}`)
+          button.btn.btn-secondary.btn-sm(type="button" data-dismiss="modal") Cancel
+          button.btn.btn-primary.btn-sm#btn-save-menu-item Save
 
-   
+  //- ===== MODAL: Add / Edit Menu Group =====
+  .modal.fade#modal-menu-group(tabindex="-1" role="dialog")
+    .modal-dialog(role="document")
+      .modal-content
+        .modal-header
+          h5.modal-title#modal-menu-group-title Add Menu Group
+          button.close(type="button" data-dismiss="modal" aria-label="Close")
+            span(aria-hidden="true") &times;
+        .modal-body
+          form#form-menu-group
+            .form-group
+              label Group Code *
+              input.form-control.form-control-sm#fg-code(type="text" required maxlength="50" placeholder="e.g. DAILY_OPS")
+            .form-group
+              label Group Name *
+              input.form-control.form-control-sm#fg-name(type="text" required maxlength="100")
+            .form-row
+              .col-6
+                .form-group
+                  label Sequence *
+                  input.form-control.form-control-sm#fg-sequence(type="number" required value="1")
+              .col-6
+                .form-group
+                  label Icon
+                  input.form-control.form-control-sm#fg-icon(type="text" maxlength="50" placeholder="bi-clock")
+        .modal-footer
+          button.btn.btn-secondary.btn-sm(type="button" data-dismiss="modal") Cancel
+          button.btn.btn-primary.btn-sm#btn-save-menu-group Save
+
+  //- ===== MODAL: Add Global Access Rule =====
+  .modal.fade#modal-global-access(tabindex="-1" role="dialog")
+    .modal-dialog(role="document")
+      .modal-content
+        .modal-header
+          h5.modal-title Add Global Access Rule
+          button.close(type="button" data-dismiss="modal" aria-label="Close")
+            span(aria-hidden="true") &times;
+        .modal-body
+          form#form-global-access
+            .form-group
+              .d-flex.justify-content-between.align-items-center.mb-1
+                label.mb-0 Roles *
+                span
+                  a.small(href="#" id="ga-select-all") All
+                  |  &nbsp;·&nbsp;
+                  a.small(href="#" id="ga-deselect-all") None
+              .border.rounded.p-2#ga-roles-checkboxes(style="max-height:160px;overflow-y:auto")
+                .text-muted.small Loading...
+            .form-group
+              label Menu Item *
+              select.custom-select.custom-select-sm#ga-menu(required)
+                option(value="") Select menu item
+            .form-group
+              label Access *
+              .d-flex
+                .custom-control.custom-radio.mr-4
+                  input.custom-control-input(type="radio" name="ga-allowed" id="ga-allow" value="1" checked)
+                  label.custom-control-label(for="ga-allow")
+                    span.badge.badge-success Allow
+                .custom-control.custom-radio
+                  input.custom-control-input(type="radio" name="ga-allowed" id="ga-deny" value="0")
+                  label.custom-control-label(for="ga-deny")
+                    span.badge.badge-danger Deny
+        .modal-footer
+          button.btn.btn-secondary.btn-sm(type="button" data-dismiss="modal") Cancel
+          button.btn.btn-primary.btn-sm#btn-save-global Save Rule
+
+  //- ===== MODAL: Add Location Override =====
+  .modal.fade#modal-override(tabindex="-1" role="dialog")
+    .modal-dialog(role="document")
+      .modal-content
+        .modal-header
+          h5.modal-title Add Location Override
+          button.close(type="button" data-dismiss="modal" aria-label="Close")
+            span(aria-hidden="true") &times;
+        .modal-body
+          form#form-override
+            .form-group.d-none#ov-location-group
+              label Location Code *
+              input.form-control.form-control-sm#ov-location(type="text" maxlength="50" placeholder="e.g. MUE")
+              small.form-text.text-muted Leave blank to use your own location
+            .form-group
+              .d-flex.justify-content-between.align-items-center.mb-1
+                label.mb-0 Roles *
+                span
+                  a.small(href="#" id="ov-select-all") All
+                  |  &nbsp;·&nbsp;
+                  a.small(href="#" id="ov-deselect-all") None
+              .border.rounded.p-2#ov-roles-checkboxes(style="max-height:160px;overflow-y:auto")
+                .text-muted.small Loading...
+            .form-group
+              label Menu Item *
+              select.custom-select.custom-select-sm#ov-menu(required)
+                option(value="") Select menu item
+            .form-group
+              label Access *
+              .d-flex
+                .custom-control.custom-radio.mr-4
+                  input.custom-control-input(type="radio" name="ov-allowed" id="ov-allow" value="1" checked)
+                  label.custom-control-label(for="ov-allow")
+                    span.badge.badge-success Allow
+                .custom-control.custom-radio
+                  input.custom-control-input(type="radio" name="ov-allowed" id="ov-deny" value="0")
+                  label.custom-control-label(for="ov-deny")
+                    span.badge.badge-danger Deny
+        .modal-footer
+          button.btn.btn-secondary.btn-sm(type="button" data-dismiss="modal") Cancel
+          button.btn.btn-primary.btn-sm#btn-save-override Save Override
+
+  script.
+    const userLocationCode = '#{user.location_code}';
+    const userName = '#{user.User_Name}';
+    const pageIsSuperUser = !{JSON.stringify(isSuperUser)};
+  script(src=`/javascripts/menu-management.js?v=${CACHE_BUST}`)


### PR DESCRIPTION
## Summary
- Remove `t_tank_stk_rcpt_dtl` from all stock calculations — it tracks physical decant tank-wise and was a stopgap; purchase source of truth is `t_tank_invoice / t_tank_invoice_dtl`
- Fix purchase value: now computed as `total_line_amount + SUM(charges)` per invoice line, covering VAT, Additional VAT, and Delivery charges
- Fix IOCL invoice parser: `total_line_amount` now reads the base amount from `BASIC DESTINATION PRICE` line (position 3) instead of the gross "Total for material", making it consistent with BPCL

## Migration required
Run `db/migrations/stock-summary-fuel-invoice-only.sql` on the database to update:
1. `get_closing_product_stock_balance` (function)
2. `get_all_products_stock_summary` (procedure)

## Test plan
- [ ] Run migration SQL on dev DB
- [ ] Stock summary for April 2026: MS purchase value ~50 Lakhs, HSD ~2.1 Crore
- [ ] Verify opening/closing stock qty unchanged for fuel products
- [ ] Parse a new IOCL invoice PDF and confirm `total_line_amount` = base amount (qty × rate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)