### PR TITLE
Fuel invoice: capture Bay No. from BPCL invoices

### DIFF
--- a/config/invoice-parsers/BPCL.json
+++ b/config/invoice-parsers/BPCL.json
@@ -26,6 +26,11 @@
       "keyword": "Seal/Lock No:",
       "strategy": "value_after_keyword",
       "pattern": "[\\d/]+"
+    },
+    "bay_number": {
+      "keyword": "BAY No.:",
+      "strategy": "value_after_keyword",
+      "pattern": "[\\d\\s/]+"
     }
   },
   "lines": {

--- a/controllers/tank-receipt-controller.js
+++ b/controllers/tank-receipt-controller.js
@@ -225,6 +225,7 @@ module.exports = {
                 truck_number: header.truck_number || null,
                 delivery_doc_no: header.delivery_doc_no || null,
                 seal_lock_no: header.seal_lock_no || null,
+                bay_number: header.bay_number ? header.bay_number.trim() : null,
                 total_invoice_amount: header.total_invoice_amount || null
             };
 

--- a/db/migrations/tank-invoice-bay-number.sql
+++ b/db/migrations/tank-invoice-bay-number.sql
@@ -1,0 +1,5 @@
+-- Migration: Add bay_number column to t_tank_invoice
+-- Captures the Bay No. field from BPCL fuel invoices (e.g. "1352 / 4")
+
+ALTER TABLE t_tank_invoice
+    ADD COLUMN bay_number VARCHAR(20) NULL AFTER seal_lock_no;

--- a/db/txn-tank-invoice.js
+++ b/db/txn-tank-invoice.js
@@ -47,6 +47,11 @@ module.exports = function(sequelize, DataTypes) {
             type: DataTypes.STRING(100),
             allowNull: true
         },
+        bay_number: {
+            field: 'bay_number',
+            type: DataTypes.STRING(20),
+            allowNull: true
+        },
         total_invoice_amount: {
             field: 'total_invoice_amount',
             type: DataTypes.DECIMAL(12, 2),

--- a/public/javascripts/app-scripts.js
+++ b/public/javascripts/app-scripts.js
@@ -2216,7 +2216,8 @@ function renderInvoicePreview(inv) {
                 <td class="text-muted">Truck No.</td><td>${inv.truck_number || '—'}</td></tr>
             <tr><td class="text-muted">Delivery Doc No.</td><td>${inv.delivery_doc_no || '—'}</td>
                 <td class="text-muted">Seal / Lock No.</td><td>${inv.seal_lock_no || '—'}</td></tr>
-            <tr><td class="text-muted">Total Amount</td><td colspan="3"><strong>₹ ${fmtN(inv.total_invoice_amount)}</strong></td></tr>
+            <tr><td class="text-muted">Bay No.</td><td>${inv.bay_number || '—'}</td>
+                <td class="text-muted">Total Amount</td><td><strong>₹ ${fmtN(inv.total_invoice_amount)}</strong></td></tr>
         </tbody>
     </table>
     <h6 class="border-bottom pb-1">Product Lines</h6>

--- a/views/fuel-invoice.pug
+++ b/views/fuel-invoice.pug
@@ -56,6 +56,9 @@ block content
                         label.small Seal / Lock No
                         input#fi_seal_lock_no.form-control.form-control-sm(type='text' value=(invoice ? invoice.seal_lock_no : '') readonly=editDisabled)
                     div.col-md-2.form-group
+                        label.small Bay No.
+                        input#fi_bay_number.form-control.form-control-sm(type='text' value=(invoice ? invoice.bay_number : '') readonly=editDisabled)
+                    div.col-md-2.form-group
                         label.small Total Invoice Amount
                         input#fi_total_amount.form-control.form-control-sm(type='number' step='0.01' min='0' value=(invoice ? invoice.total_invoice_amount : '') readonly=editDisabled)
 
@@ -237,6 +240,7 @@ block content
                         truck_number:         document.getElementById('fi_truck_number').value,
                         delivery_doc_no:      document.getElementById('fi_delivery_doc_no').value,
                         seal_lock_no:         document.getElementById('fi_seal_lock_no').value,
+                        bay_number:           document.getElementById('fi_bay_number').value,
                         total_invoice_amount: document.getElementById('fi_total_amount').value,
                         lines
                     })
@@ -294,6 +298,7 @@ block content
             if (h.truck_number)   document.getElementById('fi_truck_number').value   = h.truck_number;
             if (h.delivery_doc_no)document.getElementById('fi_delivery_doc_no').value= h.delivery_doc_no;
             if (h.seal_lock_no)   document.getElementById('fi_seal_lock_no').value   = h.seal_lock_no;
+            if (h.bay_number)     document.getElementById('fi_bay_number').value     = h.bay_number;
             if (h.total_invoice_amount) document.getElementById('fi_total_amount').value = h.total_invoice_amount;
 
             if (supplierId) {


### PR DESCRIPTION
## Summary
- Parses Bay No. from BPCL PDF invoices (e.g. `1352 / 4`) and stores in `t_tank_invoice.bay_number`
- Displays Bay No. in the fuel invoice form and in the invoice preview modal on the tank receipts page
- Migration: `db/migrations/tank-invoice-bay-number.sql` (already applied to dev and prod)

## Test plan
- [ ] Upload a BPCL fuel invoice PDF — Bay No. field should auto-populate
- [ ] Save invoice and verify `bay_number` persisted in DB
- [ ] Open invoice preview modal from tank receipts — Bay No. row visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)