### PR TITLE
GL accounting: GST split, Output CGST/SGST ledgers, product ledger map UI

### DIFF
--- a/dao/product-ledger-map-dao.js
+++ b/dao/product-ledger-map-dao.js
@@ -1,0 +1,66 @@
+const db = require('../db/db-connection');
+const { QueryTypes } = require('sequelize');
+
+const VALID_MAP_TYPES = ['SALES', 'PURCHASE', 'OUTPUT_CGST', 'OUTPUT_SGST'];
+
+module.exports = {
+
+    getAllMappings: async (locationCode) => {
+        return db.sequelize.query(`
+            SELECT
+                p.product_id,
+                p.product_name,
+                p.cgst_percent,
+                p.sgst_percent,
+                p.is_lube_product,
+                MAX(CASE WHEN plm.map_type = 'SALES'       THEN plm.ledger_id END) AS sales_ledger_id,
+                MAX(CASE WHEN plm.map_type = 'PURCHASE'    THEN plm.ledger_id END) AS purchase_ledger_id,
+                MAX(CASE WHEN plm.map_type = 'OUTPUT_CGST' THEN plm.ledger_id END) AS output_cgst_ledger_id,
+                MAX(CASE WHEN plm.map_type = 'OUTPUT_SGST' THEN plm.ledger_id END) AS output_sgst_ledger_id
+            FROM m_product p
+            LEFT JOIN gl_product_ledger_map plm
+                   ON plm.product_id    = p.product_id
+                  AND plm.location_code = :locationCode
+            WHERE p.location_code = :locationCode
+            GROUP BY p.product_id, p.product_name, p.cgst_percent, p.sgst_percent, p.is_lube_product
+            ORDER BY p.is_lube_product DESC, p.product_name
+        `, {
+            replacements: { locationCode },
+            type: QueryTypes.SELECT
+        });
+    },
+
+    upsertMapping: async (locationCode, productId, mapType, ledgerId, updatedBy) => {
+        if (!VALID_MAP_TYPES.includes(mapType)) {
+            throw new Error(`Invalid map_type: ${mapType}`);
+        }
+        await db.sequelize.query(`
+            INSERT INTO gl_product_ledger_map
+                (location_code, product_id, map_type, ledger_id, created_by, updated_by)
+            VALUES
+                (:locationCode, :productId, :mapType, :ledgerId, :updatedBy, :updatedBy)
+            ON DUPLICATE KEY UPDATE
+                ledger_id  = :ledgerId,
+                updated_by = :updatedBy
+        `, {
+            replacements: { locationCode, productId, mapType, ledgerId, updatedBy },
+            type: QueryTypes.INSERT
+        });
+    },
+
+    deleteMapping: async (locationCode, productId, mapType) => {
+        if (!VALID_MAP_TYPES.includes(mapType)) {
+            throw new Error(`Invalid map_type: ${mapType}`);
+        }
+        await db.sequelize.query(`
+            DELETE FROM gl_product_ledger_map
+            WHERE location_code = :locationCode
+              AND product_id    = :productId
+              AND map_type      = :mapType
+        `, {
+            replacements: { locationCode, productId, mapType },
+            type: QueryTypes.DELETE
+        });
+    }
+
+};

--- a/db/migrations/gl-output-gst-ledgers.sql
+++ b/db/migrations/gl-output-gst-ledgers.sql
@@ -1,0 +1,163 @@
+-- ============================================================
+-- GL Output GST Ledgers
+-- Generated: 2026-05-01
+--
+-- Seeds OUTPUT CGST and OUTPUT SGST ledgers under the
+-- "Duties & Taxes" group for every location that does not
+-- already have them.
+--
+-- Also extends trg_location_seed_data to create these two
+-- ledgers automatically when a new location is added.
+-- ============================================================
+
+-- ── Backfill all existing locations ──────────────────────────────────────────
+
+INSERT INTO gl_ledgers (location_code, ledger_name, group_id, active_flag, created_by, updated_by)
+SELECT g.location_code, 'OUTPUT CGST', g.group_id, 'Y', 'system', 'system'
+FROM gl_ledger_groups g
+WHERE g.group_name = 'Duties & Taxes'
+  AND NOT EXISTS (
+      SELECT 1 FROM gl_ledgers l
+      WHERE l.location_code = g.location_code
+        AND l.ledger_name   = 'OUTPUT CGST'
+  );
+
+INSERT INTO gl_ledgers (location_code, ledger_name, group_id, active_flag, created_by, updated_by)
+SELECT g.location_code, 'OUTPUT SGST', g.group_id, 'Y', 'system', 'system'
+FROM gl_ledger_groups g
+WHERE g.group_name = 'Duties & Taxes'
+  AND NOT EXISTS (
+      SELECT 1 FROM gl_ledgers l
+      WHERE l.location_code = g.location_code
+        AND l.ledger_name   = 'OUTPUT SGST'
+  );
+
+-- ── Extend trg_location_seed_data ────────────────────────────────────────────
+
+DROP TRIGGER IF EXISTS trg_location_seed_data;
+
+DELIMITER $$
+
+CREATE TRIGGER trg_location_seed_data
+AFTER INSERT ON m_location
+FOR EACH ROW
+BEGIN
+    DECLARE v_supplier_id     INT;
+    DECLARE v_template_id     INT;
+    DECLARE v_bank_name       VARCHAR(150);
+    DECLARE v_supplier_name   VARCHAR(200);
+    DECLARE v_dt_group_id     INT;
+
+    IF @disable_triggers IS NULL OR @disable_triggers = 0 THEN
+
+        -- Insert Petty Cash Expenses
+        INSERT INTO m_expense
+            (Expense_name, location_code, Expense_default_amt, created_by, updated_by, updation_date, creation_date)
+        VALUES
+            ('Tiffin',         NEW.location_code, 200, 'admin', 'admin', NOW(), NOW()),
+            ('Tea',            NEW.location_code,  30, 'admin', 'admin', NOW(), NOW()),
+            ('Bus Fare',       NEW.location_code,  30, 'admin', 'admin', NOW(), NOW()),
+            ('TT Driver Batta',NEW.location_code, 100, 'admin', 'admin', NOW(), NOW()),
+            ('Others',         NEW.location_code,   0, 'admin', 'admin', NOW(), NOW());
+
+        -- Insert Lookup defaults
+        INSERT INTO m_lookup
+            (lookup_type, description, tag, start_date_active, end_date_active,
+             attribute1, attribute2, attribute3, attribute4, attribute5,
+             created_by, updated_by, updation_date, creation_date, location_code, tally_export)
+        VALUES
+            ('CashFlow', 'To Bank',           'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Cashier A/C (+)',   'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Cashier A/C (-)',   'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Cash Receipt',      'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Collection',        'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Balance B/F',       'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Expense',           'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'To WithDrawals',    'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'To Deposits',       'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Shift Opening',     'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'To Bank',           'OUT', '2024-06-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Shift Cash Return', 'IN',  '2025-04-08', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Salary Payout',     'OUT', '2024-04-01', NULL, '200', NULL, NULL, NULL, 'SALARY EXPENSES', 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Salary Recovery',   'IN',  '2024-04-01', NULL, NULL, NULL, NULL, NULL, 'SALARY EXPENSES', 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Discount',          'OUT', '2025-10-30', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y');
+
+        -- Seed Output GST ledgers under Duties & Taxes
+        SELECT group_id INTO v_dt_group_id
+        FROM gl_ledger_groups
+        WHERE location_code = NEW.location_code
+          AND group_name    = 'Duties & Taxes'
+        LIMIT 1;
+
+        IF v_dt_group_id IS NOT NULL THEN
+            INSERT INTO gl_ledgers (location_code, ledger_name, group_id, active_flag, created_by, updated_by)
+            VALUES (NEW.location_code, 'OUTPUT CGST', v_dt_group_id, 'Y', 'system', 'system');
+
+            INSERT INTO gl_ledgers (location_code, ledger_name, group_id, active_flag, created_by, updated_by)
+            VALUES (NEW.location_code, 'OUTPUT SGST', v_dt_group_id, 'Y', 'system', 'system');
+        END IF;
+
+        -- Auto-create oil company supplier + SOA bank
+        -- The after_supplier_insert_ledger_rule trigger on m_supplier fires automatically.
+        IF NEW.company_name IN ('IOCL', 'BPCL', 'HPCL', 'NAYARA') THEN
+
+            SET v_supplier_name = CASE NEW.company_name
+                WHEN 'IOCL'   THEN 'Indian Oil Corporation Limited'
+                WHEN 'BPCL'   THEN 'Bharat Petroleum Corporation Limited'
+                WHEN 'HPCL'   THEN 'Hindustan Petroleum Corporation Limited'
+                WHEN 'NAYARA' THEN 'Nayara Energy Limited'
+            END;
+
+            SET v_bank_name = CASE NEW.company_name
+                WHEN 'IOCL'   THEN 'IOCL-SOA'
+                WHEN 'BPCL'   THEN 'BPCL-SOA'
+                WHEN 'HPCL'   THEN 'HPCL-SOA'
+                WHEN 'NAYARA' THEN 'NAYARA-SOA'
+            END;
+
+            -- template_id=2: IOCL SAP Account Statement
+            -- template_id=6: BPCL SAP SOA Format
+            SET v_template_id = CASE NEW.company_name
+                WHEN 'IOCL'   THEN 2
+                WHEN 'BPCL'   THEN 6
+                ELSE NULL
+            END;
+
+            INSERT INTO m_supplier
+                (supplier_name, supplier_short_name, location_id, location_code,
+                 created_by, updated_by, creation_date, updation_date)
+            VALUES (
+                v_supplier_name,
+                NEW.company_name,
+                NEW.location_id,
+                NEW.location_code,
+                'system', 'system', NOW(), NOW()
+            );
+
+            SET v_supplier_id = LAST_INSERT_ID();
+
+            INSERT INTO m_bank
+                (bank_name, bank_branch, account_number, ifsc_code,
+                 location_code, location_id, is_oil_company, active_flag, internal_flag,
+                 template_id, supplier_id, created_by, updated_by)
+            VALUES (
+                v_bank_name, 'N/A', 'N/A', 'N/A',
+                NEW.location_code, NEW.location_id, 'Y', 'Y', 'N',
+                v_template_id, v_supplier_id, 'system', 'system'
+            );
+
+        END IF;
+
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SELECT location_code,
+       SUM(CASE WHEN ledger_name = 'OUTPUT CGST' THEN 1 ELSE 0 END) AS has_cgst,
+       SUM(CASE WHEN ledger_name = 'OUTPUT SGST' THEN 1 ELSE 0 END) AS has_sgst
+FROM gl_ledgers
+WHERE ledger_name IN ('OUTPUT CGST', 'OUTPUT SGST')
+GROUP BY location_code
+ORDER BY location_code;

--- a/db/migrations/gl-product-gst-ledger-map.sql
+++ b/db/migrations/gl-product-gst-ledger-map.sql
@@ -1,0 +1,65 @@
+-- ============================================================
+-- GL Product GST Ledger Map
+-- Generated: 2026-05-01
+--
+-- Seeds OUTPUT_CGST and OUTPUT_SGST rows in gl_product_ledger_map
+-- for every product that has cgst_percent > 0 and already has
+-- a SALES mapping, pointing to the OUTPUT CGST / OUTPUT SGST
+-- ledgers under Duties & Taxes for that location.
+--
+-- Safe to re-run: INSERT IGNORE skips duplicates.
+-- ============================================================
+
+-- ── OUTPUT_CGST mappings ──────────────────────────────────────────────────────
+
+INSERT IGNORE INTO gl_product_ledger_map (location_code, product_id, map_type, ledger_id)
+SELECT
+    plm.location_code,
+    plm.product_id,
+    'OUTPUT_CGST',
+    gst_l.ledger_id
+FROM gl_product_ledger_map plm
+JOIN m_product mp ON mp.product_id = plm.product_id
+JOIN gl_ledgers gst_l ON gst_l.location_code = plm.location_code
+                      AND gst_l.ledger_name   = 'OUTPUT CGST'
+JOIN gl_ledger_groups g ON g.group_id = gst_l.group_id
+                        AND g.group_name = 'Duties & Taxes'
+WHERE plm.map_type      = 'SALES'
+  AND mp.cgst_percent   > 0;
+
+-- ── OUTPUT_SGST mappings ──────────────────────────────────────────────────────
+
+INSERT IGNORE INTO gl_product_ledger_map (location_code, product_id, map_type, ledger_id)
+SELECT
+    plm.location_code,
+    plm.product_id,
+    'OUTPUT_SGST',
+    gst_l.ledger_id
+FROM gl_product_ledger_map plm
+JOIN m_product mp ON mp.product_id = plm.product_id
+JOIN gl_ledgers gst_l ON gst_l.location_code = plm.location_code
+                      AND gst_l.ledger_name   = 'OUTPUT SGST'
+JOIN gl_ledger_groups g ON g.group_id = gst_l.group_id
+                        AND g.group_name = 'Duties & Taxes'
+WHERE plm.map_type      = 'SALES'
+  AND mp.cgst_percent   > 0;
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SELECT map_type, COUNT(*) AS rows_inserted
+FROM gl_product_ledger_map
+WHERE map_type IN ('OUTPUT_CGST', 'OUTPUT_SGST')
+GROUP BY map_type;
+
+-- Spot check: products with SALES but missing OUTPUT_CGST (should be 0 or only cgst=0 products)
+SELECT plm.location_code, plm.product_id, mp.product_name, mp.cgst_percent
+FROM gl_product_ledger_map plm
+JOIN m_product mp ON mp.product_id = plm.product_id
+WHERE plm.map_type    = 'SALES'
+  AND mp.cgst_percent > 0
+  AND NOT EXISTS (
+      SELECT 1 FROM gl_product_ledger_map plm2
+      WHERE plm2.location_code = plm.location_code
+        AND plm2.product_id    = plm.product_id
+        AND plm2.map_type      = 'OUTPUT_CGST'
+  )
+ORDER BY plm.location_code, mp.product_name;

--- a/db/migrations/gst-split-triggers.sql
+++ b/db/migrations/gst-split-triggers.sql
@@ -1,0 +1,248 @@
+-- ============================================================
+-- GST Split Triggers
+-- Generated: 2026-05-01
+--
+-- Automatically populates GST fields on t_credits and t_cashsales
+-- on every INSERT and UPDATE, by looking up the product's
+-- cgst_percent / sgst_percent from m_product.
+--
+-- Fields populated:
+--   cgst_percent  ← m_product.cgst_percent
+--   sgst_percent  ← m_product.sgst_percent
+--   base_amount   = amount / (1 + (cgst + sgst) / 100)   [GST-exclusive]
+--   cgst_amount   = base_amount × cgst_percent / 100
+--   sgst_amount   = base_amount × sgst_percent / 100
+--
+-- For fuel (cgst_percent = 0 or NULL):
+--   base_amount = amount, all tax fields = 0
+--
+-- Fires on every INSERT and every UPDATE so corrections to amount
+-- or product_id are always reflected in the tax fields.
+--
+-- Gated by @disable_triggers: SET @disable_triggers = 1 before any
+-- bulk operation (backfill, data migration, dev refresh restore) to
+-- skip per-row lookups. Reset to 0 or NULL when done.
+-- ============================================================
+
+DROP TRIGGER IF EXISTS trg_credits_gst_before_insert;
+DROP TRIGGER IF EXISTS trg_credits_gst_before_update;
+DROP TRIGGER IF EXISTS trg_cashsales_gst_before_insert;
+DROP TRIGGER IF EXISTS trg_cashsales_gst_before_update;
+
+DELIMITER $$
+
+-- ── t_credits : BEFORE INSERT ─────────────────────────────────────────────────
+
+CREATE TRIGGER trg_credits_gst_before_insert
+BEFORE INSERT ON t_credits
+FOR EACH ROW
+BEGIN
+    DECLARE v_cgst DECIMAL(5,2) DEFAULT 0;
+    DECLARE v_sgst DECIMAL(5,2) DEFAULT 0;
+    DECLARE v_base DECIMAL(15,3);
+
+    IF @disable_triggers IS NULL OR @disable_triggers = 0 THEN
+
+        SELECT COALESCE(cgst_percent, 0), COALESCE(sgst_percent, 0)
+        INTO   v_cgst, v_sgst
+        FROM   m_product
+        WHERE  product_id = NEW.product_id
+        LIMIT 1;
+
+        SET NEW.cgst_percent = v_cgst;
+        SET NEW.sgst_percent = v_sgst;
+
+        IF v_cgst > 0 OR v_sgst > 0 THEN
+            SET v_base           = COALESCE(NEW.amount, 0) / (1 + (v_cgst + v_sgst) / 100);
+            SET NEW.base_amount  = ROUND(v_base, 3);
+            SET NEW.cgst_amount  = ROUND(v_base * v_cgst / 100, 3);
+            SET NEW.sgst_amount  = ROUND(v_base * v_sgst / 100, 3);
+        ELSE
+            SET NEW.base_amount  = COALESCE(NEW.amount, 0);
+            SET NEW.cgst_amount  = 0;
+            SET NEW.sgst_amount  = 0;
+        END IF;
+
+    END IF;
+END$$
+
+-- ── t_credits : BEFORE UPDATE ─────────────────────────────────────────────────
+
+CREATE TRIGGER trg_credits_gst_before_update
+BEFORE UPDATE ON t_credits
+FOR EACH ROW
+BEGIN
+    DECLARE v_cgst DECIMAL(5,2) DEFAULT 0;
+    DECLARE v_sgst DECIMAL(5,2) DEFAULT 0;
+    DECLARE v_base DECIMAL(15,3);
+
+    IF @disable_triggers IS NULL OR @disable_triggers = 0 THEN
+
+        SELECT COALESCE(cgst_percent, 0), COALESCE(sgst_percent, 0)
+        INTO   v_cgst, v_sgst
+        FROM   m_product
+        WHERE  product_id = NEW.product_id
+        LIMIT 1;
+
+        SET NEW.cgst_percent = v_cgst;
+        SET NEW.sgst_percent = v_sgst;
+
+        IF v_cgst > 0 OR v_sgst > 0 THEN
+            SET v_base           = COALESCE(NEW.amount, 0) / (1 + (v_cgst + v_sgst) / 100);
+            SET NEW.base_amount  = ROUND(v_base, 3);
+            SET NEW.cgst_amount  = ROUND(v_base * v_cgst / 100, 3);
+            SET NEW.sgst_amount  = ROUND(v_base * v_sgst / 100, 3);
+        ELSE
+            SET NEW.base_amount  = COALESCE(NEW.amount, 0);
+            SET NEW.cgst_amount  = 0;
+            SET NEW.sgst_amount  = 0;
+        END IF;
+
+    END IF;
+END$$
+
+-- ── t_cashsales : BEFORE INSERT ───────────────────────────────────────────────
+
+CREATE TRIGGER trg_cashsales_gst_before_insert
+BEFORE INSERT ON t_cashsales
+FOR EACH ROW
+BEGIN
+    DECLARE v_cgst DECIMAL(5,2) DEFAULT 0;
+    DECLARE v_sgst DECIMAL(5,2) DEFAULT 0;
+    DECLARE v_base DECIMAL(15,3);
+
+    IF @disable_triggers IS NULL OR @disable_triggers = 0 THEN
+
+        SELECT COALESCE(cgst_percent, 0), COALESCE(sgst_percent, 0)
+        INTO   v_cgst, v_sgst
+        FROM   m_product
+        WHERE  product_id = NEW.product_id
+        LIMIT 1;
+
+        SET NEW.cgst_percent = v_cgst;
+        SET NEW.sgst_percent = v_sgst;
+
+        IF v_cgst > 0 OR v_sgst > 0 THEN
+            SET v_base           = COALESCE(NEW.amount, 0) / (1 + (v_cgst + v_sgst) / 100);
+            SET NEW.base_amount  = ROUND(v_base, 3);
+            SET NEW.cgst_amount  = ROUND(v_base * v_cgst / 100, 3);
+            SET NEW.sgst_amount  = ROUND(v_base * v_sgst / 100, 3);
+        ELSE
+            SET NEW.base_amount  = COALESCE(NEW.amount, 0);
+            SET NEW.cgst_amount  = 0;
+            SET NEW.sgst_amount  = 0;
+        END IF;
+
+    END IF;
+END$$
+
+-- ── t_cashsales : BEFORE UPDATE ───────────────────────────────────────────────
+
+CREATE TRIGGER trg_cashsales_gst_before_update
+BEFORE UPDATE ON t_cashsales
+FOR EACH ROW
+BEGIN
+    DECLARE v_cgst DECIMAL(5,2) DEFAULT 0;
+    DECLARE v_sgst DECIMAL(5,2) DEFAULT 0;
+    DECLARE v_base DECIMAL(15,3);
+
+    IF @disable_triggers IS NULL OR @disable_triggers = 0 THEN
+
+        SELECT COALESCE(cgst_percent, 0), COALESCE(sgst_percent, 0)
+        INTO   v_cgst, v_sgst
+        FROM   m_product
+        WHERE  product_id = NEW.product_id
+        LIMIT 1;
+
+        SET NEW.cgst_percent = v_cgst;
+        SET NEW.sgst_percent = v_sgst;
+
+        IF v_cgst > 0 OR v_sgst > 0 THEN
+            SET v_base           = COALESCE(NEW.amount, 0) / (1 + (v_cgst + v_sgst) / 100);
+            SET NEW.base_amount  = ROUND(v_base, 3);
+            SET NEW.cgst_amount  = ROUND(v_base * v_cgst / 100, 3);
+            SET NEW.sgst_amount  = ROUND(v_base * v_sgst / 100, 3);
+        ELSE
+            SET NEW.base_amount  = COALESCE(NEW.amount, 0);
+            SET NEW.cgst_amount  = 0;
+            SET NEW.sgst_amount  = 0;
+        END IF;
+
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- ── Backfill existing rows ────────────────────────────────────────────────────
+-- Disable triggers for bulk backfill, then re-enable.
+
+SET @disable_triggers = 1;
+
+-- t_credits backfill
+UPDATE t_credits tc
+JOIN m_product mp ON mp.product_id = tc.product_id
+SET
+    tc.cgst_percent = COALESCE(mp.cgst_percent, 0),
+    tc.sgst_percent = COALESCE(mp.sgst_percent, 0),
+    tc.base_amount  = CASE
+                        WHEN COALESCE(mp.cgst_percent, 0) + COALESCE(mp.sgst_percent, 0) > 0
+                        THEN ROUND(tc.amount / (1 + (COALESCE(mp.cgst_percent,0) + COALESCE(mp.sgst_percent,0)) / 100), 3)
+                        ELSE tc.amount
+                      END,
+    tc.cgst_amount  = CASE
+                        WHEN COALESCE(mp.cgst_percent, 0) > 0
+                        THEN ROUND(
+                               tc.amount / (1 + (COALESCE(mp.cgst_percent,0) + COALESCE(mp.sgst_percent,0)) / 100)
+                               * COALESCE(mp.cgst_percent,0) / 100, 3)
+                        ELSE 0
+                      END,
+    tc.sgst_amount  = CASE
+                        WHEN COALESCE(mp.sgst_percent, 0) > 0
+                        THEN ROUND(
+                               tc.amount / (1 + (COALESCE(mp.cgst_percent,0) + COALESCE(mp.sgst_percent,0)) / 100)
+                               * COALESCE(mp.sgst_percent,0) / 100, 3)
+                        ELSE 0
+                      END
+WHERE tc.cgst_percent IS NULL;
+
+-- t_cashsales backfill
+UPDATE t_cashsales cs
+JOIN m_product mp ON mp.product_id = cs.product_id
+SET
+    cs.cgst_percent = COALESCE(mp.cgst_percent, 0),
+    cs.sgst_percent = COALESCE(mp.sgst_percent, 0),
+    cs.base_amount  = CASE
+                        WHEN COALESCE(mp.cgst_percent, 0) + COALESCE(mp.sgst_percent, 0) > 0
+                        THEN ROUND(cs.amount / (1 + (COALESCE(mp.cgst_percent,0) + COALESCE(mp.sgst_percent,0)) / 100), 3)
+                        ELSE cs.amount
+                      END,
+    cs.cgst_amount  = CASE
+                        WHEN COALESCE(mp.cgst_percent, 0) > 0
+                        THEN ROUND(
+                               cs.amount / (1 + (COALESCE(mp.cgst_percent,0) + COALESCE(mp.sgst_percent,0)) / 100)
+                               * COALESCE(mp.cgst_percent,0) / 100, 3)
+                        ELSE 0
+                      END,
+    cs.sgst_amount  = CASE
+                        WHEN COALESCE(mp.sgst_percent, 0) > 0
+                        THEN ROUND(
+                               cs.amount / (1 + (COALESCE(mp.cgst_percent,0) + COALESCE(mp.sgst_percent,0)) / 100)
+                               * COALESCE(mp.sgst_percent,0) / 100, 3)
+                        ELSE 0
+                      END
+WHERE cs.cgst_percent IS NULL;
+
+SET @disable_triggers = 0;
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SHOW TRIGGERS WHERE `Table` IN ('t_credits', 't_cashsales') AND Timing = 'BEFORE';
+
+SELECT 't_credits backfill' AS tbl,
+       SUM(CASE WHEN cgst_percent > 0 THEN 1 ELSE 0 END) AS gst_rows,
+       SUM(CASE WHEN cgst_percent = 0 THEN 1 ELSE 0 END) AS non_gst_rows
+FROM t_credits
+UNION ALL
+SELECT 't_cashsales backfill',
+       SUM(CASE WHEN cgst_percent > 0 THEN 1 ELSE 0 END),
+       SUM(CASE WHEN cgst_percent = 0 THEN 1 ELSE 0 END)
+FROM t_cashsales;

--- a/db/migrations/location-seed-oil-company-supplier.sql
+++ b/db/migrations/location-seed-oil-company-supplier.sql
@@ -1,0 +1,113 @@
+-- Migration: Auto-create oil company supplier + SOA bank when a location is created
+-- Extends trg_location_seed_data to INSERT into m_supplier and m_bank based on company_name.
+-- The after_supplier_insert_ledger_rule trigger on m_supplier fires automatically,
+-- so the ledger rule is created at no extra cost.
+--
+-- Oil company mapping (m_location.company_name → supplier_name / bank_name / template_id):
+--   IOCL   → Indian Oil Corporation Limited   | IOCL-SOA  | template_id=2 (IOCL SAP Account Statement)
+--   BPCL   → Bharat Petroleum Corporation Ltd | BPCL-SOA  | template_id=6 (BPCL SAP SOA Format)
+--   HPCL   → Hindustan Petroleum Corp Ltd     | HPCL-SOA  | template_id=NULL (no template yet)
+--   NAYARA → Nayara Energy Limited             | NAYARA-SOA| template_id=NULL (no template yet)
+
+DROP TRIGGER IF EXISTS trg_location_seed_data;
+
+DELIMITER $$
+
+CREATE TRIGGER trg_location_seed_data
+AFTER INSERT ON m_location
+FOR EACH ROW
+BEGIN
+    DECLARE v_supplier_id   INT;
+    DECLARE v_template_id   INT;
+    DECLARE v_bank_name     VARCHAR(150);
+    DECLARE v_supplier_name VARCHAR(200);
+
+    IF @disable_triggers IS NULL OR @disable_triggers = 0 THEN
+
+        -- Insert Petty Cash Expenses
+        INSERT INTO m_expense
+            (Expense_name, location_code, Expense_default_amt, created_by, updated_by, updation_date, creation_date)
+        VALUES
+            ('Tiffin',         NEW.location_code, 200, 'admin', 'admin', NOW(), NOW()),
+            ('Tea',            NEW.location_code,  30, 'admin', 'admin', NOW(), NOW()),
+            ('Bus Fare',       NEW.location_code,  30, 'admin', 'admin', NOW(), NOW()),
+            ('TT Driver Batta',NEW.location_code, 100, 'admin', 'admin', NOW(), NOW()),
+            ('Others',         NEW.location_code,   0, 'admin', 'admin', NOW(), NOW());
+
+        -- Insert Lookup defaults
+        INSERT INTO m_lookup
+            (lookup_type, description, tag, start_date_active, end_date_active,
+             attribute1, attribute2, attribute3, attribute4, attribute5,
+             created_by, updated_by, updation_date, creation_date, location_code, tally_export)
+        VALUES
+            ('CashFlow', 'To Bank',           'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Cashier A/C (+)',   'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Cashier A/C (-)',   'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Cash Receipt',      'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Collection',        'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Balance B/F',       'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Expense',           'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'To WithDrawals',    'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'To Deposits',       'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Shift Opening',     'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'To Bank',           'OUT', '2024-06-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Shift Cash Return', 'IN',  '2025-04-08', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Salary Payout',     'OUT', '2024-04-01', NULL, '200', NULL, NULL, NULL, 'SALARY EXPENSES', 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Salary Recovery',   'IN',  '2024-04-01', NULL, NULL, NULL, NULL, NULL, 'SALARY EXPENSES', 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Discount',          'OUT', '2025-10-30', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y');
+
+        -- Auto-create oil company supplier + SOA bank
+        -- The after_supplier_insert_ledger_rule trigger on m_supplier fires automatically.
+        IF NEW.company_name IN ('IOCL', 'BPCL', 'HPCL', 'NAYARA') THEN
+
+            SET v_supplier_name = CASE NEW.company_name
+                WHEN 'IOCL'   THEN 'Indian Oil Corporation Limited'
+                WHEN 'BPCL'   THEN 'Bharat Petroleum Corporation Limited'
+                WHEN 'HPCL'   THEN 'Hindustan Petroleum Corporation Limited'
+                WHEN 'NAYARA' THEN 'Nayara Energy Limited'
+            END;
+
+            SET v_bank_name = CASE NEW.company_name
+                WHEN 'IOCL'   THEN 'IOCL-SOA'
+                WHEN 'BPCL'   THEN 'BPCL-SOA'
+                WHEN 'HPCL'   THEN 'HPCL-SOA'
+                WHEN 'NAYARA' THEN 'NAYARA-SOA'
+            END;
+
+            -- template_id=2: IOCL SAP Account Statement
+            -- template_id=6: BPCL SAP SOA Format
+            SET v_template_id = CASE NEW.company_name
+                WHEN 'IOCL'   THEN 2
+                WHEN 'BPCL'   THEN 6
+                ELSE NULL
+            END;
+
+            INSERT INTO m_supplier
+                (supplier_name, supplier_short_name, location_id, location_code,
+                 created_by, updated_by, creation_date, updation_date)
+            VALUES (
+                v_supplier_name,
+                NEW.company_name,
+                NEW.location_id,
+                NEW.location_code,
+                'system', 'system', NOW(), NOW()
+            );
+
+            SET v_supplier_id = LAST_INSERT_ID();
+
+            INSERT INTO m_bank
+                (bank_name, bank_branch, account_number, ifsc_code,
+                 location_code, location_id, is_oil_company, active_flag, internal_flag,
+                 template_id, supplier_id, created_by, updated_by)
+            VALUES (
+                v_bank_name, 'N/A', 'N/A', 'N/A',
+                NEW.location_code, NEW.location_id, 'Y', 'Y', 'N',
+                v_template_id, v_supplier_id, 'system', 'system'
+            );
+
+        END IF;
+
+    END IF;
+END$$
+
+DELIMITER ;

--- a/routes/products-routes.js
+++ b/routes/products-routes.js
@@ -5,6 +5,7 @@ const login = require('connect-ensure-login');
 const isLoginEnsured = login.ensureLoggedIn({});
 const security = require("../utils/app-security");
 const ProductDao = require('../dao/product-dao');
+const ProductLedgerMapDao = require('../dao/product-ledger-map-dao');
 const dbMapping = require("../db/ui-db-field-mapping")
 const config = require('../config/app-config');
 const locationConfigDao = require('../dao/location-config-dao');
@@ -231,6 +232,51 @@ router.put('/api/:id', [isLoginEnsured, security.isAdmin()], async function (req
             success: false,
             error: 'Failed to update product: ' + error.message
         });
+    }
+});
+
+// ── Product Ledger Map ────────────────────────────────────────────────────────
+
+router.get('/ledger-map', [isLoginEnsured, security.isAdmin()], async (req, res) => {
+    const locationCode = req.user.location_code;
+    try {
+        const [products, salesLedgers, purchaseLedgers, taxLedgers] = await Promise.all([
+            ProductLedgerMapDao.getAllMappings(locationCode),
+            getLedgersByGroup(locationCode, 'Sales Accounts'),
+            getLedgersByGroup(locationCode, 'Purchase Accounts'),
+            getLedgersByGroup(locationCode, 'Duties & Taxes')
+        ]);
+        res.render('product-ledger-map', {
+            title: 'Product GL Ledger Map',
+            user: req.user,
+            config: config.APP_CONFIGS,
+            products,
+            salesLedgers,
+            purchaseLedgers,
+            taxLedgers
+        });
+    } catch (err) {
+        console.error('Error loading product ledger map:', err);
+        req.flash('error', 'Failed to load product ledger map: ' + err.message);
+        res.redirect('/products');
+    }
+});
+
+router.put('/api/ledger-maps/:productId/:mapType', [isLoginEnsured, security.isAdmin()], async (req, res) => {
+    const { productId, mapType } = req.params;
+    const { ledger_id } = req.body;
+    const locationCode = req.user.location_code;
+    const updatedBy = req.user.username || req.user.Person_id;
+    try {
+        if (!ledger_id) {
+            await ProductLedgerMapDao.deleteMapping(locationCode, productId, mapType);
+        } else {
+            await ProductLedgerMapDao.upsertMapping(locationCode, productId, mapType, ledger_id, updatedBy);
+        }
+        res.json({ success: true });
+    } catch (err) {
+        console.error('Error saving product ledger map:', err);
+        res.status(500).json({ success: false, error: err.message });
     }
 });
 

--- a/services/create-accounting-service.js
+++ b/services/create-accounting-service.js
@@ -1,0 +1,834 @@
+// services/create-accounting-service.js
+// GL accounting engine — processes gl_accounting_events → gl_journal_headers + gl_journal_lines
+//
+// Event types handled:
+//   CREDIT_SALE  (source_id = tcredit_id)   — Customer DR / Sales CR + Output CGST CR + Output SGST CR
+//   CASH_SALE    (source_id = cashsales_id)  — Cash DR / Sales CR + Output CGST CR + Output SGST CR
+//   DAY_BILL     (source_id = day_bill_id)   — Cash/Digital DR / Sales CR + GST CRs per product line
+//   BANK_TXN     (source_id = t_bank_id)     — bank statement / oil-company SOA line
+//
+// Raised automatically by DB triggers on t_credits, t_cashsales, t_day_bill,
+// t_bank_transaction, and t_bank_transaction_splits.
+// UPDATE events reverse existing vouchers and regenerate fresh ones.
+// DELETE events reverse only.
+
+const db = require('../db/db-connection');
+const { QueryTypes } = require('sequelize');
+
+const VOUCHER_PREFIXES = {
+    SALES:    'SAL',
+    PURCHASE: 'PUR',
+    PAYMENT:  'PMT',
+    RECEIPT:  'RCT',
+    JOURNAL:  'JNL',
+    CONTRA:   'CNT'
+};
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+async function processEvents(locationCode, fromDate, toDate, processedBy) {
+    const events = await db.sequelize.query(`
+        SELECT * FROM gl_accounting_events
+        WHERE location_code = :locationCode
+          AND event_date BETWEEN :fromDate AND :toDate
+          AND event_status = 'UNPROCESSED'
+        ORDER BY event_date, event_id
+    `, {
+        replacements: { locationCode, fromDate, toDate },
+        type: QueryTypes.SELECT
+    });
+
+    const summary = { processed: 0, errors: 0, skipped: 0, details: [] };
+
+    for (const event of events) {
+        try {
+            const result = await processEvent(event, processedBy);
+            summary.processed += result.voucherCount;
+            summary.details.push({ event_id: event.event_id, status: 'PROCESSED', vouchers: result.voucherCount });
+        } catch (err) {
+            await markEventError(event.event_id, err.message);
+            summary.errors++;
+            summary.details.push({ event_id: event.event_id, status: 'ERROR', message: err.message });
+        }
+    }
+
+    return summary;
+}
+
+async function reprocessEvents(locationCode, fromDate, toDate, processedBy) {
+    await db.sequelize.query(`
+        UPDATE gl_accounting_events
+        SET event_status  = 'UNPROCESSED',
+            event_type    = 'UPDATE',
+            voucher_id    = NULL,
+            error_message = NULL,
+            processed_at  = NULL,
+            processed_by  = NULL
+        WHERE location_code = :locationCode
+          AND event_date BETWEEN :fromDate AND :toDate
+          AND event_status IN ('PROCESSED', 'ERROR')
+    `, {
+        replacements: { locationCode, fromDate, toDate },
+        type: QueryTypes.UPDATE
+    });
+
+    return await processEvents(locationCode, fromDate, toDate, processedBy);
+}
+
+module.exports = { processEvents, reprocessEvents };
+
+// ─── Event Dispatcher ─────────────────────────────────────────────────────────
+
+async function processEvent(event, processedBy) {
+    if (event.event_type === 'UPDATE' || event.event_type === 'DELETE') {
+        await reverseExistingVouchers(event.location_code, event.source_type, event.source_id, processedBy);
+    }
+
+    if (event.event_type === 'DELETE') {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    switch (event.source_type) {
+        case 'CREDIT_SALE':   return await processCreditSaleEvent(event, processedBy);
+        case 'CASH_SALE':     return await processCashSaleEvent(event, processedBy);
+        case 'DAY_BILL':      return await processDayBillEvent(event, processedBy);
+        case 'BANK_TXN':      return await processBankTxnEvent(event, processedBy);
+        default:
+            throw new Error(`Unhandled source_type: ${event.source_type}`);
+    }
+}
+
+// ─── CREDIT_SALE Handler ──────────────────────────────────────────────────────
+// Customer DR (total) → Sales CR (base) + Output CGST CR + Output SGST CR
+
+async function processCreditSaleEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: tcreditId, event_date } = event;
+
+    const rows = await db.sequelize.query(`
+        SELECT
+            tc.tcredit_id,
+            tc.product_id,
+            p.product_name,
+            tc.creditlist_id,
+            cl.Company_Name AS customer_name,
+            tc.qty,
+            tc.amount,
+            tc.base_amount,
+            tc.cgst_amount,
+            tc.sgst_amount,
+            tc.bill_no
+        FROM t_credits tc
+        JOIN m_product p       ON p.product_id     = tc.product_id
+        JOIN m_credit_list cl  ON cl.creditlist_id  = tc.creditlist_id
+        WHERE tc.tcredit_id = :tcreditId
+    `, {
+        replacements: { tcreditId },
+        type: QueryTypes.SELECT
+    });
+
+    if (!rows.length) throw new Error(`Credit entry not found: tcredit_id=${tcreditId}`);
+    const row = rows[0];
+
+    const salesLedgerId = await resolveProductLedger(location_code, row.product_id, 'SALES');
+    if (!salesLedgerId) throw new Error(`Sales ledger not configured for product ${row.product_name} (id:${row.product_id})`);
+
+    const customerLedgerId = await resolveLedger(location_code, 'CREDIT', row.creditlist_id);
+    if (!customerLedgerId) throw new Error(`GL ledger not found for customer ${row.customer_name} (creditlist_id:${row.creditlist_id})`);
+
+    const totalAmount = parseFloat(row.amount);
+    const baseAmount  = parseFloat(row.base_amount  || totalAmount);
+    const cgstAmount  = parseFloat(row.cgst_amount  || 0);
+    const sgstAmount  = parseFloat(row.sgst_amount  || 0);
+    const qty         = parseFloat(row.qty).toFixed(3);
+    const narration   = `${qty} ${row.product_name} | ₹${totalAmount.toFixed(2)} | ${row.customer_name} | Bill: ${row.bill_no}`;
+
+    const lines = [
+        { ledger_id: customerLedgerId, dr_amount: totalAmount, cr_amount: 0,           narration },
+        { ledger_id: salesLedgerId,    dr_amount: 0,           cr_amount: baseAmount,  narration }
+    ];
+
+    if (cgstAmount > 0) {
+        const cgstLedgerId = await resolveProductLedger(location_code, row.product_id, 'OUTPUT_CGST');
+        if (!cgstLedgerId) throw new Error(`OUTPUT_CGST ledger not mapped for product ${row.product_name} at ${location_code}`);
+        lines.push({ ledger_id: cgstLedgerId, dr_amount: 0, cr_amount: cgstAmount, narration });
+    }
+    if (sgstAmount > 0) {
+        const sgstLedgerId = await resolveProductLedger(location_code, row.product_id, 'OUTPUT_SGST');
+        if (!sgstLedgerId) throw new Error(`OUTPUT_SGST ledger not mapped for product ${row.product_name} at ${location_code}`);
+        lines.push({ ledger_id: sgstLedgerId, dr_amount: 0, cr_amount: sgstAmount, narration });
+    }
+
+    const vid = await createVoucher({
+        locationCode: location_code,
+        fyId:         fy_id,
+        voucherType:  'SALES',
+        voucherDate:  event_date,
+        sourceType:   'CREDIT_SALE',
+        sourceId:     tcreditId,
+        narration,
+        lines,
+        postedBy: processedBy
+    });
+
+    await markEventProcessed(event.event_id, vid, processedBy);
+    return { voucherCount: 1 };
+}
+
+// ─── CASH_SALE Handler ────────────────────────────────────────────────────────
+// Cash DR (total) → Sales CR (base) + Output CGST CR + Output SGST CR
+
+async function processCashSaleEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: cashsalesId, event_date } = event;
+
+    const rows = await db.sequelize.query(`
+        SELECT
+            cs.cashsales_id,
+            cs.product_id,
+            p.product_name,
+            cs.qty,
+            cs.amount,
+            cs.base_amount,
+            cs.cgst_amount,
+            cs.sgst_amount,
+            cs.bill_no
+        FROM t_cashsales cs
+        JOIN m_product p ON p.product_id = cs.product_id
+        WHERE cs.cashsales_id = :cashsalesId
+    `, {
+        replacements: { cashsalesId },
+        type: QueryTypes.SELECT
+    });
+
+    if (!rows.length) throw new Error(`Cash sale not found: cashsales_id=${cashsalesId}`);
+    const row = rows[0];
+
+    if (parseFloat(row.amount) <= 0) {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const salesLedgerId = await resolveProductLedger(location_code, row.product_id, 'SALES');
+    if (!salesLedgerId) throw new Error(`Sales ledger not configured for product ${row.product_name} (id:${row.product_id})`);
+
+    const cashLedgerId = await resolveCashLedger(location_code);
+    if (!cashLedgerId) throw new Error(`Cash-in-Hand ledger not found for location ${location_code}`);
+
+    const totalAmount = parseFloat(row.amount);
+    const baseAmount  = parseFloat(row.base_amount  || totalAmount);
+    const cgstAmount  = parseFloat(row.cgst_amount  || 0);
+    const sgstAmount  = parseFloat(row.sgst_amount  || 0);
+    const qty         = parseFloat(row.qty).toFixed(3);
+    const narration   = `${qty} ${row.product_name} | ₹${totalAmount.toFixed(2)} | Bill: ${row.bill_no}`;
+
+    const lines = [
+        { ledger_id: cashLedgerId,  dr_amount: totalAmount, cr_amount: 0,          narration },
+        { ledger_id: salesLedgerId, dr_amount: 0,           cr_amount: baseAmount, narration }
+    ];
+
+    if (cgstAmount > 0) {
+        const cgstLedgerId = await resolveProductLedger(location_code, row.product_id, 'OUTPUT_CGST');
+        if (!cgstLedgerId) throw new Error(`OUTPUT_CGST ledger not mapped for product ${row.product_name} at ${location_code}`);
+        lines.push({ ledger_id: cgstLedgerId, dr_amount: 0, cr_amount: cgstAmount, narration });
+    }
+    if (sgstAmount > 0) {
+        const sgstLedgerId = await resolveProductLedger(location_code, row.product_id, 'OUTPUT_SGST');
+        if (!sgstLedgerId) throw new Error(`OUTPUT_SGST ledger not mapped for product ${row.product_name} at ${location_code}`);
+        lines.push({ ledger_id: sgstLedgerId, dr_amount: 0, cr_amount: sgstAmount, narration });
+    }
+
+    const vid = await createVoucher({
+        locationCode: location_code,
+        fyId:         fy_id,
+        voucherType:  'SALES',
+        voucherDate:  event_date,
+        sourceType:   'CASH_SALE',
+        sourceId:     cashsalesId,
+        narration,
+        lines,
+        postedBy: processedBy
+    });
+
+    await markEventProcessed(event.event_id, vid, processedBy);
+    return { voucherCount: 1 };
+}
+
+// ─── DAY_BILL Handler ─────────────────────────────────────────────────────────
+// One voucher per day bill header:
+//   CASH header   → Cash DR          → Product Sales CR (per product line)
+//   DIGITAL header → Vendor (creditlist card_flag=Y) DR → Product Sales CR (per product line)
+
+async function processDayBillEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: dayBillId, event_date } = event;
+    const voucherIds = [];
+
+    // Fetch all headers for this day bill
+    const headers = await db.sequelize.query(`
+        SELECT
+            dbh.header_id,
+            dbh.bill_type,
+            dbh.vendor_id,
+            dbh.total_amount,
+            CASE WHEN dbh.bill_type = 'DIGITAL' THEN cl.Company_Name ELSE 'CASH' END AS party_name
+        FROM t_day_bill_header dbh
+        LEFT JOIN m_credit_list cl ON cl.creditlist_id = dbh.vendor_id
+        WHERE dbh.day_bill_id = :dayBillId
+        ORDER BY dbh.bill_type, dbh.header_id
+    `, {
+        replacements: { dayBillId },
+        type: QueryTypes.SELECT
+    });
+
+    if (!headers.length) {
+        // Day bill exists but has no headers yet (regeneration in progress) — skip silently
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const cashLedgerId = await resolveCashLedger(location_code);
+    if (!cashLedgerId) throw new Error(`Cash-in-Hand ledger not found for location ${location_code}`);
+
+    for (const header of headers) {
+        if (parseFloat(header.total_amount) <= 0) continue;
+
+        // Resolve the debit ledger
+        let drLedgerId;
+        if (header.bill_type === 'CASH') {
+            drLedgerId = cashLedgerId;
+        } else {
+            // Digital vendor — creditlist with card_flag=Y
+            drLedgerId = await resolveLedger(location_code, 'CREDIT', header.vendor_id);
+            if (!drLedgerId) throw new Error(`GL ledger not found for digital vendor ${header.party_name} (creditlist_id:${header.vendor_id})`);
+        }
+
+        // Fetch line items for this header
+        const items = await db.sequelize.query(`
+            SELECT
+                dbi.product_id,
+                p.product_name,
+                dbi.quantity,
+                dbi.total_amount,
+                dbi.base_amount,
+                dbi.cgst_amount,
+                dbi.sgst_amount
+            FROM t_day_bill_items dbi
+            JOIN m_product p ON p.product_id = dbi.product_id
+            WHERE dbi.header_id = :headerId
+              AND dbi.total_amount > 0
+        `, {
+            replacements: { headerId: header.header_id },
+            type: QueryTypes.SELECT
+        });
+
+        if (!items.length) continue;
+
+        // Build journal lines — one DR line (payment method) + Sales/GST CR lines per product
+        const lines = [];
+        const totalAmount = parseFloat(header.total_amount);
+        const headerNarration = `Day Bill ${header.bill_type}${header.bill_type === 'DIGITAL' ? ' — ' + header.party_name : ''} | ₹${totalAmount.toFixed(2)} | ${event_date}`;
+
+        // Debit: payment method (Cash or Digital vendor) for total
+        lines.push({ ledger_id: drLedgerId, dr_amount: totalAmount, cr_amount: 0, narration: headerNarration });
+
+        // Credit: Sales (base) + Output CGST + Output SGST per product
+        for (const item of items) {
+            const salesLedgerId = await resolveProductLedger(location_code, item.product_id, 'SALES');
+            if (!salesLedgerId) throw new Error(`Sales ledger not configured for product ${item.product_name} (id:${item.product_id})`);
+
+            const itemTotal   = parseFloat(item.total_amount);
+            const itemBase    = parseFloat(item.base_amount  || itemTotal);
+            const itemCgst    = parseFloat(item.cgst_amount  || 0);
+            const itemSgst    = parseFloat(item.sgst_amount  || 0);
+            const itemNarration = `${parseFloat(item.quantity).toFixed(3)} ${item.product_name} | ₹${itemTotal.toFixed(2)} | ${headerNarration}`;
+
+            lines.push({ ledger_id: salesLedgerId, dr_amount: 0, cr_amount: itemBase, narration: itemNarration });
+
+            if (itemCgst > 0) {
+                const cgstLedgerId = await resolveProductLedger(location_code, item.product_id, 'OUTPUT_CGST');
+                if (!cgstLedgerId) throw new Error(`OUTPUT_CGST ledger not mapped for product ${item.product_name} at ${location_code}`);
+                lines.push({ ledger_id: cgstLedgerId, dr_amount: 0, cr_amount: itemCgst, narration: itemNarration });
+            }
+            if (itemSgst > 0) {
+                const sgstLedgerId = await resolveProductLedger(location_code, item.product_id, 'OUTPUT_SGST');
+                if (!sgstLedgerId) throw new Error(`OUTPUT_SGST ledger not mapped for product ${item.product_name} at ${location_code}`);
+                lines.push({ ledger_id: sgstLedgerId, dr_amount: 0, cr_amount: itemSgst, narration: itemNarration });
+            }
+        }
+
+        const vid = await createVoucher({
+            locationCode: location_code,
+            fyId:         fy_id,
+            voucherType:  'SALES',
+            voucherDate:  event_date,
+            sourceType:   'DAY_BILL',
+            sourceId:     dayBillId,
+            narration:    headerNarration,
+            lines,
+            postedBy:     processedBy
+        });
+        voucherIds.push(vid);
+    }
+
+    await markEventProcessed(event.event_id, voucherIds[voucherIds.length - 1] || null, processedBy);
+    return { voucherCount: voucherIds.length };
+}
+
+// ─── BANK_TXN Handler ────────────────────────────────────────────────────────
+// One voucher per classified bank transaction (real bank or oil company SOA line).
+//
+// Skip conditions:
+//   • accounting_type IS NULL          — not yet classified; mark PROCESSED 0 vouchers
+//   • amount = 0                       — nothing to journal
+//   • is_oil_company='Y' + external_source='Bank' — SOA payment receipt line;
+//                                        the real bank statement row already journals it
+//   • is_oil_company='N' + external_source='Bank' + credit_amount>0
+//                                      — receiving side of a contra; the paying bank's
+//                                        debit row journals the transfer
+//   • external_source='Static' + ledger in 'Purchase Accounts' group
+//                                      — purchase invoice handler covers this
+//
+// Direction logic:
+//   Real bank:       credit_amount>0 → Bank DR, counterpart CR
+//                    debit_amount>0  → counterpart DR, Bank CR
+//   Oil company SOA: credit_amount>0 → Sundry Creditor CR (charge, we owe more), counterpart DR
+//                    debit_amount>0  → Sundry Creditor DR (rebate, we owe less), counterpart CR
+
+const ACCOUNTING_TYPE_VOUCHER_MAP = {
+    'Payment':  'PAYMENT',
+    'Receipt':  'RECEIPT',
+    'Contra':   'CONTRA',
+    'Journal':  'JOURNAL',
+    'Purchase': 'PURCHASE',
+};
+
+async function processBankTxnEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: tBankId, event_date } = event;
+
+    const rows = await db.sequelize.query(`
+        SELECT
+            tbt.t_bank_id,
+            tbt.bank_id,
+            tbt.trans_date,
+            tbt.credit_amount,
+            tbt.debit_amount,
+            tbt.accounting_type,
+            tbt.ledger_name,
+            tbt.external_id,
+            tbt.external_source,
+            tbt.is_split,
+            tbt.remarks,
+            mb.is_oil_company,
+            mb.supplier_id,
+            mb.bank_name,
+            mb.location_code AS bank_location
+        FROM t_bank_transaction tbt
+        JOIN m_bank mb ON mb.bank_id = tbt.bank_id
+        WHERE tbt.t_bank_id = :tBankId
+    `, { replacements: { tBankId }, type: QueryTypes.SELECT });
+
+    if (!rows.length) throw new Error(`Bank transaction not found: t_bank_id=${tBankId}`);
+    const txn = rows[0];
+
+    // Skip: transaction not yet classified
+    if (!txn.accounting_type) {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const creditAmt = parseFloat(txn.credit_amount || 0);
+    const debitAmt  = parseFloat(txn.debit_amount  || 0);
+    const txnAmount = creditAmt > 0 ? creditAmt : debitAmt;
+
+    if (txnAmount <= 0) {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const isOilCo = txn.is_oil_company === 'Y';
+
+    // Skip: all external_source='Bank' lines on oil-company SOA (our payment receipt lines —
+    // the real bank statement already journals the payment)
+    if (isOilCo && txn.external_source === 'Bank') {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    // Skip: receiving side of a contra between real banks
+    if (!isOilCo && txn.external_source === 'Bank' && creditAmt > 0) {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const voucherType = ACCOUNTING_TYPE_VOUCHER_MAP[txn.accounting_type];
+    if (!voucherType) throw new Error(`Unknown accounting_type: '${txn.accounting_type}' on t_bank_id=${tBankId}`);
+
+    // Resolve the bank's own GL ledger
+    let bankLedgerId;
+    if (isOilCo) {
+        if (!txn.supplier_id) throw new Error(`Oil company bank '${txn.bank_name}' (bank_id:${txn.bank_id}) has no supplier_id linked — update m_bank.supplier_id`);
+        bankLedgerId = await resolveLedger(location_code, 'SUPPLIER', txn.supplier_id);
+        if (!bankLedgerId) throw new Error(`SUPPLIER GL ledger not found for bank '${txn.bank_name}' (supplier_id:${txn.supplier_id})`);
+    } else {
+        bankLedgerId = await resolveLedger(location_code, 'BANK', txn.bank_id);
+        if (!bankLedgerId) throw new Error(`BANK GL ledger not found for bank '${txn.bank_name}' (bank_id:${txn.bank_id})`);
+    }
+
+    // For real bank: credit_amount → bank is DR; debit_amount → bank is CR
+    // For oil company SOA: credit_amount → bank (Sundry Creditor) is CR; debit_amount → bank (SC) is DR
+    // The "bankSide" determines where the bank ledger goes in the journal lines.
+    const bankIsDr = isOilCo ? debitAmt > 0 : creditAmt > 0;
+
+    const narration = txn.remarks
+        ? txn.remarks
+        : `${txn.accounting_type} | ${txn.bank_name} | ₹${txnAmount.toFixed(2)} | ${event_date}`;
+
+    let lines;
+
+    if (txn.is_split === 'Y') {
+        lines = await buildSplitLines(tBankId, bankLedgerId, bankIsDr, txnAmount, narration, location_code);
+    } else {
+        const counterLedgerId = await resolveCounterpartLedger(txn, location_code, event.event_id, processedBy);
+        if (counterLedgerId === null) {
+            // resolveCounterpartLedger already called markEventProcessed for skip cases
+            return { voucherCount: 0 };
+        }
+        lines = buildTwoLineJournal(bankLedgerId, counterLedgerId, bankIsDr, txnAmount, narration);
+    }
+
+    const vid = await createVoucher({
+        locationCode: location_code,
+        fyId:         fy_id,
+        voucherType,
+        voucherDate:  event_date,
+        sourceType:   'BANK_TXN',
+        sourceId:     tBankId,
+        narration,
+        lines,
+        postedBy:     processedBy
+    });
+
+    await markEventProcessed(event.event_id, vid, processedBy);
+    return { voucherCount: 1 };
+}
+
+// Returns counterpart ledger_id, or null if the event was already marked PROCESSED (skip).
+// Throws on unresolvable ledger.
+async function resolveCounterpartLedger(txn, locationCode, eventId, processedBy) {
+    const { external_source, external_id, ledger_name } = txn;
+
+    if (external_source === 'Static') {
+        const info = await resolveLedgerByName(locationCode, ledger_name);
+        if (!info) throw new Error(`Static GL ledger '${ledger_name}' not found for location ${locationCode}`);
+        if (info.group_name === 'Purchase Accounts') {
+            // Purchase invoices are journaled by the PURCHASE_INVOICE handler — skip here
+            await markEventProcessed(eventId, null, processedBy);
+            return null;
+        }
+        return info.ledger_id;
+    }
+
+    if (external_source === 'Credit') {
+        const id = await resolveLedger(locationCode, 'CREDIT', external_id);
+        if (!id) throw new Error(`CREDIT GL ledger not found for creditlist_id=${external_id}`);
+        return id;
+    }
+
+    if (external_source === 'Supplier') {
+        const id = await resolveLedger(locationCode, 'SUPPLIER', external_id);
+        if (!id) throw new Error(`SUPPLIER GL ledger not found for supplier_id=${external_id}`);
+        return id;
+    }
+
+    if (external_source === 'Bank') {
+        // Debit-side of a real-bank contra (credit side was already skipped above)
+        const id = await resolveLedger(locationCode, 'BANK', external_id);
+        if (!id) throw new Error(`BANK GL ledger not found for contra bank_id=${external_id}`);
+        return id;
+    }
+
+    throw new Error(`Cannot resolve counterpart ledger: external_source='${external_source}', external_id=${external_id}, ledger_name='${ledger_name}'`);
+}
+
+async function buildSplitLines(tBankId, bankLedgerId, bankIsDr, txnAmount, narration, locationCode) {
+    const splits = await db.sequelize.query(`
+        SELECT split_id, amount, ledger_name, external_id, external_source, remarks
+        FROM t_bank_transaction_splits
+        WHERE t_bank_id = :tBankId
+        ORDER BY split_id
+    `, { replacements: { tBankId }, type: QueryTypes.SELECT });
+
+    if (!splits.length) throw new Error(`Split transaction t_bank_id=${tBankId} has no split rows`);
+
+    const lines = [];
+    // Bank line covers the total
+    lines.push(bankIsDr
+        ? { ledger_id: bankLedgerId, dr_amount: txnAmount, cr_amount: 0,         narration }
+        : { ledger_id: bankLedgerId, dr_amount: 0,         cr_amount: txnAmount, narration }
+    );
+
+    for (const split of splits) {
+        const splitAmt = parseFloat(split.amount);
+        const splitNarration = split.remarks || narration;
+        const counterLedgerId = await resolveSplitCounterLedger(split, locationCode);
+        lines.push(bankIsDr
+            ? { ledger_id: counterLedgerId, dr_amount: 0,        cr_amount: splitAmt, narration: splitNarration }
+            : { ledger_id: counterLedgerId, dr_amount: splitAmt, cr_amount: 0,        narration: splitNarration }
+        );
+    }
+
+    return lines;
+}
+
+async function resolveSplitCounterLedger(split, locationCode) {
+    const { external_source, external_id, ledger_name, split_id } = split;
+    const errCtx = `split_id=${split_id}`;
+
+    if (external_source === 'Static') {
+        const info = await resolveLedgerByName(locationCode, ledger_name);
+        if (!info) throw new Error(`Static GL ledger '${ledger_name}' not found for ${errCtx}`);
+        return info.ledger_id;
+    }
+    if (external_source === 'Credit') {
+        const id = await resolveLedger(locationCode, 'CREDIT', external_id);
+        if (!id) throw new Error(`CREDIT GL ledger not found for creditlist_id=${external_id} (${errCtx})`);
+        return id;
+    }
+    if (external_source === 'Supplier') {
+        const id = await resolveLedger(locationCode, 'SUPPLIER', external_id);
+        if (!id) throw new Error(`SUPPLIER GL ledger not found for supplier_id=${external_id} (${errCtx})`);
+        return id;
+    }
+    if (external_source === 'Bank') {
+        const id = await resolveLedger(locationCode, 'BANK', external_id);
+        if (!id) throw new Error(`BANK GL ledger not found for bank_id=${external_id} (${errCtx})`);
+        return id;
+    }
+    throw new Error(`Cannot resolve split ledger: source='${external_source}', id=${external_id} (${errCtx})`);
+}
+
+function buildTwoLineJournal(bankLedgerId, counterLedgerId, bankIsDr, amount, narration) {
+    if (bankIsDr) {
+        return [
+            { ledger_id: bankLedgerId,    dr_amount: amount, cr_amount: 0,      narration },
+            { ledger_id: counterLedgerId, dr_amount: 0,      cr_amount: amount, narration }
+        ];
+    } else {
+        return [
+            { ledger_id: counterLedgerId, dr_amount: amount, cr_amount: 0,      narration },
+            { ledger_id: bankLedgerId,    dr_amount: 0,      cr_amount: amount, narration }
+        ];
+    }
+}
+
+// ─── Voucher Utilities ────────────────────────────────────────────────────────
+
+async function createVoucher({ locationCode, fyId, voucherType, voucherDate, sourceType, sourceId, narration, lines, postedBy }) {
+    const totalDr = lines.reduce((s, l) => s + (l.dr_amount || 0), 0);
+    const totalCr = lines.reduce((s, l) => s + (l.cr_amount || 0), 0);
+    if (Math.abs(totalDr - totalCr) > 0.005) {
+        throw new Error(`Voucher does not balance: DR ${totalDr.toFixed(2)} vs CR ${totalCr.toFixed(2)}`);
+    }
+
+    const voucherNo = await generateVoucherNo(locationCode, fyId, voucherType);
+
+    const [voucherId] = await db.sequelize.query(`
+        INSERT INTO gl_journal_headers
+            (location_code, fy_id, voucher_type, voucher_date, voucher_no,
+             narration, source_type, source_id, is_reversal, is_exported,
+             posted_by, created_by)
+        VALUES
+            (:locationCode, :fyId, :voucherType, :voucherDate, :voucherNo,
+             :narration, :sourceType, :sourceId, 'N', 'N',
+             :postedBy, :postedBy)
+    `, {
+        replacements: { locationCode, fyId, voucherType, voucherDate, voucherNo, narration, sourceType, sourceId, postedBy },
+        type: QueryTypes.INSERT
+    });
+
+    for (let i = 0; i < lines.length; i++) {
+        const { ledger_id, dr_amount = 0, cr_amount = 0, narration: lineNarration = null } = lines[i];
+        await db.sequelize.query(`
+            INSERT INTO gl_journal_lines
+                (voucher_id, line_no, ledger_id, dr_amount, cr_amount, narration, created_by)
+            VALUES
+                (:voucherId, :lineNo, :ledgerId, :drAmount, :crAmount, :lineNarration, :postedBy)
+        `, {
+            replacements: { voucherId, lineNo: i + 1, ledgerId: ledger_id, drAmount: dr_amount, crAmount: cr_amount, lineNarration, postedBy },
+            type: QueryTypes.INSERT
+        });
+    }
+
+    return voucherId;
+}
+
+async function reverseExistingVouchers(locationCode, sourceType, sourceId, reversedBy) {
+    const existing = await db.sequelize.query(`
+        SELECT voucher_id, voucher_type, voucher_date, fy_id, narration
+        FROM gl_journal_headers
+        WHERE location_code = :locationCode
+          AND source_type   = :sourceType
+          AND source_id     = :sourceId
+          AND is_reversal   = 'N'
+    `, {
+        replacements: { locationCode, sourceType, sourceId },
+        type: QueryTypes.SELECT
+    });
+
+    for (const v of existing) {
+        const lines = await db.sequelize.query(`
+            SELECT ledger_id, cr_amount AS dr_amount, dr_amount AS cr_amount
+            FROM gl_journal_lines
+            WHERE voucher_id = :voucherId
+        `, {
+            replacements: { voucherId: v.voucher_id },
+            type: QueryTypes.SELECT
+        });
+
+        const voucherNo = await generateVoucherNo(locationCode, v.fy_id, v.voucher_type);
+
+        const [reversalId] = await db.sequelize.query(`
+            INSERT INTO gl_journal_headers
+                (location_code, fy_id, voucher_type, voucher_date, voucher_no,
+                 narration, source_type, source_id, is_reversal, reversal_of_voucher_id,
+                 is_exported, posted_by, created_by)
+            VALUES
+                (:locationCode, :fyId, :voucherType, NOW(), :voucherNo,
+                 :narration, :sourceType, :sourceId, 'Y', :originalId,
+                 'N', :reversedBy, :reversedBy)
+        `, {
+            replacements: {
+                locationCode,
+                fyId:        v.fy_id,
+                voucherType: v.voucher_type,
+                voucherNo,
+                narration:   `REVERSAL of ${v.voucher_type} — ${v.narration || ''}`,
+                sourceType,
+                sourceId,
+                originalId:  v.voucher_id,
+                reversedBy
+            },
+            type: QueryTypes.INSERT
+        });
+
+        for (let i = 0; i < lines.length; i++) {
+            const { ledger_id, dr_amount, cr_amount } = lines[i];
+            await db.sequelize.query(`
+                INSERT INTO gl_journal_lines
+                    (voucher_id, line_no, ledger_id, dr_amount, cr_amount, created_by)
+                VALUES (:reversalId, :lineNo, :ledgerId, :drAmount, :crAmount, :reversedBy)
+            `, {
+                replacements: { reversalId, lineNo: i + 1, ledgerId: ledger_id, drAmount: dr_amount, crAmount: cr_amount, reversedBy },
+                type: QueryTypes.INSERT
+            });
+        }
+    }
+}
+
+async function generateVoucherNo(locationCode, fyId, voucherType) {
+    const prefix = VOUCHER_PREFIXES[voucherType] || 'JNL';
+    const result = await db.sequelize.query(`
+        SELECT COALESCE(MAX(
+            CAST(SUBSTRING(voucher_no, LOCATE('-', voucher_no) + 1) AS UNSIGNED)
+        ), 0) + 1 AS next_no
+        FROM gl_journal_headers
+        WHERE location_code = :locationCode
+          AND fy_id         = :fyId
+          AND voucher_type  = :voucherType
+          AND voucher_no IS NOT NULL
+    `, {
+        replacements: { locationCode, fyId, voucherType },
+        type: QueryTypes.SELECT
+    });
+    const nextNo = result[0].next_no;
+    return `${prefix}-${String(nextNo).padStart(4, '0')}`;
+}
+
+// ─── Ledger Resolvers ─────────────────────────────────────────────────────────
+
+async function resolveLedger(locationCode, sourceType, sourceId) {
+    const rows = await db.sequelize.query(`
+        SELECT ledger_id FROM gl_ledgers
+        WHERE location_code = :locationCode
+          AND source_type   = :sourceType
+          AND source_id     = :sourceId
+        LIMIT 1
+    `, {
+        replacements: { locationCode, sourceType, sourceId },
+        type: QueryTypes.SELECT
+    });
+    return rows[0] ? rows[0].ledger_id : null;
+}
+
+async function resolveProductLedger(locationCode, productId, mapType) {
+    const rows = await db.sequelize.query(`
+        SELECT ledger_id FROM gl_product_ledger_map
+        WHERE location_code = :locationCode
+          AND product_id    = :productId
+          AND map_type      = :mapType
+        LIMIT 1
+    `, {
+        replacements: { locationCode, productId, mapType },
+        type: QueryTypes.SELECT
+    });
+    return rows[0] ? rows[0].ledger_id : null;
+}
+
+async function resolveLedgerByName(locationCode, ledgerName) {
+    const rows = await db.sequelize.query(`
+        SELECT l.ledger_id, g.group_name
+        FROM gl_ledgers l
+        JOIN gl_ledger_groups g ON g.group_id = l.group_id
+        WHERE l.location_code = :locationCode
+          AND l.ledger_name   = :ledgerName
+          AND l.active_flag   = 'Y'
+        LIMIT 1
+    `, {
+        replacements: { locationCode, ledgerName },
+        type: QueryTypes.SELECT
+    });
+    return rows[0] || null;
+}
+
+async function resolveCashLedger(locationCode) {
+    const rows = await db.sequelize.query(`
+        SELECT l.ledger_id FROM gl_ledgers l
+        JOIN gl_ledger_groups g ON g.group_id = l.group_id
+        WHERE l.location_code = :locationCode
+          AND g.group_name    = 'Cash-in-Hand'
+          AND l.active_flag   = 'Y'
+        LIMIT 1
+    `, {
+        replacements: { locationCode },
+        type: QueryTypes.SELECT
+    });
+    return rows[0] ? rows[0].ledger_id : null;
+}
+
+// ─── Event Status Helpers ─────────────────────────────────────────────────────
+
+async function markEventProcessed(eventId, voucherId, processedBy) {
+    await db.sequelize.query(`
+        UPDATE gl_accounting_events
+        SET event_status  = 'PROCESSED',
+            voucher_id    = :voucherId,
+            processed_at  = NOW(),
+            processed_by  = :processedBy
+        WHERE event_id = :eventId
+    `, {
+        replacements: { eventId, voucherId, processedBy },
+        type: QueryTypes.UPDATE
+    });
+}
+
+async function markEventError(eventId, errorMessage) {
+    await db.sequelize.query(`
+        UPDATE gl_accounting_events
+        SET event_status  = 'ERROR',
+            error_message = :errorMessage,
+            processed_at  = NOW()
+        WHERE event_id = :eventId
+    `, {
+        replacements: { eventId, errorMessage: String(errorMessage).substring(0, 1000) },
+        type: QueryTypes.UPDATE
+    });
+}

--- a/views/product-ledger-map.pug
+++ b/views/product-ledger-map.pug
@@ -1,0 +1,121 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0.text-primary Product GL Ledger Map
+            a.btn.btn-sm.btn-outline-secondary(href="/products") &larr; Back to Products
+
+        .alert.alert-info.py-2
+            i.bi.bi-info-circle.me-1
+            | Assign GL ledgers for each product. Changes auto-save on selection.
+            | Output CGST / Output SGST only apply to GST products.
+
+        div#saveStatus.mb-2(style="min-height:24px;")
+
+        .table-responsive
+            table.table.table-bordered.table-hover.table-sm#ledgerMapTable
+                thead.thead-dark
+                    tr
+                        th(style="min-width:200px;") Product
+                        th.text-center(style="width:50px;") CGST%
+                        th(style="min-width:180px;") Sales Ledger
+                        th(style="min-width:180px;") Purchase Ledger
+                        th(style="min-width:180px;") Output CGST
+                        th(style="min-width:180px;") Output SGST
+                tbody
+                    each p in products
+                        - const isGst = p.cgst_percent > 0
+                        tr(class=isGst ? '' : 'table-secondary')
+                            td
+                                strong= p.product_name
+                                if isGst
+                                    span.badge.badge-warning.ml-1 GST
+                            td.text-center= p.cgst_percent + '%'
+                            td
+                                select.form-control.form-control-sm.ledger-select(
+                                    data-product-id=p.product_id,
+                                    data-map-type="SALES")
+                                    option(value="") — Not Set —
+                                    each l in salesLedgers
+                                        option(value=l.ledger_id, selected=(p.sales_ledger_id == l.ledger_id))= l.ledger_name
+                            td
+                                select.form-control.form-control-sm.ledger-select(
+                                    data-product-id=p.product_id,
+                                    data-map-type="PURCHASE")
+                                    option(value="") — Not Set —
+                                    each l in purchaseLedgers
+                                        option(value=l.ledger_id, selected=(p.purchase_ledger_id == l.ledger_id))= l.ledger_name
+                            td
+                                if isGst
+                                    select.form-control.form-control-sm.ledger-select(
+                                        data-product-id=p.product_id,
+                                        data-map-type="OUTPUT_CGST")
+                                        option(value="") — Not Set —
+                                        each l in taxLedgers
+                                            option(value=l.ledger_id, selected=(p.output_cgst_ledger_id == l.ledger_id))= l.ledger_name
+                                else
+                                    span.text-muted.small N/A
+                            td
+                                if isGst
+                                    select.form-control.form-control-sm.ledger-select(
+                                        data-product-id=p.product_id,
+                                        data-map-type="OUTPUT_SGST")
+                                        option(value="") — Not Set —
+                                        each l in taxLedgers
+                                            option(value=l.ledger_id, selected=(p.output_sgst_ledger_id == l.ledger_id))= l.ledger_name
+                                else
+                                    span.text-muted.small N/A
+
+    style.
+        #ledgerMapTable thead th { position: sticky; top: 0; z-index: 1; }
+        .table-secondary td { color: #6c757d; }
+        select.saving { border-color: #ffc107 !important; }
+        select.saved  { border-color: #28a745 !important; }
+        select.error  { border-color: #dc3545 !important; }
+
+    script.
+        document.querySelectorAll('.ledger-select').forEach(function(sel) {
+            sel.addEventListener('change', function() {
+                const productId = this.dataset.productId;
+                const mapType   = this.dataset.mapType;
+                const ledgerId  = this.value;
+                const el        = this;
+
+                el.classList.remove('saved', 'error');
+                el.classList.add('saving');
+                el.disabled = true;
+
+                fetch('/products/api/ledger-maps/' + productId + '/' + mapType, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ ledger_id: ledgerId || null })
+                })
+                .then(r => r.json())
+                .then(data => {
+                    el.classList.remove('saving');
+                    el.disabled = false;
+                    if (data.success) {
+                        el.classList.add('saved');
+                        showStatus('Saved.', 'success');
+                        setTimeout(() => el.classList.remove('saved'), 2000);
+                    } else {
+                        el.classList.add('error');
+                        showStatus('Error: ' + data.error, 'danger');
+                    }
+                })
+                .catch(function(err) {
+                    el.classList.remove('saving');
+                    el.disabled = false;
+                    el.classList.add('error');
+                    showStatus('Error: ' + err.message, 'danger');
+                });
+            });
+        });
+
+        function showStatus(msg, type) {
+            const el = document.getElementById('saveStatus');
+            el.innerHTML = '<span class="text-' + type + ' small">' + msg + '</span>';
+            setTimeout(() => { el.innerHTML = ''; }, 3000);
+        }

--- a/views/products.pug
+++ b/views/products.pug
@@ -38,7 +38,6 @@ block content
                             th(scope="col") HSN Code
                             th(scope="col") Unit
                             th(scope="col") Price
-                            th(scope="col") Ledger Name
                             th(scope="col") CGST%
                             th(scope="col") SGST%
                             if user.Role === 'SuperUser'
@@ -59,7 +58,6 @@ block content
                                         .input-group-prepend
                                             span.input-group-text ₹
                                         span.form-control-plaintext= val.price
-                                td(scope="row")= val.ledger_name || '-'
                                 td(scope="row") #{val.cgst_percent}%
                                 td(scope="row") #{val.sgst_percent}%
                                 if user.Role === 'SuperUser'
@@ -186,16 +184,6 @@ block content
                                                 )
                                     .col-6
                                         .product-detail
-                                            small.text-muted Ledger
-                                            input.mobile-input.fw-bold.text-uppercase(
-                                                type="text",
-                                                id=`mobile-ledger-${index}`,
-                                                value=val.ledger_name || 'N/A',
-                                                readonly,
-                                                style="border: none; background: transparent; padding: 0; font-weight: bold; text-transform: uppercase;"
-                                            )
-                                    .col-6
-                                        .product-detail
                                             small.text-muted CGST
                                             .input-group.input-group-sm
                                                 input.mobile-input.fw-bold(
@@ -279,18 +267,6 @@ block content
                                 label.form-label Price
                                 input.form-control(type="number", name="price", step="0.01", required)
                             .col-md-6.mb-3
-                                label.form-label Sales Ledger
-                                select.form-control(name="ledger_name")
-                                    option(value="") — Not Set —
-                                    each l in salesLedgers
-                                        option(value=l.ledger_name)= l.ledger_name
-                            .col-md-6.mb-3
-                                label.form-label Purchase Ledger
-                                select.form-control(name="purchase_ledger_name")
-                                    option(value="") — Not Set —
-                                    each l in purchaseLedgers
-                                        option(value=l.ledger_name)= l.ledger_name
-                            .col-md-6.mb-3
                                 label.form-label CGST %
                                 input.form-control(type="number", name="cgst_percent", step="0.01", min="0", max="100")
                             .col-md-6.mb-3
@@ -355,18 +331,6 @@ block content
                             .col-md-6.mb-3
                                 label.form-label Price
                                 input#edit-price.form-control(type="number", step="0.01")
-                            .col-md-6.mb-3
-                                label.form-label Sales Ledger
-                                select#edit-ledger-name.form-control
-                                    option(value="") — Not Set —
-                                    each l in salesLedgers
-                                        option(value=l.ledger_name)= l.ledger_name
-                            .col-md-6.mb-3
-                                label.form-label Purchase Ledger
-                                select#edit-purchase-ledger-name.form-control
-                                    option(value="") — Not Set —
-                                    each l in purchaseLedgers
-                                        option(value=l.ledger_name)= l.ledger_name
                             .col-md-6.mb-3
                                 label.form-label CGST %
                                 input#edit-cgst.form-control(type="number", step="0.01", min="0", max="100")
@@ -573,8 +537,6 @@ block content
             document.getElementById('edit-hsn-code').value = product.hsn_code || '';
             document.getElementById('edit-unit').value = product.unit || '';
             document.getElementById('edit-price').value = product.price || '';
-            document.getElementById('edit-ledger-name').value = product.ledger_name || '';
-            document.getElementById('edit-purchase-ledger-name').value = product.purchase_ledger_name || '';
             document.getElementById('edit-cgst').value = product.cgst_percent || 0;
             document.getElementById('edit-sgst').value = product.sgst_percent || 0;
 
@@ -619,8 +581,6 @@ block content
                 m_product_name: document.getElementById('edit-product-name').value.toUpperCase().trim(),
                 m_product_price: document.getElementById('edit-price').value,
                 m_product_unit: document.getElementById('edit-unit').value.toUpperCase(),
-                m_product_ledger_name: ($('#edit-ledger-name').val() || '').toUpperCase(),
-                m_product_purchase_ledger_name: ($('#edit-purchase-ledger-name').val() || '').toUpperCase(),
                 m_product_cgst: document.getElementById('edit-cgst').value,
                 m_product_sgst: document.getElementById('edit-sgst').value
             };


### PR DESCRIPTION
## Summary
- BEFORE triggers on t_credits/t_cashsales to auto-populate GST amounts from m_product (backfill done on prod)
- OUTPUT CGST/SGST ledgers seeded for all 23 locations; gl_product_ledger_map populated for all GST products
- Accounting service handlers (CREDIT_SALE, CASH_SALE, DAY_BILL, BANK_TXN) updated to produce GST-split journal lines
- New product ledger map UI at /products/ledger-map — inline auto-save dropdowns
- Ledger name fields hidden from products page (data preserved for Tally rewrite)

## Test plan
- [ ] Visit /products/ledger-map — confirm all products show with correct ledger dropdowns pre-selected
- [ ] Change a ledger assignment — confirm green border flash and no page reload
- [ ] Confirm fuel products show N/A for Output CGST/SGST columns
- [ ] Visit /products — confirm Ledger Name column and form fields are gone
- [ ] Create a credit sale or cash sale for a GST product — confirm gl_accounting_events row created

🤖 Generated with [Claude Code](https://claude.com/claude-code)