### PR TITLE
VAT report: show all charge columns dynamically

### DIFF
--- a/controllers/reports-vat-controller.js
+++ b/controllers/reports-vat-controller.js
@@ -5,6 +5,30 @@ const locationdao = require('../dao/report-dao');
 const personDao = require('../dao/person-dao');
 const ExcelJS = require('exceljs');
 
+function flattenRows(vatRows, chargeTypes) {
+    return vatRows.map((row, idx) => {
+        const charges = typeof row.charges_json === 'string'
+            ? JSON.parse(row.charges_json)
+            : (row.charges_json || {});
+        const flat = { 'Sl No': idx + 1, ...row };
+        delete flat.charges_json;
+        chargeTypes.forEach(ct => {
+            flat[ct] = parseFloat(charges[ct] || 0);
+        });
+        return flat;
+    });
+}
+
+function computeTotals(rows, chargeTypes) {
+    const totals = { total_value: 0 };
+    chargeTypes.forEach(ct => { totals[ct] = 0; });
+    rows.forEach(row => {
+        totals.total_value += parseFloat(row['Value'] || 0);
+        chargeTypes.forEach(ct => { totals[ct] += row[ct] || 0; });
+    });
+    return totals;
+}
+
 module.exports = {
 
     getVatReport: async (req, res, next) => {
@@ -25,13 +49,13 @@ module.exports = {
             const personLocationPromise = await personDao.findUserLocations(personId);
             const personLocations = personLocationPromise.map(l => ({ LocationCodes: l.location_code }));
 
-            const [vatRows, vatTotals] = await Promise.all([
-                VatDao.getVatDetail(locationCode, fromDate, toDate),
-                VatDao.getVatTotals(locationCode, fromDate, toDate)
+            const [chargeTypes, vatRowsRaw] = await Promise.all([
+                VatDao.getChargeTypes(locationCode, fromDate, toDate),
+                VatDao.getVatDetail(locationCode, fromDate, toDate)
             ]);
 
-            // Add serial numbers
-            const vatRowsWithSl = vatRows.map((row, idx) => ({ 'Sl No': idx + 1, ...row }));
+            const vatRows = flattenRows(vatRowsRaw, chargeTypes);
+            const vatTotals = computeTotals(vatRows, chargeTypes);
 
             const renderData = {
                 title: 'VAT Report',
@@ -43,12 +67,9 @@ module.exports = {
                 locationCode,
                 formattedFromDate: moment(fromDate).format('DD/MM/YYYY'),
                 formattedToDate: moment(toDate).format('DD/MM/YYYY'),
-                vatRows: vatRowsWithSl,
-                vatTotals: {
-                    total_value: parseFloat(vatTotals.total_value || 0),
-                    total_vat: parseFloat(vatTotals.total_vat || 0),
-                    total_add_vat: parseFloat(vatTotals.total_add_vat || 0)
-                }
+                chargeTypes,
+                vatRows,
+                vatTotals
             };
 
             if (caller === 'notpdf') {
@@ -74,24 +95,29 @@ module.exports = {
             const fromDate = req.body.fromClosingDate;
             const toDate = req.body.toClosingDate;
 
-            const [vatRows, vatTotals] = await Promise.all([
-                VatDao.getVatDetail(locationCode, fromDate, toDate),
-                VatDao.getVatTotals(locationCode, fromDate, toDate)
+            const [chargeTypes, vatRowsRaw] = await Promise.all([
+                VatDao.getChargeTypes(locationCode, fromDate, toDate),
+                VatDao.getVatDetail(locationCode, fromDate, toDate)
             ]);
+
+            const vatRows = flattenRows(vatRowsRaw, chargeTypes);
+            const vatTotals = computeTotals(vatRows, chargeTypes);
 
             const toNum = v => parseFloat(v || 0);
 
             const workbook = new ExcelJS.Workbook();
             const sheet = workbook.addWorksheet('VAT Report');
 
-            // Title rows
             sheet.getCell('A1').value = 'VAT REPORT - FUEL PURCHASE';
             sheet.getCell('A1').font = { bold: true, size: 14 };
             sheet.getCell('A2').value = locationDetails.location_name;
             sheet.getCell('A3').value = `Period: ${moment(fromDate).format('DD/MM/YYYY')} to ${moment(toDate).format('DD/MM/YYYY')}`;
             let currentRow = 5;
 
-            const headerValues = ['Sl No', 'Name', 'TIN No', 'HSN Code', 'Invoice No', 'Invoice Date', 'Value', 'Tax Rate', 'VAT', 'Addition VAT'];
+            // Fixed columns: Sl No, Name, TIN No, HSN Code, Invoice No, Invoice Date, Value, Tax Rate
+            // Then one column per charge type
+            const fixedHeaders = ['Sl No', 'Name', 'TIN No', 'HSN Code', 'Invoice No', 'Invoice Date', 'Value', 'Tax Rate'];
+            const headerValues = [...fixedHeaders, ...chargeTypes];
             const headerRow = sheet.getRow(currentRow);
             headerRow.values = headerValues;
             headerRow.font = { bold: true };
@@ -102,7 +128,8 @@ module.exports = {
             });
             currentRow++;
 
-            const numCols = [7, 8, 9, 10]; // Value, Tax Rate, VAT, Addition VAT (1-indexed)
+            const numericColIndices = [7, 8, ...chargeTypes.map((_, i) => 9 + i)]; // Value=7, Tax Rate=8, charges start at 9
+
             vatRows.forEach((row, idx) => {
                 const dr = sheet.getRow(currentRow);
                 dr.getCell(1).value = idx + 1;
@@ -113,9 +140,10 @@ module.exports = {
                 dr.getCell(6).value = row['Invoice Date'];
                 dr.getCell(7).value = toNum(row['Value']);
                 dr.getCell(8).value = toNum(row['Tax Rate']);
-                dr.getCell(9).value = toNum(row['VAT']);
-                dr.getCell(10).value = toNum(row['Addition VAT']);
-                numCols.forEach(c => { dr.getCell(c).numFmt = '#,##0.00'; });
+                chargeTypes.forEach((ct, i) => {
+                    dr.getCell(9 + i).value = toNum(row[ct]);
+                });
+                numericColIndices.forEach(c => { dr.getCell(c).numFmt = '#,##0.00'; });
                 dr.eachCell(cell => {
                     cell.border = { top: { style: 'thin' }, left: { style: 'thin' }, bottom: { style: 'thin' }, right: { style: 'thin' } };
                 });
@@ -126,18 +154,21 @@ module.exports = {
             const totalRow = sheet.getRow(currentRow);
             totalRow.getCell(1).value = 'Total';
             totalRow.getCell(7).value = toNum(vatTotals.total_value);
-            totalRow.getCell(9).value = toNum(vatTotals.total_vat);
-            totalRow.getCell(10).value = toNum(vatTotals.total_add_vat);
-            [7, 9, 10].forEach(c => { totalRow.getCell(c).numFmt = '#,##0.00'; });
+            chargeTypes.forEach((ct, i) => {
+                totalRow.getCell(9 + i).value = toNum(vatTotals[ct]);
+            });
+            [7, ...chargeTypes.map((_, i) => 9 + i)].forEach(c => { totalRow.getCell(c).numFmt = '#,##0.00'; });
             totalRow.font = { bold: true };
             totalRow.eachCell(cell => {
                 cell.border = { top: { style: 'thin' }, left: { style: 'thin' }, bottom: { style: 'thin' }, right: { style: 'thin' } };
                 cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFFFF99' } };
             });
 
+            // Column widths: fixed + dynamic charge columns at width 15
             sheet.columns = [
                 { width: 6 }, { width: 28 }, { width: 14 }, { width: 12 },
-                { width: 18 }, { width: 14 }, { width: 15 }, { width: 10 }, { width: 15 }, { width: 14 }
+                { width: 18 }, { width: 14 }, { width: 15 }, { width: 10 },
+                ...chargeTypes.map(() => ({ width: 15 }))
             ];
 
             const buffer = await workbook.xlsx.writeBuffer();

--- a/dao/report-vat-dao.js
+++ b/dao/report-vat-dao.js
@@ -3,6 +3,25 @@ const Sequelize = require("sequelize");
 
 module.exports = {
 
+    getChargeTypes: async (locationCode, reportFromDate, reportToDate) => {
+        const result = await db.sequelize.query(
+            `SELECT DISTINCT tic.charge_type
+             FROM t_tank_invoice ti
+             JOIN t_tank_invoice_dtl tid ON ti.id = tid.invoice_id
+             JOIN m_product mp ON tid.product_id = mp.product_id
+             JOIN t_tank_invoice_charges tic ON tid.id = tic.invoice_dtl_id
+             WHERE ti.location_id = :locationCode
+               AND ti.invoice_date BETWEEN :reportFromDate AND :reportToDate
+               AND COALESCE(mp.is_lube_product, 0) = 0
+             ORDER BY tic.charge_type`,
+            {
+                replacements: { locationCode, reportFromDate, reportToDate },
+                type: Sequelize.QueryTypes.SELECT
+            }
+        );
+        return result.map(r => r.charge_type);
+    },
+
     getVatDetail: async (locationCode, reportFromDate, reportToDate) => {
         const result = await db.sequelize.query(
             `SELECT
@@ -13,8 +32,9 @@ module.exports = {
                 DATE_FORMAT(ti.invoice_date, '%d-%b-%Y') AS \`Invoice Date\`,
                 tid.total_line_amount AS Value,
                 COALESCE(vat.charge_pct, 0) AS \`Tax Rate\`,
-                COALESCE(vat.charge_amount, 0) AS VAT,
-                COALESCE(add_vat.charge_amount, 0) AS \`Addition VAT\`
+                (SELECT JSON_OBJECTAGG(charge_type, charge_amount)
+                 FROM t_tank_invoice_charges
+                 WHERE invoice_dtl_id = tid.id) AS charges_json
             FROM t_tank_invoice ti
             JOIN t_tank_invoice_dtl tid ON ti.id = tid.invoice_id
             JOIN m_product mp ON tid.product_id = mp.product_id
@@ -22,8 +42,6 @@ module.exports = {
             LEFT JOIN m_location ml ON ml.location_code = ti.location_id
             LEFT JOIN t_tank_invoice_charges vat
                 ON tid.id = vat.invoice_dtl_id AND vat.charge_type = 'VAT'
-            LEFT JOIN t_tank_invoice_charges add_vat
-                ON tid.id = add_vat.invoice_dtl_id AND add_vat.charge_type = 'ADDITIONAL_VAT'
             WHERE ti.location_id = :locationCode
               AND ti.invoice_date BETWEEN :reportFromDate AND :reportToDate
               AND COALESCE(mp.is_lube_product, 0) = 0
@@ -34,30 +52,6 @@ module.exports = {
             }
         );
         return result;
-    },
-
-    getVatTotals: async (locationCode, reportFromDate, reportToDate) => {
-        const result = await db.sequelize.query(
-            `SELECT
-                SUM(tid.total_line_amount) AS total_value,
-                SUM(COALESCE(vat.charge_amount, 0)) AS total_vat,
-                SUM(COALESCE(add_vat.charge_amount, 0)) AS total_add_vat
-            FROM t_tank_invoice ti
-            JOIN t_tank_invoice_dtl tid ON ti.id = tid.invoice_id
-            JOIN m_product mp ON tid.product_id = mp.product_id
-            LEFT JOIN t_tank_invoice_charges vat
-                ON tid.id = vat.invoice_dtl_id AND vat.charge_type = 'VAT'
-            LEFT JOIN t_tank_invoice_charges add_vat
-                ON tid.id = add_vat.invoice_dtl_id AND add_vat.charge_type = 'ADDITIONAL_VAT'
-            WHERE ti.location_id = :locationCode
-              AND ti.invoice_date BETWEEN :reportFromDate AND :reportToDate
-              AND COALESCE(mp.is_lube_product, 0) = 0`,
-            {
-                replacements: { locationCode, reportFromDate, reportToDate },
-                type: Sequelize.QueryTypes.SELECT
-            }
-        );
-        return result[0];
     }
 
 };

--- a/views/reports-vat.pug
+++ b/views/reports-vat.pug
@@ -5,6 +5,7 @@ block content
         script.
             var vatRowsFromServer = !{JSON.stringify(vatRows)}
             var vatTotalsFromServer = !{JSON.stringify(vatTotals)}
+            var chargeTypesFromServer = !{JSON.stringify(chargeTypes)}
 
             document.addEventListener('DOMContentLoaded', function() {
                 renderVatTable();
@@ -13,6 +14,7 @@ block content
             function renderVatTable() {
                 var rows = vatRowsFromServer;
                 var totals = vatTotalsFromServer;
+                var chargeTypes = chargeTypesFromServer;
 
                 if (!rows || rows.length === 0) {
                     document.getElementById('vat-table-container').innerHTML =
@@ -28,18 +30,26 @@ block content
                     }).format(parseFloat(v) || 0);
                 };
 
+                var thStyle = "border:1px solid #000;text-align:center;";
+                var toTitleCase = function(ct) {
+                    return ct.replace(/_/g, ' ').replace(/\w+/g, function(w) {
+                        return w.charAt(0).toUpperCase() + w.slice(1).toLowerCase();
+                    });
+                };
+
                 var html = "<table class='table table-bordered table-sm' style='width:100%;border:1px solid #000;font-size:13px;'>";
                 html += "<thead class='thead-light'><tr>";
-                html += "<th style='border:1px solid #000;text-align:center;'>Sl No</th>";
-                html += "<th style='border:1px solid #000;'>Name</th>";
-                html += "<th style='border:1px solid #000;text-align:center;'>TIN No</th>";
-                html += "<th style='border:1px solid #000;text-align:center;'>HSN Code</th>";
-                html += "<th style='border:1px solid #000;'>Invoice No</th>";
-                html += "<th style='border:1px solid #000;text-align:center;'>Invoice Date</th>";
-                html += "<th style='border:1px solid #000;text-align:right;'>Value</th>";
-                html += "<th style='border:1px solid #000;text-align:center;'>Tax Rate</th>";
-                html += "<th style='border:1px solid #000;text-align:right;'>VAT</th>";
-                html += "<th style='border:1px solid #000;text-align:right;'>Addition VAT</th>";
+                html += "<th style='" + thStyle + "'>Sl No</th>";
+                html += "<th style='" + thStyle + "'>Name</th>";
+                html += "<th style='" + thStyle + "'>TIN No</th>";
+                html += "<th style='" + thStyle + "'>HSN Code</th>";
+                html += "<th style='" + thStyle + "'>Invoice No</th>";
+                html += "<th style='" + thStyle + "'>Invoice Date</th>";
+                html += "<th style='" + thStyle + "'>Value</th>";
+                html += "<th style='" + thStyle + "'>Tax Rate</th>";
+                chargeTypes.forEach(function(ct) {
+                    html += "<th style='" + thStyle + "'>" + toTitleCase(ct) + "</th>";
+                });
                 html += "</tr></thead><tbody>";
 
                 rows.forEach(function(row) {
@@ -52,8 +62,9 @@ block content
                     html += "<td style='border:1px solid #000;text-align:center;'>" + (row['Invoice Date'] || '-') + "</td>";
                     html += "<td style='border:1px solid #000;text-align:right;'>" + fmt(row['Value']) + "</td>";
                     html += "<td style='border:1px solid #000;text-align:center;'>" + (row['Tax Rate'] || 0) + "</td>";
-                    html += "<td style='border:1px solid #000;text-align:right;'>" + fmt(row['VAT']) + "</td>";
-                    html += "<td style='border:1px solid #000;text-align:right;'>" + fmt(row['Addition VAT']) + "</td>";
+                    chargeTypes.forEach(function(ct) {
+                        html += "<td style='border:1px solid #000;text-align:right;'>" + fmt(row[ct]) + "</td>";
+                    });
                     html += "</tr>";
                 });
 
@@ -62,8 +73,9 @@ block content
                 html += "<td colspan='6' style='border:1px solid #000;text-align:right;'>Total</td>";
                 html += "<td style='border:1px solid #000;text-align:right;'>" + fmt(totals.total_value) + "</td>";
                 html += "<td style='border:1px solid #000;'></td>";
-                html += "<td style='border:1px solid #000;text-align:right;'>" + fmt(totals.total_vat) + "</td>";
-                html += "<td style='border:1px solid #000;text-align:right;'>" + fmt(totals.total_add_vat) + "</td>";
+                chargeTypes.forEach(function(ct) {
+                    html += "<td style='border:1px solid #000;text-align:right;'>" + fmt(totals[ct]) + "</td>";
+                });
                 html += "</tr>";
 
                 html += "</tbody></table>";


### PR DESCRIPTION
## Summary
- Replaced hard-coded VAT / Additional VAT columns with dynamic columns sourced from `t_tank_invoice_charges`
- Any charge type present in the selected period (e.g. DLY for BPCL, VAT, Additional VAT) appears as its own column automatically
- Column headers are center-aligned and displayed in title case
- Excel export updated to match

## Test plan
- [ ] Load VAT report for a BPCL location — verify DLY column appears alongside VAT and Additional Vat
- [ ] Load VAT report for an IOCL location — verify only the charge columns that exist for that period appear
- [ ] Export to Excel — confirm dynamic columns render correctly
- [ ] Total row sums correctly for each charge column

🤖 Generated with [Claude Code](https://claude.com/claude-code)