### PR TITLE
GL accounting: product ledger mapping UI

### DIFF
--- a/dao/product-dao.js
+++ b/dao/product-dao.js
@@ -60,12 +60,13 @@ module.exports = {
         
         const baseQuery = {
             attributes: [
-                'product_id', 
-                'product_name', 
-                'qty', 
-                'unit', 
+                'product_id',
+                'product_name',
+                'qty',
+                'unit',
                 'price',
                 'ledger_name',
+                'purchase_ledger_name',
                 'cgst_percent',
                 'sgst_percent',
                 'sku_name',
@@ -202,6 +203,7 @@ findPumpProducts: async (locationCode) => {
             price: product.price,
             unit: product.unit,
             ledger_name: product.ledger_name,
+            purchase_ledger_name: product.purchase_ledger_name,
             cgst_percent: product.cgst_percent,
             sgst_percent: product.sgst_percent,
             updated_by: product.updated_by,

--- a/db/product.js
+++ b/db/product.js
@@ -50,6 +50,10 @@ module.exports = function(sequelize, DataTypes) {
             type: DataTypes.STRING(100),
             allowNull: true
         },
+        purchase_ledger_name: {
+            type: DataTypes.STRING(100),
+            allowNull: true
+        },
         cgst_percent: {
             type: DataTypes.DECIMAL(5, 2),
             allowNull: true

--- a/db/ui-db-field-mapping.js
+++ b/db/ui-db-field-mapping.js
@@ -15,6 +15,7 @@ module.exports = {
         unit: req.body.m_product_unit_0,
         price: req.body.m_product_price_0,
         ledger_name: req.body.m_product_ledger_name_0,
+        purchase_ledger_name: req.body.m_product_purchase_ledger_name_0,
         cgst_percent: req.body.m_product_cgst_0,
         sgst_percent: req.body.m_product_sgst_0,
         sku_name: req.body.m_product_sku_name_0,

--- a/routes/products-routes.js
+++ b/routes/products-routes.js
@@ -8,6 +8,7 @@ const ProductDao = require('../dao/product-dao');
 const dbMapping = require("../db/ui-db-field-mapping")
 const config = require('../config/app-config');
 const locationConfigDao = require('../dao/location-config-dao');
+const { getLedgersByGroup } = require('./gl-routes');
 
 const PRODUCT_NAME_EDITABLE_SETTING = 'PRODUCT_NAME_EDITABLE';
 
@@ -22,10 +23,12 @@ router.get('/', [isLoginEnsured, security.isAdmin()], async function (req, res, 
     const locationCode = req.user.location_code;
     let products = [];
     try {
-        const [data, editableSetting, pumpLinkedNames] = await Promise.all([
+        const [data, editableSetting, pumpLinkedNames, salesLedgers, purchaseLedgers] = await Promise.all([
             ProductDao.findProducts(locationCode),
             locationConfigDao.getSetting(locationCode, PRODUCT_NAME_EDITABLE_SETTING),
-            ProductDao.findPumpLinkedProductNames(locationCode)
+            ProductDao.findPumpLinkedProductNames(locationCode),
+            getLedgersByGroup(locationCode, 'Sales Accounts'),
+            getLedgersByGroup(locationCode, 'Purchase Accounts')
         ]);
         const canEditProductName = isTruthySetting(editableSetting);
         const pumpLinkedSet = new Set(pumpLinkedNames);
@@ -39,6 +42,7 @@ router.get('/', [isLoginEnsured, security.isAdmin()], async function (req, res, 
                 qty: product.qty,
                 price: product.price,
                 ledger_name: product.ledger_name,
+                purchase_ledger_name: product.purchase_ledger_name,
                 cgst_percent: product.cgst_percent,
                 sgst_percent: product.sgst_percent,
                 sku_name: product.sku_name,
@@ -50,12 +54,14 @@ router.get('/', [isLoginEnsured, security.isAdmin()], async function (req, res, 
             });
         });
 
-        res.render('products', { 
-            title: 'Products', 
-            user: req.user, 
-            products: products, 
+        res.render('products', {
+            title: 'Products',
+            user: req.user,
+            products: products,
             config: config.APP_CONFIGS,
             canEditProductName: canEditProductName,
+            salesLedgers: salesLedgers,
+            purchaseLedgers: purchaseLedgers,
             messages: req.flash()
         });
     } catch (error) {
@@ -78,6 +84,7 @@ router.get('/api/data', [isLoginEnsured, security.isAdmin()], function (req, res
                 qty: product.qty,
                 price: product.price,
                 ledger_name: product.ledger_name,
+                purchase_ledger_name: product.purchase_ledger_name,
                 cgst_percent: product.cgst_percent,
                 sgst_percent: product.sgst_percent,
                 sku_name: product.sku_name,
@@ -115,6 +122,7 @@ router.post('/api', [isLoginEnsured, security.isAdmin()], function (req, res, ne
                 m_product_unit_0: req.body.unit,
                 m_product_price_0: req.body.price,
                 m_product_ledger_name_0: req.body.ledger_name,
+                m_product_purchase_ledger_name_0: req.body.purchase_ledger_name,
                 m_product_cgst_0: req.body.cgst_percent || 0,
                 m_product_sgst_0: req.body.sgst_percent || 0,
                 m_product_sku_name_0: req.body.sku_name || '',
@@ -199,6 +207,7 @@ router.put('/api/:id', [isLoginEnsured, security.isAdmin()], async function (req
             price: req.body.m_product_price,
             unit: req.body.m_product_unit,
             ledger_name: req.body.m_product_ledger_name,
+            purchase_ledger_name: req.body.m_product_purchase_ledger_name,
             cgst_percent: req.body.m_product_cgst,
             sgst_percent: req.body.m_product_sgst,
             is_tank_product: req.body.m_product_is_tank_product,

--- a/views/products.pug
+++ b/views/products.pug
@@ -47,7 +47,7 @@ block content
                             th(scope="col") Edit
                     tbody
                         each val, index in products
-                            - const productPayload = encodeURIComponent(JSON.stringify({ id: val.id, name: val.name, sku_name: val.sku_name || '', sku_number: val.sku_number || '', hsn_code: val.hsn_code || '', unit: val.unit || '', price: val.price || '', ledger_name: val.ledger_name || '', cgst_percent: val.cgst_percent || 0, sgst_percent: val.sgst_percent || 0, is_tank_product: val.is_tank_product ? 1 : 0, is_lube_product: val.is_lube_product ? 1 : 0, can_edit_name: val.can_edit_name ? 1 : 0 }))
+                            - const productPayload = encodeURIComponent(JSON.stringify({ id: val.id, name: val.name, sku_name: val.sku_name || '', sku_number: val.sku_number || '', hsn_code: val.hsn_code || '', unit: val.unit || '', price: val.price || '', ledger_name: val.ledger_name || '', purchase_ledger_name: val.purchase_ledger_name || '', cgst_percent: val.cgst_percent || 0, sgst_percent: val.sgst_percent || 0, is_tank_product: val.is_tank_product ? 1 : 0, is_lube_product: val.is_lube_product ? 1 : 0, can_edit_name: val.can_edit_name ? 1 : 0 }))
                             tr(id=`product-row-${index}`)
                                 th(scope="row")= index + 1
                                 td(scope="row")
@@ -106,7 +106,7 @@ block content
         .mobile-cards-view.d-block.d-lg-none
             .row
                 each val, index in products
-                    - const mobileProductPayload = encodeURIComponent(JSON.stringify({ id: val.id, name: val.name, sku_name: val.sku_name || '', sku_number: val.sku_number || '', hsn_code: val.hsn_code || '', unit: val.unit || '', price: val.price || '', ledger_name: val.ledger_name || '', cgst_percent: val.cgst_percent || 0, sgst_percent: val.sgst_percent || 0, is_tank_product: val.is_tank_product ? 1 : 0, is_lube_product: val.is_lube_product ? 1 : 0, can_edit_name: val.can_edit_name ? 1 : 0 }))
+                    - const mobileProductPayload = encodeURIComponent(JSON.stringify({ id: val.id, name: val.name, sku_name: val.sku_name || '', sku_number: val.sku_number || '', hsn_code: val.hsn_code || '', unit: val.unit || '', price: val.price || '', ledger_name: val.ledger_name || '', purchase_ledger_name: val.purchase_ledger_name || '', cgst_percent: val.cgst_percent || 0, sgst_percent: val.sgst_percent || 0, is_tank_product: val.is_tank_product ? 1 : 0, is_lube_product: val.is_lube_product ? 1 : 0, can_edit_name: val.can_edit_name ? 1 : 0 }))
                     .col-12.mb-3
                         .card.product-card.shadow-sm(id=`mobile-product-card-${index}`)
                             .card-header.d-flex.justify-content-between.align-items-center
@@ -278,9 +278,18 @@ block content
                             .col-md-6.mb-3
                                 label.form-label Price
                                 input.form-control(type="number", name="price", step="0.01", required)
-                            .col-md-12.mb-3
-                                label.form-label Ledger Name
-                                input.form-control.text-uppercase(type="text", name="ledger_name", style="text-transform: uppercase;")
+                            .col-md-6.mb-3
+                                label.form-label Sales Ledger
+                                select.form-control(name="ledger_name")
+                                    option(value="") — Not Set —
+                                    each l in salesLedgers
+                                        option(value=l.ledger_name)= l.ledger_name
+                            .col-md-6.mb-3
+                                label.form-label Purchase Ledger
+                                select.form-control(name="purchase_ledger_name")
+                                    option(value="") — Not Set —
+                                    each l in purchaseLedgers
+                                        option(value=l.ledger_name)= l.ledger_name
                             .col-md-6.mb-3
                                 label.form-label CGST %
                                 input.form-control(type="number", name="cgst_percent", step="0.01", min="0", max="100")
@@ -346,9 +355,18 @@ block content
                             .col-md-6.mb-3
                                 label.form-label Price
                                 input#edit-price.form-control(type="number", step="0.01")
-                            .col-md-12.mb-3
-                                label.form-label Ledger Name
-                                input#edit-ledger-name.form-control.text-uppercase(type="text", style="text-transform: uppercase;")
+                            .col-md-6.mb-3
+                                label.form-label Sales Ledger
+                                select#edit-ledger-name.form-control
+                                    option(value="") — Not Set —
+                                    each l in salesLedgers
+                                        option(value=l.ledger_name)= l.ledger_name
+                            .col-md-6.mb-3
+                                label.form-label Purchase Ledger
+                                select#edit-purchase-ledger-name.form-control
+                                    option(value="") — Not Set —
+                                    each l in purchaseLedgers
+                                        option(value=l.ledger_name)= l.ledger_name
                             .col-md-6.mb-3
                                 label.form-label CGST %
                                 input#edit-cgst.form-control(type="number", step="0.01", min="0", max="100")
@@ -556,6 +574,7 @@ block content
             document.getElementById('edit-unit').value = product.unit || '';
             document.getElementById('edit-price').value = product.price || '';
             document.getElementById('edit-ledger-name').value = product.ledger_name || '';
+            document.getElementById('edit-purchase-ledger-name').value = product.purchase_ledger_name || '';
             document.getElementById('edit-cgst').value = product.cgst_percent || 0;
             document.getElementById('edit-sgst').value = product.sgst_percent || 0;
 
@@ -600,7 +619,8 @@ block content
                 m_product_name: document.getElementById('edit-product-name').value.toUpperCase().trim(),
                 m_product_price: document.getElementById('edit-price').value,
                 m_product_unit: document.getElementById('edit-unit').value.toUpperCase(),
-                m_product_ledger_name: document.getElementById('edit-ledger-name').value.toUpperCase(),
+                m_product_ledger_name: ($('#edit-ledger-name').val() || '').toUpperCase(),
+                m_product_purchase_ledger_name: ($('#edit-purchase-ledger-name').val() || '').toUpperCase(),
                 m_product_cgst: document.getElementById('edit-cgst').value,
                 m_product_sgst: document.getElementById('edit-sgst').value
             };
@@ -663,6 +683,8 @@ block content
         // Event listeners
         document.addEventListener('DOMContentLoaded', function() {
             document.getElementById('refreshDataBtn').addEventListener('click', refreshData);
+
+
             
             // Add uppercase event listeners to all text inputs in the modal
             const textInputs = document.querySelectorAll('input[type="text"].text-uppercase');


### PR DESCRIPTION
## Summary
- Adds `purchase_ledger_name` field to `m_product` (model, DAO, form mapping)
- Products page now renders Sales/Purchase ledger dropdowns as plain server-side selects populated from `gl_ledgers` (Sales Accounts / Purchase Accounts groups)
- Replaces previous Select2 AJAX typeahead — ledger must exist in ledger master before it can be assigned to a product

## Test plan
- [ ] Open Products page — both ledger dropdowns appear populated
- [ ] Add a new product, assign ledgers, save — verify `gl_product_ledger_map` row created via trigger
- [ ] Edit an existing product, change ledger — verify `gl_product_ledger_map_h` history row written

🤖 Generated with [Claude Code](https://claude.com/claude-code)