### PR TITLE
Fix: save PDF buffer when creating fuel invoice via purchases route

### DIFF
--- a/controllers/purchases-controller.js
+++ b/controllers/purchases-controller.js
@@ -6,6 +6,7 @@ const locationConfig = require('../utils/location-config');
 const utils = require('../utils/app-utils');
 const dateFormat = require('dateformat');
 const DocumentStoreDao = require('../dao/document-store-dao');
+const { tempInvoiceStore } = require('./tank-receipt-controller');
 
 module.exports = {
 
@@ -187,8 +188,21 @@ module.exports = {
                 truck_number:         body.truck_number   || null,
                 delivery_doc_no:      body.delivery_doc_no || null,
                 seal_lock_no:         body.seal_lock_no   || null,
+                bay_number:           body.bay_number     || null,
                 total_invoice_amount: body.total_invoice_amount || null
             };
+
+            // Retrieve PDF buffer from temp store if a tempId was passed (from parse-invoice flow)
+            let pdfBuffer = null;
+            let originalFileName = null;
+            if (body.tempId) {
+                const temp = tempInvoiceStore.get(body.tempId);
+                if (temp) {
+                    pdfBuffer = temp.buffer;
+                    originalFileName = temp.originalFileName;
+                    tempInvoiceStore.delete(body.tempId);
+                }
+            }
 
             const lines = (Array.isArray(body.lines) ? body.lines : []).map(l => ({
                 product_id:        Number(l.product_id),
@@ -211,7 +225,7 @@ module.exports = {
             if (lines.some(l => !l.product_id)) return res.status(400).json({ success: false, error: 'All lines must have a product selected.' });
 
             const invoice = await TankInvoiceDao.saveInvoice(
-                header, lines, null, locationCode, header.supplier_id, null
+                header, lines, pdfBuffer, locationCode, header.supplier_id, originalFileName
             );
             return res.json({ success: true, id: invoice.id });
         } catch (err) {

--- a/controllers/tank-receipt-controller.js
+++ b/controllers/tank-receipt-controller.js
@@ -570,3 +570,5 @@ const getInvoiceNumbersSet = (locationCode) => {
         }).catch(() => resolve(new Set()));
     });
 }
+
+module.exports.tempInvoiceStore = tempInvoiceStore;

--- a/views/fuel-invoice.pug
+++ b/views/fuel-invoice.pug
@@ -107,6 +107,7 @@ block content
 
         let fi_lineCount = 0;
         const fi_chargeCounters = {};
+        let fi_tempId = null;
 
         function fuelInvoiceAddLine(data) {
             const i = fi_lineCount++;
@@ -233,6 +234,7 @@ block content
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
+                        tempId:               fi_tempId,
                         supplier_id:          supplierId,
                         supplier_name:        supplierName,
                         invoice_number:       invoiceNumber,
@@ -282,6 +284,7 @@ block content
                     statusEl.className = 'text-danger small ml-3';
                     return;
                 }
+                fi_tempId = json.tempId || null;
                 fuelInvoicePrefill(json.data, json.supplier, json.supplierId, json.products, json.mappings);
                 statusEl.textContent = 'Invoice read successfully.';
                 statusEl.className = 'text-success small ml-3';


### PR DESCRIPTION
## Summary
- The fuel-invoice page uploaded PDFs via `/tank-receipts/parse-invoice` (stored in `tempInvoiceStore`) but saved via `/purchases/fuel-invoice/save` which never retrieved the buffer — View PDF always failed for BPCL invoices entered this way
- IOCL invoices worked because they use the older `/tank-receipts/save-invoice` flow which properly passes `tempId`
- Fix: expose `tempInvoiceStore` from tank-receipt-controller, capture `tempId` in frontend after parse, pass it on save, retrieve PDF buffer in `saveFuelInvoice`
- Also adds missing `bay_number` to the purchases save header

## Test plan
- [ ] Upload a BPCL PDF → save → View PDF should now open the PDF correctly
- [ ] Verify IOCL flow unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)