### PR TITLE
GL accounting: full report chain, manual journal, and GL control page

### DIFF
--- a/dao/product-ledger-map-dao.js
+++ b/dao/product-ledger-map-dao.js
@@ -1,9 +1,6 @@
 const db = require('../db/db-connection');
 const { QueryTypes } = require('sequelize');
 
-// All map types the accounting engine supports — add new types here only
-const VALID_MAP_TYPES = ['SALES', 'PURCHASE', 'OUTPUT_CGST', 'OUTPUT_SGST', 'INPUT_CGST', 'INPUT_SGST'];
-
 module.exports = {
 
     // Returns one row per product with all current mapping ledger IDs
@@ -24,6 +21,16 @@ module.exports = {
         });
     },
 
+    // Returns map type definitions from m_lookup — drives the UI modal rows
+    getMapTypes: async () => {
+        return db.sequelize.query(`
+            SELECT tag AS type, description AS label, attribute1 AS \`group\`
+            FROM m_lookup
+            WHERE lookup_type = 'ProductMapType'
+            ORDER BY lookup_id
+        `, { type: QueryTypes.SELECT });
+    },
+
     // Returns flat rows (product_id, map_type, ledger_id) — used to build the modal lookup
     getAllMappingsRaw: async (locationCode) => {
         return db.sequelize.query(`
@@ -37,9 +44,6 @@ module.exports = {
     },
 
     upsertMapping: async (locationCode, productId, mapType, ledgerId, updatedBy) => {
-        if (!VALID_MAP_TYPES.includes(mapType)) {
-            throw new Error(`Invalid map_type: ${mapType}`);
-        }
         await db.sequelize.query(`
             INSERT INTO gl_product_ledger_map
                 (location_code, product_id, map_type, ledger_id, created_by, updated_by)
@@ -55,9 +59,6 @@ module.exports = {
     },
 
     deleteMapping: async (locationCode, productId, mapType) => {
-        if (!VALID_MAP_TYPES.includes(mapType)) {
-            throw new Error(`Invalid map_type: ${mapType}`);
-        }
         await db.sequelize.query(`
             DELETE FROM gl_product_ledger_map
             WHERE location_code = :locationCode

--- a/db/migrations/gl-accounting-event-triggers.sql
+++ b/db/migrations/gl-accounting-event-triggers.sql
@@ -1,0 +1,335 @@
+-- ============================================================
+-- GL Accounting Event Triggers
+-- Generated: 2026-04-30
+--
+-- Raises gl_accounting_events rows automatically on writes to:
+--   t_credits    → CREDIT_SALE events  (source_id = tcredit_id)
+--   t_cashsales  → CASH_SALE events    (source_id = cashsales_id)
+--   t_day_bill   → DAY_BILL events     (source_id = day_bill_id)
+--
+-- UPDATE logic (shared by all three tables):
+--   • PROCESSED event exists  → INSERT new UPDATE event (engine will reverse + redo)
+--   • UNPROCESSED event exists → flip event_type to UPDATE in-place (picks up latest data when run)
+--   • No event exists         → INSERT CREATE event (edge case: accounting never run)
+--
+-- DELETE logic (credits / cashsales only — for shift reopen):
+--   • PROCESSED event exists  → INSERT DELETE event (engine reverses)
+--   • UNPROCESSED event exists → DELETE the pending event (never journalised, nothing to reverse)
+-- ============================================================
+
+DROP TRIGGER IF EXISTS trg_credit_sale_gl_insert;
+DROP TRIGGER IF EXISTS trg_credit_sale_gl_update;
+DROP TRIGGER IF EXISTS trg_credit_sale_gl_delete;
+DROP TRIGGER IF EXISTS trg_cash_sale_gl_insert;
+DROP TRIGGER IF EXISTS trg_cash_sale_gl_update;
+DROP TRIGGER IF EXISTS trg_cash_sale_gl_delete;
+DROP TRIGGER IF EXISTS trg_day_bill_gl_insert;
+DROP TRIGGER IF EXISTS trg_day_bill_gl_update;
+
+DELIMITER $$
+
+-- ── t_credits : INSERT ────────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_credit_sale_gl_insert
+AFTER INSERT ON t_credits
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+    DECLARE v_closing_date  DATE;
+    DECLARE v_fy_id         INT;
+
+    SELECT c.location_code, DATE(c.closing_date)
+    INTO   v_location_code, v_closing_date
+    FROM   t_closing c
+    WHERE  c.closing_id = NEW.closing_id;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = v_location_code
+      AND  v_closing_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        VALUES
+            (v_location_code, v_fy_id, 'CREDIT_SALE', NEW.tcredit_id, 'CREATE', v_closing_date, 'UNPROCESSED', 'TRIGGER');
+    END IF;
+END$$
+
+-- ── t_credits : UPDATE ────────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_credit_sale_gl_update
+AFTER UPDATE ON t_credits
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_closing_date    DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    SELECT c.location_code, DATE(c.closing_date)
+    INTO   v_location_code, v_closing_date
+    FROM   t_closing c
+    WHERE  c.closing_id = NEW.closing_id;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = v_location_code
+      AND  v_closing_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'CREDIT_SALE' AND source_id = NEW.tcredit_id AND event_status = 'PROCESSED';
+
+        SELECT COUNT(*) INTO v_pending_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'CREDIT_SALE' AND source_id = NEW.tcredit_id AND event_status = 'UNPROCESSED';
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'CREDIT_SALE', NEW.tcredit_id, 'UPDATE', v_closing_date, 'UNPROCESSED', 'TRIGGER');
+        ELSEIF v_pending_count > 0 THEN
+            UPDATE gl_accounting_events
+            SET    event_type = 'UPDATE'
+            WHERE  source_type = 'CREDIT_SALE' AND source_id = NEW.tcredit_id AND event_status = 'UNPROCESSED';
+        ELSE
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'CREDIT_SALE', NEW.tcredit_id, 'CREATE', v_closing_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_credits : DELETE ────────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_credit_sale_gl_delete
+AFTER DELETE ON t_credits
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_closing_date    DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT c.location_code, DATE(c.closing_date)
+    INTO   v_location_code, v_closing_date
+    FROM   t_closing c
+    WHERE  c.closing_id = OLD.closing_id;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = v_location_code
+      AND  v_closing_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'CREDIT_SALE' AND source_id = OLD.tcredit_id AND event_status = 'PROCESSED';
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'CREDIT_SALE', OLD.tcredit_id, 'DELETE', v_closing_date, 'UNPROCESSED', 'TRIGGER');
+        ELSE
+            DELETE FROM gl_accounting_events
+            WHERE  source_type = 'CREDIT_SALE' AND source_id = OLD.tcredit_id AND event_status = 'UNPROCESSED';
+        END IF;
+    END IF;
+END$$
+
+-- ── t_cashsales : INSERT ──────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_cash_sale_gl_insert
+AFTER INSERT ON t_cashsales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+    DECLARE v_closing_date  DATE;
+    DECLARE v_fy_id         INT;
+
+    SELECT c.location_code, DATE(c.closing_date)
+    INTO   v_location_code, v_closing_date
+    FROM   t_closing c
+    WHERE  c.closing_id = NEW.closing_id;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = v_location_code
+      AND  v_closing_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        VALUES
+            (v_location_code, v_fy_id, 'CASH_SALE', NEW.cashsales_id, 'CREATE', v_closing_date, 'UNPROCESSED', 'TRIGGER');
+    END IF;
+END$$
+
+-- ── t_cashsales : UPDATE ──────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_cash_sale_gl_update
+AFTER UPDATE ON t_cashsales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_closing_date    DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    SELECT c.location_code, DATE(c.closing_date)
+    INTO   v_location_code, v_closing_date
+    FROM   t_closing c
+    WHERE  c.closing_id = NEW.closing_id;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = v_location_code
+      AND  v_closing_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'CASH_SALE' AND source_id = NEW.cashsales_id AND event_status = 'PROCESSED';
+
+        SELECT COUNT(*) INTO v_pending_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'CASH_SALE' AND source_id = NEW.cashsales_id AND event_status = 'UNPROCESSED';
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'CASH_SALE', NEW.cashsales_id, 'UPDATE', v_closing_date, 'UNPROCESSED', 'TRIGGER');
+        ELSEIF v_pending_count > 0 THEN
+            UPDATE gl_accounting_events
+            SET    event_type = 'UPDATE'
+            WHERE  source_type = 'CASH_SALE' AND source_id = NEW.cashsales_id AND event_status = 'UNPROCESSED';
+        ELSE
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'CASH_SALE', NEW.cashsales_id, 'CREATE', v_closing_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_cashsales : DELETE ──────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_cash_sale_gl_delete
+AFTER DELETE ON t_cashsales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_closing_date    DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT c.location_code, DATE(c.closing_date)
+    INTO   v_location_code, v_closing_date
+    FROM   t_closing c
+    WHERE  c.closing_id = OLD.closing_id;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = v_location_code
+      AND  v_closing_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'CASH_SALE' AND source_id = OLD.cashsales_id AND event_status = 'PROCESSED';
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'CASH_SALE', OLD.cashsales_id, 'DELETE', v_closing_date, 'UNPROCESSED', 'TRIGGER');
+        ELSE
+            DELETE FROM gl_accounting_events
+            WHERE  source_type = 'CASH_SALE' AND source_id = OLD.cashsales_id AND event_status = 'UNPROCESSED';
+        END IF;
+    END IF;
+END$$
+
+-- ── t_day_bill : INSERT ───────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_day_bill_gl_insert
+AFTER INSERT ON t_day_bill
+FOR EACH ROW
+BEGIN
+    DECLARE v_fy_id INT;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = NEW.location_code
+      AND  NEW.bill_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        VALUES
+            (NEW.location_code, v_fy_id, 'DAY_BILL', NEW.day_bill_id, 'CREATE', NEW.bill_date, 'UNPROCESSED', 'TRIGGER');
+    END IF;
+END$$
+
+-- ── t_day_bill : UPDATE ───────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_day_bill_gl_update
+AFTER UPDATE ON t_day_bill
+FOR EACH ROW
+BEGIN
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = NEW.location_code
+      AND  NEW.bill_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'DAY_BILL' AND source_id = NEW.day_bill_id AND event_status = 'PROCESSED';
+
+        SELECT COUNT(*) INTO v_pending_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'DAY_BILL' AND source_id = NEW.day_bill_id AND event_status = 'UNPROCESSED';
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (NEW.location_code, v_fy_id, 'DAY_BILL', NEW.day_bill_id, 'UPDATE', NEW.bill_date, 'UNPROCESSED', 'TRIGGER');
+        ELSEIF v_pending_count > 0 THEN
+            UPDATE gl_accounting_events
+            SET    event_type = 'UPDATE'
+            WHERE  source_type = 'DAY_BILL' AND source_id = NEW.day_bill_id AND event_status = 'UNPROCESSED';
+        ELSE
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (NEW.location_code, v_fy_id, 'DAY_BILL', NEW.day_bill_id, 'CREATE', NEW.bill_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SHOW TRIGGERS WHERE `Table` IN ('t_credits', 't_cashsales', 't_day_bill');

--- a/db/migrations/gl-bank-txn-setup.sql
+++ b/db/migrations/gl-bank-txn-setup.sql
@@ -1,0 +1,264 @@
+-- ============================================================
+-- GL Bank Transaction Event Triggers
+-- Generated: 2026-04-30
+--
+-- Raises gl_accounting_events rows automatically on writes to:
+--   t_bank_transaction        → BANK_TXN events  (source_id = t_bank_id)
+--   t_bank_transaction_splits → BANK_TXN UPDATE event on parent t_bank_id
+--
+-- Prerequisites:
+--   • m_bank.supplier_id column already exists (added in a prior migration)
+--   • Populate m_bank.supplier_id for is_oil_company='Y' rows BEFORE triggering
+--     live accounting, otherwise oil-company transactions will throw ledger errors.
+--     See the "Link oil company banks" section below for per-location UPDATE pattern.
+--
+-- INSERT trigger:
+--   Always raises a CREATE event. If accounting_type is NULL (not yet classified)
+--   the service handler will skip it (mark PROCESSED, 0 vouchers).  When the user
+--   later classifies the transaction, the UPDATE trigger fires and raises an UPDATE
+--   event which the handler processes normally.
+--
+-- UPDATE trigger (t_bank_transaction):
+--   Only fires when classification-relevant columns change:
+--     accounting_type, external_source, external_id, ledger_name, is_split
+--   Uses NULL-safe <=> operator to detect real changes.
+--   Follows the same PROCESSED/UNPROCESSED/None logic as other GL triggers.
+--
+-- UPDATE/DELETE triggers (t_bank_transaction_splits):
+--   Raise an UPDATE event on the parent t_bank_id so the handler can
+--   re-read all splits and regenerate vouchers.
+-- ============================================================
+
+
+-- ── Link oil company banks to m_supplier ─────────────────────────────────────
+-- Run this per-location to link each oil-company bank to its matching supplier.
+-- Example — IOCL bank for location SFS:
+--
+--   UPDATE m_bank SET supplier_id = (
+--       SELECT supplier_id FROM m_supplier
+--       WHERE supplier_name LIKE '%INDIANOIL%' AND location_code = 'SFS'
+--       LIMIT 1
+--   ) WHERE bank_id = <iocl_bank_id_for_sfs>;
+--
+-- BPCL example:
+--   UPDATE m_bank SET supplier_id = (
+--       SELECT supplier_id FROM m_supplier
+--       WHERE supplier_name LIKE '%BPCL%' AND location_code = 'SFS'
+--       LIMIT 1
+--   ) WHERE is_oil_company = 'Y' AND bank_name LIKE '%BPCL%' AND location_code = 'SFS';
+--
+-- After linking, verify with:
+--   SELECT bank_id, bank_name, location_code, supplier_id
+--   FROM m_bank WHERE is_oil_company = 'Y';
+-- ─────────────────────────────────────────────────────────────────────────────
+
+
+DROP TRIGGER IF EXISTS trg_bank_txn_gl_insert;
+DROP TRIGGER IF EXISTS trg_bank_txn_gl_update;
+DROP TRIGGER IF EXISTS trg_bank_txn_split_gl_insert;
+DROP TRIGGER IF EXISTS trg_bank_txn_split_gl_delete;
+
+DELIMITER $$
+
+-- ── t_bank_transaction : INSERT ───────────────────────────────────────────────
+
+CREATE TRIGGER trg_bank_txn_gl_insert
+AFTER INSERT ON t_bank_transaction
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+    DECLARE v_fy_id         INT;
+
+    SELECT mb.location_code
+    INTO   v_location_code
+    FROM   m_bank mb
+    WHERE  mb.bank_id = NEW.bank_id;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT fy.fy_id INTO v_fy_id
+        FROM   gl_financial_years fy
+        WHERE  fy.location_code = v_location_code
+          AND  NEW.trans_date BETWEEN fy.start_date AND fy.end_date
+        LIMIT 1;
+
+        IF v_fy_id IS NOT NULL THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'BANK_TXN', NEW.t_bank_id, 'CREATE', NEW.trans_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bank_transaction : UPDATE ───────────────────────────────────────────────
+-- Only fires when classification-relevant columns change.
+
+CREATE TRIGGER trg_bank_txn_gl_update
+AFTER UPDATE ON t_bank_transaction
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+    DECLARE v_cols_changed    TINYINT DEFAULT 0;
+
+    -- Check if any classification column changed (NULL-safe comparison)
+    IF NOT (NEW.external_source <=> OLD.external_source)
+    OR NOT (NEW.external_id     <=> OLD.external_id)
+    OR NOT (NEW.ledger_name     <=> OLD.ledger_name)
+    OR NOT (NEW.is_split        <=> OLD.is_split)
+    THEN
+        SET v_cols_changed = 1;
+    END IF;
+
+    IF v_cols_changed = 1 THEN
+        SELECT mb.location_code
+        INTO   v_location_code
+        FROM   m_bank mb
+        WHERE  mb.bank_id = NEW.bank_id;
+
+        IF v_location_code IS NOT NULL THEN
+            SELECT fy.fy_id INTO v_fy_id
+            FROM   gl_financial_years fy
+            WHERE  fy.location_code = v_location_code
+              AND  NEW.trans_date BETWEEN fy.start_date AND fy.end_date
+            LIMIT 1;
+
+            IF v_fy_id IS NOT NULL THEN
+                SELECT COUNT(*) INTO v_processed_count
+                FROM   gl_accounting_events
+                WHERE  source_type = 'BANK_TXN' AND source_id = NEW.t_bank_id AND event_status = 'PROCESSED';
+
+                SELECT COUNT(*) INTO v_pending_count
+                FROM   gl_accounting_events
+                WHERE  source_type = 'BANK_TXN' AND source_id = NEW.t_bank_id AND event_status = 'UNPROCESSED';
+
+                IF v_processed_count > 0 THEN
+                    INSERT INTO gl_accounting_events
+                        (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                    VALUES
+                        (v_location_code, v_fy_id, 'BANK_TXN', NEW.t_bank_id, 'UPDATE', NEW.trans_date, 'UNPROCESSED', 'TRIGGER');
+                ELSEIF v_pending_count > 0 THEN
+                    UPDATE gl_accounting_events
+                    SET    event_type = 'UPDATE'
+                    WHERE  source_type = 'BANK_TXN' AND source_id = NEW.t_bank_id AND event_status = 'UNPROCESSED';
+                ELSE
+                    INSERT INTO gl_accounting_events
+                        (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                    VALUES
+                        (v_location_code, v_fy_id, 'BANK_TXN', NEW.t_bank_id, 'CREATE', NEW.trans_date, 'UNPROCESSED', 'TRIGGER');
+                END IF;
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bank_transaction_splits : INSERT ───────────────────────────────────────
+-- A new split row means the parent transaction's accounting changes → UPDATE event.
+
+CREATE TRIGGER trg_bank_txn_split_gl_insert
+AFTER INSERT ON t_bank_transaction_splits
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_trans_date      DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    SELECT mb.location_code, tbt.trans_date
+    INTO   v_location_code, v_trans_date
+    FROM   t_bank_transaction tbt
+    JOIN   m_bank mb ON mb.bank_id = tbt.bank_id
+    WHERE  tbt.t_bank_id = NEW.t_bank_id;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT fy.fy_id INTO v_fy_id
+        FROM   gl_financial_years fy
+        WHERE  fy.location_code = v_location_code
+          AND  v_trans_date BETWEEN fy.start_date AND fy.end_date
+        LIMIT 1;
+
+        IF v_fy_id IS NOT NULL THEN
+            SELECT COUNT(*) INTO v_processed_count
+            FROM   gl_accounting_events
+            WHERE  source_type = 'BANK_TXN' AND source_id = NEW.t_bank_id AND event_status = 'PROCESSED';
+
+            SELECT COUNT(*) INTO v_pending_count
+            FROM   gl_accounting_events
+            WHERE  source_type = 'BANK_TXN' AND source_id = NEW.t_bank_id AND event_status = 'UNPROCESSED';
+
+            IF v_processed_count > 0 THEN
+                INSERT INTO gl_accounting_events
+                    (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                VALUES
+                    (v_location_code, v_fy_id, 'BANK_TXN', NEW.t_bank_id, 'UPDATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+            ELSEIF v_pending_count > 0 THEN
+                UPDATE gl_accounting_events
+                SET    event_type = 'UPDATE'
+                WHERE  source_type = 'BANK_TXN' AND source_id = NEW.t_bank_id AND event_status = 'UNPROCESSED';
+            ELSE
+                INSERT INTO gl_accounting_events
+                    (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                VALUES
+                    (v_location_code, v_fy_id, 'BANK_TXN', NEW.t_bank_id, 'CREATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bank_transaction_splits : DELETE ───────────────────────────────────────
+-- Removing a split row also changes parent accounting → UPDATE event.
+
+CREATE TRIGGER trg_bank_txn_split_gl_delete
+AFTER DELETE ON t_bank_transaction_splits
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_trans_date      DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    SELECT mb.location_code, tbt.trans_date
+    INTO   v_location_code, v_trans_date
+    FROM   t_bank_transaction tbt
+    JOIN   m_bank mb ON mb.bank_id = tbt.bank_id
+    WHERE  tbt.t_bank_id = OLD.t_bank_id;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT fy.fy_id INTO v_fy_id
+        FROM   gl_financial_years fy
+        WHERE  fy.location_code = v_location_code
+          AND  v_trans_date BETWEEN fy.start_date AND fy.end_date
+        LIMIT 1;
+
+        IF v_fy_id IS NOT NULL THEN
+            SELECT COUNT(*) INTO v_processed_count
+            FROM   gl_accounting_events
+            WHERE  source_type = 'BANK_TXN' AND source_id = OLD.t_bank_id AND event_status = 'PROCESSED';
+
+            SELECT COUNT(*) INTO v_pending_count
+            FROM   gl_accounting_events
+            WHERE  source_type = 'BANK_TXN' AND source_id = OLD.t_bank_id AND event_status = 'UNPROCESSED';
+
+            IF v_processed_count > 0 THEN
+                INSERT INTO gl_accounting_events
+                    (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                VALUES
+                    (v_location_code, v_fy_id, 'BANK_TXN', OLD.t_bank_id, 'UPDATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+            ELSEIF v_pending_count > 0 THEN
+                UPDATE gl_accounting_events
+                SET    event_type = 'UPDATE'
+                WHERE  source_type = 'BANK_TXN' AND source_id = OLD.t_bank_id AND event_status = 'UNPROCESSED';
+            -- If no event exists for a split delete, nothing to do (nothing was ever journaled)
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SHOW TRIGGERS WHERE `Table` IN ('t_bank_transaction', 't_bank_transaction_splits');

--- a/db/migrations/gl-bowser-triggers.sql
+++ b/db/migrations/gl-bowser-triggers.sql
@@ -1,0 +1,399 @@
+-- ============================================================
+-- GL Bowser Sale Event Triggers
+-- Generated: 2026-05-02
+--
+-- Raises gl_accounting_events rows automatically on writes to:
+--   t_bowser_credits       → BOWSER_CREDIT_SALE events  (source_id = credit_id)
+--   t_bowser_cashsales     → BOWSER_CASH_SALE events    (source_id = cashsale_id)
+--   t_bowser_digital_sales → BOWSER_DIGITAL_SALE events (source_id = digital_id)
+--
+-- Location / date resolved from t_bowser_closing (joined via bowser_closing_id).
+-- DELETE triggers read location/fy/date from existing gl_accounting_events rows.
+--
+-- Bowser closing gate: the accounting engine skips BOWSER_* events for dates
+-- where t_bowser_closing.status = 'DRAFT' — same pattern as shift closing gate.
+-- ============================================================
+
+DROP TRIGGER IF EXISTS trg_bowser_credit_gl_insert;
+DROP TRIGGER IF EXISTS trg_bowser_credit_gl_update;
+DROP TRIGGER IF EXISTS trg_bowser_credit_gl_delete;
+DROP TRIGGER IF EXISTS trg_bowser_cash_gl_insert;
+DROP TRIGGER IF EXISTS trg_bowser_cash_gl_update;
+DROP TRIGGER IF EXISTS trg_bowser_cash_gl_delete;
+DROP TRIGGER IF EXISTS trg_bowser_digital_gl_insert;
+DROP TRIGGER IF EXISTS trg_bowser_digital_gl_update;
+DROP TRIGGER IF EXISTS trg_bowser_digital_gl_delete;
+
+DELIMITER $$
+
+-- ── t_bowser_credits : INSERT ─────────────────────────────────────────────────
+
+CREATE TRIGGER trg_bowser_credit_gl_insert
+AFTER INSERT ON t_bowser_credits
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+    DECLARE v_trans_date    DATE;
+    DECLARE v_fy_id         INT;
+
+    SELECT tbc.location_code, tbc.closing_date
+    INTO   v_location_code, v_trans_date
+    FROM   t_bowser_closing tbc
+    WHERE  tbc.bowser_closing_id = NEW.bowser_closing_id;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT fy.fy_id INTO v_fy_id
+        FROM   gl_financial_years fy
+        WHERE  fy.location_code = v_location_code
+          AND  v_trans_date BETWEEN fy.start_date AND fy.end_date
+        LIMIT 1;
+
+        IF v_fy_id IS NOT NULL THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'BOWSER_CREDIT_SALE', NEW.credit_id, 'CREATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bowser_credits : UPDATE ─────────────────────────────────────────────────
+-- Fires when any financially relevant column changes.
+
+CREATE TRIGGER trg_bowser_credit_gl_update
+AFTER UPDATE ON t_bowser_credits
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_trans_date      DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    IF NOT (NEW.amount       <=> OLD.amount)
+    OR NOT (NEW.product_id   <=> OLD.product_id)
+    OR NOT (NEW.creditlist_id <=> OLD.creditlist_id)
+    OR NOT (NEW.quantity     <=> OLD.quantity)
+    OR NOT (NEW.rate         <=> OLD.rate)
+    THEN
+        SELECT tbc.location_code, tbc.closing_date
+        INTO   v_location_code, v_trans_date
+        FROM   t_bowser_closing tbc
+        WHERE  tbc.bowser_closing_id = NEW.bowser_closing_id;
+
+        IF v_location_code IS NOT NULL THEN
+            SELECT fy.fy_id INTO v_fy_id
+            FROM   gl_financial_years fy
+            WHERE  fy.location_code = v_location_code
+              AND  v_trans_date BETWEEN fy.start_date AND fy.end_date
+            LIMIT 1;
+
+            IF v_fy_id IS NOT NULL THEN
+                SELECT COUNT(*) INTO v_processed_count
+                FROM   gl_accounting_events
+                WHERE  source_type = 'BOWSER_CREDIT_SALE' AND source_id = NEW.credit_id AND event_status = 'PROCESSED';
+
+                SELECT COUNT(*) INTO v_pending_count
+                FROM   gl_accounting_events
+                WHERE  source_type = 'BOWSER_CREDIT_SALE' AND source_id = NEW.credit_id AND event_status = 'UNPROCESSED';
+
+                IF v_processed_count > 0 THEN
+                    INSERT INTO gl_accounting_events
+                        (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                    VALUES
+                        (v_location_code, v_fy_id, 'BOWSER_CREDIT_SALE', NEW.credit_id, 'UPDATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+                ELSEIF v_pending_count > 0 THEN
+                    UPDATE gl_accounting_events
+                    SET    event_type = 'UPDATE'
+                    WHERE  source_type = 'BOWSER_CREDIT_SALE' AND source_id = NEW.credit_id AND event_status = 'UNPROCESSED';
+                ELSE
+                    INSERT INTO gl_accounting_events
+                        (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                    VALUES
+                        (v_location_code, v_fy_id, 'BOWSER_CREDIT_SALE', NEW.credit_id, 'CREATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+                END IF;
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bowser_credits : DELETE ─────────────────────────────────────────────────
+
+CREATE TRIGGER trg_bowser_credit_gl_delete
+AFTER DELETE ON t_bowser_credits
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'BOWSER_CREDIT_SALE' AND source_id = OLD.credit_id
+    ORDER BY event_id DESC LIMIT 1;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'BOWSER_CREDIT_SALE' AND source_id = OLD.credit_id AND event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type = 'BOWSER_CREDIT_SALE' AND source_id = OLD.credit_id AND event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'BOWSER_CREDIT_SALE', OLD.credit_id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bowser_cashsales : INSERT ───────────────────────────────────────────────
+
+CREATE TRIGGER trg_bowser_cash_gl_insert
+AFTER INSERT ON t_bowser_cashsales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+    DECLARE v_trans_date    DATE;
+    DECLARE v_fy_id         INT;
+
+    SELECT tbc.location_code, tbc.closing_date
+    INTO   v_location_code, v_trans_date
+    FROM   t_bowser_closing tbc
+    WHERE  tbc.bowser_closing_id = NEW.bowser_closing_id;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT fy.fy_id INTO v_fy_id
+        FROM   gl_financial_years fy
+        WHERE  fy.location_code = v_location_code
+          AND  v_trans_date BETWEEN fy.start_date AND fy.end_date
+        LIMIT 1;
+
+        IF v_fy_id IS NOT NULL THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'BOWSER_CASH_SALE', NEW.cashsale_id, 'CREATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bowser_cashsales : UPDATE ───────────────────────────────────────────────
+
+CREATE TRIGGER trg_bowser_cash_gl_update
+AFTER UPDATE ON t_bowser_cashsales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_trans_date      DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    IF NOT (NEW.amount     <=> OLD.amount)
+    OR NOT (NEW.product_id <=> OLD.product_id)
+    THEN
+        SELECT tbc.location_code, tbc.closing_date
+        INTO   v_location_code, v_trans_date
+        FROM   t_bowser_closing tbc
+        WHERE  tbc.bowser_closing_id = NEW.bowser_closing_id;
+
+        IF v_location_code IS NOT NULL THEN
+            SELECT fy.fy_id INTO v_fy_id
+            FROM   gl_financial_years fy
+            WHERE  fy.location_code = v_location_code
+              AND  v_trans_date BETWEEN fy.start_date AND fy.end_date
+            LIMIT 1;
+
+            IF v_fy_id IS NOT NULL THEN
+                SELECT COUNT(*) INTO v_processed_count
+                FROM   gl_accounting_events
+                WHERE  source_type = 'BOWSER_CASH_SALE' AND source_id = NEW.cashsale_id AND event_status = 'PROCESSED';
+
+                SELECT COUNT(*) INTO v_pending_count
+                FROM   gl_accounting_events
+                WHERE  source_type = 'BOWSER_CASH_SALE' AND source_id = NEW.cashsale_id AND event_status = 'UNPROCESSED';
+
+                IF v_processed_count > 0 THEN
+                    INSERT INTO gl_accounting_events
+                        (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                    VALUES
+                        (v_location_code, v_fy_id, 'BOWSER_CASH_SALE', NEW.cashsale_id, 'UPDATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+                ELSEIF v_pending_count > 0 THEN
+                    UPDATE gl_accounting_events
+                    SET    event_type = 'UPDATE'
+                    WHERE  source_type = 'BOWSER_CASH_SALE' AND source_id = NEW.cashsale_id AND event_status = 'UNPROCESSED';
+                ELSE
+                    INSERT INTO gl_accounting_events
+                        (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                    VALUES
+                        (v_location_code, v_fy_id, 'BOWSER_CASH_SALE', NEW.cashsale_id, 'CREATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+                END IF;
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bowser_cashsales : DELETE ───────────────────────────────────────────────
+
+CREATE TRIGGER trg_bowser_cash_gl_delete
+AFTER DELETE ON t_bowser_cashsales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'BOWSER_CASH_SALE' AND source_id = OLD.cashsale_id
+    ORDER BY event_id DESC LIMIT 1;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'BOWSER_CASH_SALE' AND source_id = OLD.cashsale_id AND event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type = 'BOWSER_CASH_SALE' AND source_id = OLD.cashsale_id AND event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'BOWSER_CASH_SALE', OLD.cashsale_id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bowser_digital_sales : INSERT ──────────────────────────────────────────
+
+CREATE TRIGGER trg_bowser_digital_gl_insert
+AFTER INSERT ON t_bowser_digital_sales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+    DECLARE v_trans_date    DATE;
+    DECLARE v_fy_id         INT;
+
+    SELECT tbc.location_code, tbc.closing_date
+    INTO   v_location_code, v_trans_date
+    FROM   t_bowser_closing tbc
+    WHERE  tbc.bowser_closing_id = NEW.bowser_closing_id;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT fy.fy_id INTO v_fy_id
+        FROM   gl_financial_years fy
+        WHERE  fy.location_code = v_location_code
+          AND  v_trans_date BETWEEN fy.start_date AND fy.end_date
+        LIMIT 1;
+
+        IF v_fy_id IS NOT NULL THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'BOWSER_DIGITAL_SALE', NEW.digital_id, 'CREATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bowser_digital_sales : UPDATE ──────────────────────────────────────────
+
+CREATE TRIGGER trg_bowser_digital_gl_update
+AFTER UPDATE ON t_bowser_digital_sales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_trans_date      DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    IF NOT (NEW.amount            <=> OLD.amount)
+    OR NOT (NEW.digital_vendor_id <=> OLD.digital_vendor_id)
+    THEN
+        SELECT tbc.location_code, tbc.closing_date
+        INTO   v_location_code, v_trans_date
+        FROM   t_bowser_closing tbc
+        WHERE  tbc.bowser_closing_id = NEW.bowser_closing_id;
+
+        IF v_location_code IS NOT NULL THEN
+            SELECT fy.fy_id INTO v_fy_id
+            FROM   gl_financial_years fy
+            WHERE  fy.location_code = v_location_code
+              AND  v_trans_date BETWEEN fy.start_date AND fy.end_date
+            LIMIT 1;
+
+            IF v_fy_id IS NOT NULL THEN
+                SELECT COUNT(*) INTO v_processed_count
+                FROM   gl_accounting_events
+                WHERE  source_type = 'BOWSER_DIGITAL_SALE' AND source_id = NEW.digital_id AND event_status = 'PROCESSED';
+
+                SELECT COUNT(*) INTO v_pending_count
+                FROM   gl_accounting_events
+                WHERE  source_type = 'BOWSER_DIGITAL_SALE' AND source_id = NEW.digital_id AND event_status = 'UNPROCESSED';
+
+                IF v_processed_count > 0 THEN
+                    INSERT INTO gl_accounting_events
+                        (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                    VALUES
+                        (v_location_code, v_fy_id, 'BOWSER_DIGITAL_SALE', NEW.digital_id, 'UPDATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+                ELSEIF v_pending_count > 0 THEN
+                    UPDATE gl_accounting_events
+                    SET    event_type = 'UPDATE'
+                    WHERE  source_type = 'BOWSER_DIGITAL_SALE' AND source_id = NEW.digital_id AND event_status = 'UNPROCESSED';
+                ELSE
+                    INSERT INTO gl_accounting_events
+                        (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                    VALUES
+                        (v_location_code, v_fy_id, 'BOWSER_DIGITAL_SALE', NEW.digital_id, 'CREATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+                END IF;
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bowser_digital_sales : DELETE ──────────────────────────────────────────
+
+CREATE TRIGGER trg_bowser_digital_gl_delete
+AFTER DELETE ON t_bowser_digital_sales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'BOWSER_DIGITAL_SALE' AND source_id = OLD.digital_id
+    ORDER BY event_id DESC LIMIT 1;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'BOWSER_DIGITAL_SALE' AND source_id = OLD.digital_id AND event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type = 'BOWSER_DIGITAL_SALE' AND source_id = OLD.digital_id AND event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'BOWSER_DIGITAL_SALE', OLD.digital_id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SHOW TRIGGERS WHERE `Table` IN ('t_bowser_credits', 't_bowser_cashsales', 't_bowser_digital_sales');

--- a/db/migrations/gl-control-menu-item.sql
+++ b/db/migrations/gl-control-menu-item.sql
@@ -1,0 +1,23 @@
+-- ============================================================
+-- GL Control — Menu Item & Access
+-- Generated: 2026-05-02
+--
+-- Adds the GL Control page under the ACCOUNTING group.
+-- Run on dev and prod.
+-- ============================================================
+
+INSERT INTO m_menu_items
+    (menu_code, menu_name, icon, url_path, parent_code, sequence, effective_start_date, created_by, updated_by, group_code)
+VALUES
+    ('GL_CONTROL', 'GL Control', 'bi-sliders', '/gl/control', NULL, 8, '2026-05-02', 'SAKTHI', 'SAKTHI', 'ACCOUNTING');
+
+INSERT INTO m_menu_access_global
+    (role, menu_code, allowed, effective_start_date, created_by, updated_by)
+VALUES
+    ('SuperUser', 'GL_CONTROL', 1, '2026-05-02', 'SAKTHI', 'SAKTHI');
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SELECT menu_code, menu_name, sequence, group_code
+FROM m_menu_items
+WHERE group_code = 'ACCOUNTING'
+ORDER BY sequence;

--- a/db/migrations/gl-delete-triggers.sql
+++ b/db/migrations/gl-delete-triggers.sql
@@ -1,0 +1,184 @@
+-- ============================================================
+-- GL Delete Triggers — Source Transaction Deletion
+-- Generated: 2026-05-02
+--
+-- When a source transaction row is deleted:
+--   • UNPROCESSED / ERROR events are deleted directly —
+--     nothing was ever journaled, so nothing to reverse.
+--   • If PROCESSED events exist, a DELETE event is raised so
+--     the engine can reverse the posted vouchers.
+--
+-- location_code / fy_id / event_date are read from the
+-- existing gl_accounting_events row to avoid re-joining the
+-- source table (cleaner, works even for soft-deleted rows).
+--
+-- Covers: t_credits, t_cashsales, t_day_bill, t_bank_transaction
+-- ============================================================
+
+DROP TRIGGER IF EXISTS trg_credits_gl_delete;
+DROP TRIGGER IF EXISTS trg_cashsales_gl_delete;
+DROP TRIGGER IF EXISTS trg_day_bill_gl_delete;
+DROP TRIGGER IF EXISTS trg_bank_txn_gl_delete;
+
+DELIMITER $$
+
+-- ── t_credits : DELETE ────────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_credits_gl_delete
+AFTER DELETE ON t_credits
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'CREDIT_SALE' AND source_id = OLD.tcredit_id
+    ORDER BY event_id DESC
+    LIMIT 1;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type  = 'CREDIT_SALE'
+          AND  source_id    = OLD.tcredit_id
+          AND  event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type  = 'CREDIT_SALE'
+          AND  source_id    = OLD.tcredit_id
+          AND  event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'CREDIT_SALE', OLD.tcredit_id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_cashsales : DELETE ──────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_cashsales_gl_delete
+AFTER DELETE ON t_cashsales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'CASH_SALE' AND source_id = OLD.cashsales_id
+    ORDER BY event_id DESC
+    LIMIT 1;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type  = 'CASH_SALE'
+          AND  source_id    = OLD.cashsales_id
+          AND  event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type  = 'CASH_SALE'
+          AND  source_id    = OLD.cashsales_id
+          AND  event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'CASH_SALE', OLD.cashsales_id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_day_bill : DELETE ───────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_day_bill_gl_delete
+AFTER DELETE ON t_day_bill
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'DAY_BILL' AND source_id = OLD.day_bill_id
+    ORDER BY event_id DESC
+    LIMIT 1;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type  = 'DAY_BILL'
+          AND  source_id    = OLD.day_bill_id
+          AND  event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type  = 'DAY_BILL'
+          AND  source_id    = OLD.day_bill_id
+          AND  event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'DAY_BILL', OLD.day_bill_id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bank_transaction : DELETE ───────────────────────────────────────────────
+
+CREATE TRIGGER trg_bank_txn_gl_delete
+AFTER DELETE ON t_bank_transaction
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'BANK_TXN' AND source_id = OLD.t_bank_id
+    ORDER BY event_id DESC
+    LIMIT 1;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type  = 'BANK_TXN'
+          AND  source_id    = OLD.t_bank_id
+          AND  event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type  = 'BANK_TXN'
+          AND  source_id    = OLD.t_bank_id
+          AND  event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'BANK_TXN', OLD.t_bank_id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SHOW TRIGGERS WHERE `Table` IN ('t_credits', 't_cashsales', 't_day_bill', 't_bank_transaction');

--- a/db/migrations/gl-menu-items.sql
+++ b/db/migrations/gl-menu-items.sql
@@ -1,0 +1,38 @@
+-- ============================================================
+-- GL Accounting — Menu Items & Access
+-- Generated: 2026-05-02
+--
+-- Adds menu items for all GL reports and Manual Journal
+-- under the existing ACCOUNTING group.
+-- Run on dev and prod.
+-- ============================================================
+
+-- ── Menu Items ────────────────────────────────────────────────────────────────
+
+INSERT INTO m_menu_items
+    (menu_code, menu_name, icon, url_path, parent_code, sequence, effective_start_date, created_by, updated_by, group_code)
+VALUES
+    ('GL_MANUAL_JOURNAL', 'Manual Journal',  'bi-pencil-square',  '/gl/journal',         NULL, 2, '2026-05-02', 'SAKTHI', 'SAKTHI', 'ACCOUNTING'),
+    ('GL_DAY_BOOK',       'Day Book',         'bi-journal-text',   '/gl/day-book',        NULL, 3, '2026-05-02', 'SAKTHI', 'SAKTHI', 'ACCOUNTING'),
+    ('GL_LEDGER',         'Ledger Report',    'bi-book',           '/gl/ledger',          NULL, 4, '2026-05-02', 'SAKTHI', 'SAKTHI', 'ACCOUNTING'),
+    ('GL_TRIAL_BALANCE',  'Trial Balance',    'bi-clipboard-data', '/gl/trial-balance',   NULL, 5, '2026-05-02', 'SAKTHI', 'SAKTHI', 'ACCOUNTING'),
+    ('GL_PROFIT_LOSS',    'Profit & Loss',    'bi-graph-up',       '/gl/profit-loss',     NULL, 6, '2026-05-02', 'SAKTHI', 'SAKTHI', 'ACCOUNTING'),
+    ('GL_BALANCE_SHEET',  'Balance Sheet',    'bi-building',       '/gl/balance-sheet',   NULL, 7, '2026-05-02', 'SAKTHI', 'SAKTHI', 'ACCOUNTING');
+
+-- ── Global Access (SuperUser) ─────────────────────────────────────────────────
+
+INSERT INTO m_menu_access_global
+    (role, menu_code, allowed, effective_start_date, created_by, updated_by)
+VALUES
+    ('SuperUser', 'GL_MANUAL_JOURNAL', 1, '2026-05-02', 'SAKTHI', 'SAKTHI'),
+    ('SuperUser', 'GL_DAY_BOOK',       1, '2026-05-02', 'SAKTHI', 'SAKTHI'),
+    ('SuperUser', 'GL_LEDGER',         1, '2026-05-02', 'SAKTHI', 'SAKTHI'),
+    ('SuperUser', 'GL_TRIAL_BALANCE',  1, '2026-05-02', 'SAKTHI', 'SAKTHI'),
+    ('SuperUser', 'GL_PROFIT_LOSS',    1, '2026-05-02', 'SAKTHI', 'SAKTHI'),
+    ('SuperUser', 'GL_BALANCE_SHEET',  1, '2026-05-02', 'SAKTHI', 'SAKTHI');
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SELECT menu_code, menu_name, sequence, group_code
+FROM m_menu_items
+WHERE group_code = 'ACCOUNTING'
+ORDER BY sequence;

--- a/db/migrations/gl-product-map-types-seed.sql
+++ b/db/migrations/gl-product-map-types-seed.sql
@@ -1,0 +1,30 @@
+-- ============================================================
+-- Product GL Map Types — m_lookup seed
+-- Generated: 2026-05-02
+--
+-- Moves PRODUCT_MAP_TYPES out of code into m_lookup so new
+-- map types can be added without a code deploy.
+--
+-- lookup_type : 'ProductMapType'
+-- tag         : code key used in gl_product_ledger_map.map_type
+-- description : display label shown in the UI modal
+-- attribute1  : ledger group category key (used by the route
+--               to decide which ledger dropdown to show)
+-- ============================================================
+
+-- Idempotent: remove existing rows then re-insert
+DELETE FROM m_lookup WHERE lookup_type = 'ProductMapType';
+
+INSERT INTO m_lookup (lookup_type, description, tag, attribute1, created_by) VALUES
+    ('ProductMapType', 'Sales',       'SALES',       'sales',    'SYSTEM'),
+    ('ProductMapType', 'Purchase',    'PURCHASE',    'purchase', 'SYSTEM'),
+    ('ProductMapType', 'Output CGST', 'OUTPUT_CGST', 'tax',      'SYSTEM'),
+    ('ProductMapType', 'Output SGST', 'OUTPUT_SGST', 'tax',      'SYSTEM'),
+    ('ProductMapType', 'Input CGST',  'INPUT_CGST',  'tax',      'SYSTEM'),
+    ('ProductMapType', 'Input SGST',  'INPUT_SGST',  'tax',      'SYSTEM');
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SELECT lookup_id, description, tag, attribute1
+FROM m_lookup
+WHERE lookup_type = 'ProductMapType'
+ORDER BY lookup_id;

--- a/db/migrations/gl-purchase-invoice-triggers.sql
+++ b/db/migrations/gl-purchase-invoice-triggers.sql
@@ -1,0 +1,247 @@
+-- ============================================================
+-- GL Purchase Invoice Event Triggers
+-- Generated: 2026-05-02
+--
+-- Raises gl_accounting_events rows automatically on writes to:
+--   t_lubes_inv_hdr  → LUBES_INVOICE events  (source_id = lubes_hdr_id)
+--   t_tank_invoice   → TANK_INVOICE events   (source_id = id)
+--
+-- Triggers are on HEADERS only.  Lines are read at process time.
+--
+-- LUBES_INVOICE draft gate:
+--   The engine handler checks closing_status at process time.
+--   If DRAFT  → marks PROCESSED with 0 vouchers (skip silently).
+--   If CLOSED → journals created normally.
+--   When status changes DRAFT→CLOSED the UPDATE trigger fires,
+--   raising an UPDATE event that the engine picks up.
+--
+-- TANK_INVOICE:
+--   No status column — events processed immediately on INSERT/UPDATE.
+--   location_id column stores the location_code string.
+-- ============================================================
+
+DROP TRIGGER IF EXISTS trg_lubes_inv_gl_insert;
+DROP TRIGGER IF EXISTS trg_lubes_inv_gl_update;
+DROP TRIGGER IF EXISTS trg_lubes_inv_gl_delete;
+DROP TRIGGER IF EXISTS trg_tank_inv_gl_insert;
+DROP TRIGGER IF EXISTS trg_tank_inv_gl_update;
+DROP TRIGGER IF EXISTS trg_tank_inv_gl_delete;
+
+DELIMITER $$
+
+-- ── t_lubes_inv_hdr : INSERT ──────────────────────────────────────────────────
+
+CREATE TRIGGER trg_lubes_inv_gl_insert
+AFTER INSERT ON t_lubes_inv_hdr
+FOR EACH ROW
+BEGIN
+    DECLARE v_fy_id INT;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = NEW.location_code
+      AND  NEW.invoice_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        VALUES
+            (NEW.location_code, v_fy_id, 'LUBES_INVOICE', NEW.lubes_hdr_id, 'CREATE', NEW.invoice_date, 'UNPROCESSED', 'TRIGGER');
+    END IF;
+END$$
+
+-- ── t_lubes_inv_hdr : UPDATE ──────────────────────────────────────────────────
+-- Fires when status changes (DRAFT→CLOSED is the key transition) or financial
+-- columns change.
+
+CREATE TRIGGER trg_lubes_inv_gl_update
+AFTER UPDATE ON t_lubes_inv_hdr
+FOR EACH ROW
+BEGIN
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    IF NOT (NEW.closing_status  <=> OLD.closing_status)
+    OR NOT (NEW.supplier_id     <=> OLD.supplier_id)
+    OR NOT (NEW.invoice_amount  <=> OLD.invoice_amount)
+    OR NOT (NEW.invoice_date    <=> OLD.invoice_date)
+    THEN
+        SELECT fy.fy_id INTO v_fy_id
+        FROM   gl_financial_years fy
+        WHERE  fy.location_code = NEW.location_code
+          AND  NEW.invoice_date BETWEEN fy.start_date AND fy.end_date
+        LIMIT 1;
+
+        IF v_fy_id IS NOT NULL THEN
+            SELECT COUNT(*) INTO v_processed_count
+            FROM   gl_accounting_events
+            WHERE  source_type = 'LUBES_INVOICE' AND source_id = NEW.lubes_hdr_id AND event_status = 'PROCESSED';
+
+            SELECT COUNT(*) INTO v_pending_count
+            FROM   gl_accounting_events
+            WHERE  source_type = 'LUBES_INVOICE' AND source_id = NEW.lubes_hdr_id AND event_status = 'UNPROCESSED';
+
+            IF v_processed_count > 0 THEN
+                INSERT INTO gl_accounting_events
+                    (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                VALUES
+                    (NEW.location_code, v_fy_id, 'LUBES_INVOICE', NEW.lubes_hdr_id, 'UPDATE', NEW.invoice_date, 'UNPROCESSED', 'TRIGGER');
+            ELSEIF v_pending_count > 0 THEN
+                UPDATE gl_accounting_events
+                SET    event_type = 'UPDATE'
+                WHERE  source_type = 'LUBES_INVOICE' AND source_id = NEW.lubes_hdr_id AND event_status = 'UNPROCESSED';
+            ELSE
+                INSERT INTO gl_accounting_events
+                    (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                VALUES
+                    (NEW.location_code, v_fy_id, 'LUBES_INVOICE', NEW.lubes_hdr_id, 'CREATE', NEW.invoice_date, 'UNPROCESSED', 'TRIGGER');
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+-- ── t_lubes_inv_hdr : DELETE ──────────────────────────────────────────────────
+
+CREATE TRIGGER trg_lubes_inv_gl_delete
+AFTER DELETE ON t_lubes_inv_hdr
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'LUBES_INVOICE' AND source_id = OLD.lubes_hdr_id
+    ORDER BY event_id DESC LIMIT 1;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'LUBES_INVOICE' AND source_id = OLD.lubes_hdr_id AND event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type = 'LUBES_INVOICE' AND source_id = OLD.lubes_hdr_id AND event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'LUBES_INVOICE', OLD.lubes_hdr_id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_tank_invoice : INSERT ───────────────────────────────────────────────────
+-- location_id stores the location_code string.
+
+CREATE TRIGGER trg_tank_inv_gl_insert
+AFTER INSERT ON t_tank_invoice
+FOR EACH ROW
+BEGIN
+    DECLARE v_fy_id INT;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = NEW.location_id
+      AND  NEW.invoice_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        VALUES
+            (NEW.location_id, v_fy_id, 'TANK_INVOICE', NEW.id, 'CREATE', NEW.invoice_date, 'UNPROCESSED', 'TRIGGER');
+    END IF;
+END$$
+
+-- ── t_tank_invoice : UPDATE ───────────────────────────────────────────────────
+
+CREATE TRIGGER trg_tank_inv_gl_update
+AFTER UPDATE ON t_tank_invoice
+FOR EACH ROW
+BEGIN
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    IF NOT (NEW.total_invoice_amount <=> OLD.total_invoice_amount)
+    OR NOT (NEW.supplier_id          <=> OLD.supplier_id)
+    OR NOT (NEW.invoice_date         <=> OLD.invoice_date)
+    THEN
+        SELECT fy.fy_id INTO v_fy_id
+        FROM   gl_financial_years fy
+        WHERE  fy.location_code = NEW.location_id
+          AND  NEW.invoice_date BETWEEN fy.start_date AND fy.end_date
+        LIMIT 1;
+
+        IF v_fy_id IS NOT NULL THEN
+            SELECT COUNT(*) INTO v_processed_count
+            FROM   gl_accounting_events
+            WHERE  source_type = 'TANK_INVOICE' AND source_id = NEW.id AND event_status = 'PROCESSED';
+
+            SELECT COUNT(*) INTO v_pending_count
+            FROM   gl_accounting_events
+            WHERE  source_type = 'TANK_INVOICE' AND source_id = NEW.id AND event_status = 'UNPROCESSED';
+
+            IF v_processed_count > 0 THEN
+                INSERT INTO gl_accounting_events
+                    (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                VALUES
+                    (NEW.location_id, v_fy_id, 'TANK_INVOICE', NEW.id, 'UPDATE', NEW.invoice_date, 'UNPROCESSED', 'TRIGGER');
+            ELSEIF v_pending_count > 0 THEN
+                UPDATE gl_accounting_events
+                SET    event_type = 'UPDATE'
+                WHERE  source_type = 'TANK_INVOICE' AND source_id = NEW.id AND event_status = 'UNPROCESSED';
+            ELSE
+                INSERT INTO gl_accounting_events
+                    (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                VALUES
+                    (NEW.location_id, v_fy_id, 'TANK_INVOICE', NEW.id, 'CREATE', NEW.invoice_date, 'UNPROCESSED', 'TRIGGER');
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+-- ── t_tank_invoice : DELETE ───────────────────────────────────────────────────
+
+CREATE TRIGGER trg_tank_inv_gl_delete
+AFTER DELETE ON t_tank_invoice
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'TANK_INVOICE' AND source_id = OLD.id
+    ORDER BY event_id DESC LIMIT 1;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'TANK_INVOICE' AND source_id = OLD.id AND event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type = 'TANK_INVOICE' AND source_id = OLD.id AND event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'TANK_INVOICE', OLD.id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SHOW TRIGGERS WHERE `Table` IN ('t_lubes_inv_hdr', 't_tank_invoice');

--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -5,6 +5,7 @@ const login = require('connect-ensure-login');
 const isLoginEnsured = login.ensureLoggedIn({});
 const security = require('../utils/app-security');
 const db = require('../db/db-connection');
+const createAccountingService = require('../services/create-accounting-service');
 
 // GET /gl/api/ledgers/search?location=&group=&q=
 // Returns [{ledger_id, ledger_name}] — used by Select2 ajax typeahead on product ledger fields
@@ -38,6 +39,898 @@ router.get('/api/ledgers/search', [isLoginEnsured, security.isAdmin()], async fu
     } catch (error) {
         console.error('Error searching ledgers:', error);
         res.status(500).json({ error: 'Failed to search ledgers' });
+    }
+});
+
+// POST /gl/api/create-accounting
+// Body: { from_date, to_date }
+// Runs Create Accounting for the location and date range.
+router.post('/api/create-accounting', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const processedBy  = req.user.username;
+    const { from_date, to_date, reprocess } = req.body;
+
+    if (!from_date || !to_date) {
+        return res.status(400).json({ error: 'from_date and to_date are required' });
+    }
+
+    try {
+        const fn = reprocess === true || reprocess === 'true'
+            ? createAccountingService.reprocessEvents
+            : createAccountingService.processEvents;
+
+        const summary = await fn(locationCode, from_date, to_date, processedBy);
+        res.json({ success: true, summary });
+    } catch (err) {
+        console.error('Create Accounting error:', err);
+        res.status(500).json({ error: err.message });
+    }
+});
+
+// GET /gl/api/accounting-events?from_date=&to_date=&status=
+// Returns event queue for a date range — used by admin dashboard.
+router.get('/api/accounting-events', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const { from_date, to_date, status } = req.query;
+
+    try {
+        const rows = await db.sequelize.query(`
+            SELECT
+                e.event_id, e.source_type, e.source_id, e.event_type,
+                e.event_status, e.event_date, e.error_message,
+                e.processed_at, e.processed_by, e.voucher_id
+            FROM gl_accounting_events e
+            WHERE e.location_code = :locationCode
+              AND (:from_date IS NULL OR e.event_date >= :from_date)
+              AND (:to_date   IS NULL OR e.event_date <= :to_date)
+              AND (:status    IS NULL OR e.event_status = :status)
+            ORDER BY e.event_date DESC, e.event_id DESC
+            LIMIT 500
+        `, {
+            replacements: {
+                locationCode,
+                from_date: from_date || null,
+                to_date:   to_date   || null,
+                status:    status    || null
+            },
+            type: db.Sequelize.QueryTypes.SELECT
+        });
+        res.json(rows);
+    } catch (err) {
+        console.error('Accounting events fetch error:', err);
+        res.status(500).json({ error: err.message });
+    }
+});
+
+// ── Day Book ──────────────────────────────────────────────────────────────────
+// GET /gl/day-book?from_date=&to_date=&voucher_type=
+
+const VOUCHER_TYPES = ['SALES', 'PURCHASE', 'PAYMENT', 'RECEIPT', 'JOURNAL', 'CONTRA'];
+
+router.get('/day-book', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const today    = new Date().toISOString().substring(0, 10);
+    const fromDate = req.query.from_date    || today;
+    const toDate   = req.query.to_date      || today;
+    const selectedType = req.query.voucher_type || null;
+
+    try {
+        const rows = await db.sequelize.query(`
+            SELECT
+                h.voucher_id,
+                DATE_FORMAT(h.voucher_date, '%d-%b-%Y') AS voucher_date,
+                h.voucher_no,
+                h.voucher_type,
+                h.narration,
+                h.source_type,
+                h.is_reversal,
+                l.line_no,
+                gl.ledger_name,
+                l.dr_amount,
+                l.cr_amount,
+                l.narration AS line_narration
+            FROM gl_journal_headers h
+            JOIN gl_journal_lines l  ON l.voucher_id = h.voucher_id
+            JOIN gl_ledgers gl       ON gl.ledger_id  = l.ledger_id
+            WHERE h.location_code = :locationCode
+              AND h.voucher_date  BETWEEN :fromDate AND :toDate
+              AND (:selectedType IS NULL OR h.voucher_type = :selectedType)
+            ORDER BY h.voucher_date, h.voucher_id, l.line_no
+        `, {
+            replacements: { locationCode, fromDate, toDate, selectedType },
+            type: db.Sequelize.QueryTypes.SELECT
+        });
+
+        // Group lines under their voucher header
+        const voucherMap = new Map();
+        for (const row of rows) {
+            if (!voucherMap.has(row.voucher_id)) {
+                voucherMap.set(row.voucher_id, {
+                    voucher_id:   row.voucher_id,
+                    voucher_date: row.voucher_date,
+                    voucher_no:   row.voucher_no,
+                    voucher_type: row.voucher_type,
+                    narration:    row.narration,
+                    source_type:  row.source_type,
+                    is_reversal:  row.is_reversal,
+                    total_dr:     0,
+                    total_cr:     0,
+                    lines:        []
+                });
+            }
+            const v    = voucherMap.get(row.voucher_id);
+            const dr   = parseFloat(row.dr_amount || 0);
+            const cr   = parseFloat(row.cr_amount || 0);
+            v.total_dr += dr;
+            v.total_cr += cr;
+            v.lines.push({ line_no: row.line_no, ledger_name: row.ledger_name, dr_amount: dr, cr_amount: cr });
+        }
+
+        const vouchers      = [...voucherMap.values()];
+        const grandTotalDr  = vouchers.reduce((s, v) => s + v.total_dr, 0);
+        const grandTotalCr  = vouchers.reduce((s, v) => s + v.total_cr, 0);
+
+        res.render('gl-day-book', {
+            title:       'Day Book',
+            user:        req.user,
+            config:      require('../config/app-config').APP_CONFIGS,
+            fromDate,
+            toDate,
+            selectedType,
+            vouchers,
+            grandTotalDr,
+            grandTotalCr,
+            VOUCHER_TYPES
+        });
+    } catch (err) {
+        console.error('Day Book error:', err);
+        req.flash('error', 'Failed to load Day Book: ' + err.message);
+        res.redirect('/home');
+    }
+});
+
+// ── Ledger Report ─────────────────────────────────────────────────────────────
+// GET /gl/ledger?ledger_id=&from_date=&to_date=
+
+router.get('/ledger', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const today    = new Date().toISOString().substring(0, 10);
+    const fromDate = req.query.from_date || today;
+    const toDate   = req.query.to_date   || today;
+    const ledgerId = req.query.ledger_id ? parseInt(req.query.ledger_id) : null;
+
+    let ledger = null, entries = [], obNet = 0, periodDr = 0, periodCr = 0;
+
+    try {
+        if (ledgerId) {
+            // Fetch ledger meta
+            const ledgerRows = await db.sequelize.query(`
+                SELECT l.ledger_id, l.ledger_name, g.group_name, g.group_nature
+                FROM gl_ledgers l
+                JOIN gl_ledger_groups g ON g.group_id = l.group_id
+                WHERE l.ledger_id = :ledgerId AND l.location_code = :locationCode
+            `, { replacements: { ledgerId, locationCode }, type: db.Sequelize.QueryTypes.SELECT });
+
+            if (!ledgerRows.length) throw new Error(`Ledger not found: ${ledgerId}`);
+            ledger = ledgerRows[0];
+
+            // Opening balance = all entries before fromDate
+            const obRows = await db.sequelize.query(`
+                SELECT
+                    COALESCE(SUM(l.dr_amount), 0) AS ob_dr,
+                    COALESCE(SUM(l.cr_amount), 0) AS ob_cr
+                FROM gl_journal_lines l
+                JOIN gl_journal_headers h ON h.voucher_id = l.voucher_id
+                WHERE l.ledger_id      = :ledgerId
+                  AND h.location_code  = :locationCode
+                  AND h.voucher_date   < :fromDate
+            `, { replacements: { ledgerId, locationCode, fromDate }, type: db.Sequelize.QueryTypes.SELECT });
+
+            obNet = parseFloat(obRows[0].ob_dr) - parseFloat(obRows[0].ob_cr);
+
+            // Period entries
+            const rows = await db.sequelize.query(`
+                SELECT
+                    DATE_FORMAT(h.voucher_date, '%d-%b-%Y') AS voucher_date,
+                    h.voucher_no,
+                    h.voucher_type,
+                    h.is_reversal,
+                    COALESCE(l.narration, h.narration) AS narration,
+                    l.dr_amount,
+                    l.cr_amount
+                FROM gl_journal_lines l
+                JOIN gl_journal_headers h ON h.voucher_id = l.voucher_id
+                WHERE l.ledger_id     = :ledgerId
+                  AND h.location_code = :locationCode
+                  AND h.voucher_date  BETWEEN :fromDate AND :toDate
+                ORDER BY h.voucher_date, h.voucher_id, l.line_no
+            `, { replacements: { ledgerId, locationCode, fromDate, toDate }, type: db.Sequelize.QueryTypes.SELECT });
+
+            // Compute running balance
+            let running = obNet;
+            for (const row of rows) {
+                const dr  = parseFloat(row.dr_amount || 0);
+                const cr  = parseFloat(row.cr_amount || 0);
+                running  += dr - cr;
+                periodDr += dr;
+                periodCr += cr;
+                entries.push({
+                    voucher_date: row.voucher_date,
+                    voucher_no:   row.voucher_no,
+                    voucher_type: row.voucher_type,
+                    is_reversal:  row.is_reversal,
+                    narration:    row.narration,
+                    dr_amount:    dr,
+                    cr_amount:    cr,
+                    balance:      running
+                });
+            }
+        }
+
+        res.render('gl-ledger-report', {
+            title:       'Ledger Report',
+            user:        req.user,
+            config:      require('../config/app-config').APP_CONFIGS,
+            fromDate,
+            toDate,
+            ledgerId,
+            ledger,
+            obNet,
+            entries,
+            periodDr,
+            periodCr,
+            closingBalance: obNet + periodDr - periodCr,
+            VOUCHER_TYPES
+        });
+    } catch (err) {
+        console.error('Ledger report error:', err);
+        req.flash('error', 'Failed to load Ledger Report: ' + err.message);
+        res.redirect('/gl/day-book');
+    }
+});
+
+// ── Trial Balance ─────────────────────────────────────────────────────────────
+// GET /gl/trial-balance?as_of_date=&show_zero=1
+
+const NATURE_ORDER = { ASSETS: 1, LIABILITIES: 2, INCOME: 3, EXPENSES: 4 };
+
+router.get('/trial-balance', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const today     = new Date().toISOString().substring(0, 10);
+    const asOfDate  = req.query.as_of_date || today;
+    const showZero  = req.query.show_zero === '1';
+
+    try {
+        const rows = await db.sequelize.query(`
+            SELECT
+                g.group_name,
+                g.group_nature,
+                l.ledger_id,
+                l.ledger_name,
+                COALESCE(b.total_dr, 0) AS total_dr,
+                COALESCE(b.total_cr, 0) AS total_cr
+            FROM gl_ledgers l
+            JOIN gl_ledger_groups g ON g.group_id = l.group_id
+            LEFT JOIN (
+                SELECT jl.ledger_id,
+                       SUM(jl.dr_amount) AS total_dr,
+                       SUM(jl.cr_amount) AS total_cr
+                FROM gl_journal_lines jl
+                JOIN gl_journal_headers jh ON jh.voucher_id = jl.voucher_id
+                WHERE jh.location_code = :locationCode
+                  AND jh.voucher_date  <= :asOfDate
+                GROUP BY jl.ledger_id
+            ) b ON b.ledger_id = l.ledger_id
+            WHERE l.location_code = :locationCode
+              AND l.active_flag   = 'Y'
+            ORDER BY
+                FIELD(g.group_nature, 'ASSETS', 'LIABILITIES', 'INCOME', 'EXPENSES'),
+                g.group_name,
+                l.ledger_name
+        `, { replacements: { locationCode, asOfDate }, type: db.Sequelize.QueryTypes.SELECT });
+
+        // Group ledgers and compute net DR/CR balance per ledger
+        const groupMap = new Map();
+        let grandDr = 0, grandCr = 0;
+
+        for (const row of rows) {
+            const net   = parseFloat(row.total_dr) - parseFloat(row.total_cr);
+            const drBal = net > 0 ?  net : 0;
+            const crBal = net < 0 ? -net : 0;
+
+            if (!showZero && drBal === 0 && crBal === 0) continue;
+
+            if (!groupMap.has(row.group_name)) {
+                groupMap.set(row.group_name, {
+                    group_name:   row.group_name,
+                    group_nature: row.group_nature,
+                    rows:         [],
+                    subtotal_dr:  0,
+                    subtotal_cr:  0
+                });
+            }
+            const g = groupMap.get(row.group_name);
+            g.rows.push({ ledger_id: row.ledger_id, ledger_name: row.ledger_name, dr_balance: drBal, cr_balance: crBal });
+            g.subtotal_dr += drBal;
+            g.subtotal_cr += crBal;
+            grandDr       += drBal;
+            grandCr       += crBal;
+        }
+
+        // Sort groups by nature order
+        const groups = [...groupMap.values()].sort((a, b) =>
+            (NATURE_ORDER[a.group_nature] || 9) - (NATURE_ORDER[b.group_nature] || 9)
+        );
+
+        res.render('gl-trial-balance', {
+            title:      'Trial Balance',
+            user:       req.user,
+            config:     require('../config/app-config').APP_CONFIGS,
+            asOfDate,
+            showZero,
+            groups,
+            grandDr,
+            grandCr,
+            isBalanced: Math.abs(grandDr - grandCr) < 0.01
+        });
+    } catch (err) {
+        console.error('Trial Balance error:', err);
+        req.flash('error', 'Failed to load Trial Balance: ' + err.message);
+        res.redirect('/gl/day-book');
+    }
+});
+
+// ── Profit & Loss ─────────────────────────────────────────────────────────────
+// GET /gl/profit-loss?from_date=&to_date=
+
+router.get('/profit-loss', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const today  = new Date();
+    const fyYear = today.getMonth() >= 3 ? today.getFullYear() : today.getFullYear() - 1;
+    const fromDate = req.query.from_date || `${fyYear}-04-01`;
+    const toDate   = req.query.to_date   || `${fyYear + 1}-03-31`;
+
+    try {
+        const rows = await db.sequelize.query(`
+            SELECT
+                g.group_name,
+                g.group_nature,
+                l.ledger_id,
+                l.ledger_name,
+                COALESCE(b.total_dr, 0) AS total_dr,
+                COALESCE(b.total_cr, 0) AS total_cr
+            FROM gl_ledgers l
+            JOIN gl_ledger_groups g ON g.group_id = l.group_id
+            LEFT JOIN (
+                SELECT jl.ledger_id,
+                       SUM(jl.dr_amount) AS total_dr,
+                       SUM(jl.cr_amount) AS total_cr
+                FROM gl_journal_lines jl
+                JOIN gl_journal_headers jh ON jh.voucher_id = jl.voucher_id
+                WHERE jh.location_code = :locationCode
+                  AND jh.voucher_date  BETWEEN :fromDate AND :toDate
+                GROUP BY jl.ledger_id
+            ) b ON b.ledger_id = l.ledger_id
+            WHERE l.location_code = :locationCode
+              AND l.active_flag   = 'Y'
+              AND g.group_nature  IN ('INCOME', 'EXPENSES')
+              AND (b.total_dr IS NOT NULL OR b.total_cr IS NOT NULL)
+            ORDER BY g.group_nature DESC, g.group_name, l.ledger_name
+        `, { replacements: { locationCode, fromDate, toDate }, type: db.Sequelize.QueryTypes.SELECT });
+
+        const incomeGroupMap  = new Map();
+        const expenseGroupMap = new Map();
+        let totalIncome = 0, totalExpenses = 0;
+
+        for (const row of rows) {
+            const dr  = parseFloat(row.total_dr);
+            const cr  = parseFloat(row.total_cr);
+
+            if (row.group_nature === 'INCOME') {
+                const net = cr - dr;
+                if (!incomeGroupMap.has(row.group_name))
+                    incomeGroupMap.set(row.group_name, { group_name: row.group_name, rows: [], subtotal: 0 });
+                const g = incomeGroupMap.get(row.group_name);
+                g.rows.push({ ledger_id: row.ledger_id, ledger_name: row.ledger_name, amount: net });
+                g.subtotal  += net;
+                totalIncome += net;
+            } else {
+                const net = dr - cr;
+                if (!expenseGroupMap.has(row.group_name))
+                    expenseGroupMap.set(row.group_name, { group_name: row.group_name, rows: [], subtotal: 0 });
+                const g = expenseGroupMap.get(row.group_name);
+                g.rows.push({ ledger_id: row.ledger_id, ledger_name: row.ledger_name, amount: net });
+                g.subtotal    += net;
+                totalExpenses += net;
+            }
+        }
+
+        res.render('gl-profit-loss', {
+            title:          'Profit & Loss',
+            user:           req.user,
+            config:         require('../config/app-config').APP_CONFIGS,
+            fromDate,
+            toDate,
+            incomeGroups:   [...incomeGroupMap.values()],
+            expenseGroups:  [...expenseGroupMap.values()],
+            totalIncome,
+            totalExpenses,
+            netPL:          totalIncome - totalExpenses
+        });
+    } catch (err) {
+        console.error('P&L error:', err);
+        req.flash('error', 'Failed to load P&L: ' + err.message);
+        res.redirect('/gl/day-book');
+    }
+});
+
+// ── Balance Sheet ─────────────────────────────────────────────────────────────
+// GET /gl/balance-sheet?as_of_date=
+
+router.get('/balance-sheet', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const today    = new Date().toISOString().substring(0, 10);
+    const asOfDate = req.query.as_of_date || today;
+
+    try {
+        // Asset and liability balances cumulative up to asOfDate
+        const rows = await db.sequelize.query(`
+            SELECT
+                g.group_name,
+                g.group_nature,
+                l.ledger_id,
+                l.ledger_name,
+                COALESCE(b.total_dr, 0) AS total_dr,
+                COALESCE(b.total_cr, 0) AS total_cr
+            FROM gl_ledgers l
+            JOIN gl_ledger_groups g ON g.group_id = l.group_id
+            LEFT JOIN (
+                SELECT jl.ledger_id,
+                       SUM(jl.dr_amount) AS total_dr,
+                       SUM(jl.cr_amount) AS total_cr
+                FROM gl_journal_lines jl
+                JOIN gl_journal_headers jh ON jh.voucher_id = jl.voucher_id
+                WHERE jh.location_code = :locationCode
+                  AND jh.voucher_date  <= :asOfDate
+                GROUP BY jl.ledger_id
+            ) b ON b.ledger_id = l.ledger_id
+            WHERE l.location_code = :locationCode
+              AND l.active_flag   = 'Y'
+              AND g.group_nature  IN ('ASSETS', 'LIABILITIES')
+              AND (b.total_dr IS NOT NULL OR b.total_cr IS NOT NULL)
+            ORDER BY g.group_nature, g.group_name, l.ledger_name
+        `, { replacements: { locationCode, asOfDate }, type: db.Sequelize.QueryTypes.SELECT });
+
+        // Net P&L from inception to asOfDate — rolled into equity on liabilities side
+        const plRows = await db.sequelize.query(`
+            SELECT
+                COALESCE(SUM(CASE WHEN g.group_nature = 'INCOME'   THEN jl.cr_amount - jl.dr_amount ELSE 0 END), 0) AS total_income,
+                COALESCE(SUM(CASE WHEN g.group_nature = 'EXPENSES' THEN jl.dr_amount - jl.cr_amount ELSE 0 END), 0) AS total_expenses
+            FROM gl_journal_lines jl
+            JOIN gl_journal_headers jh ON jh.voucher_id = jl.voucher_id
+            JOIN gl_ledgers l          ON l.ledger_id   = jl.ledger_id
+            JOIN gl_ledger_groups g    ON g.group_id    = l.group_id
+            WHERE jh.location_code = :locationCode
+              AND jh.voucher_date  <= :asOfDate
+              AND g.group_nature   IN ('INCOME', 'EXPENSES')
+        `, { replacements: { locationCode, asOfDate }, type: db.Sequelize.QueryTypes.SELECT });
+
+        const netPL = parseFloat(plRows[0].total_income) - parseFloat(plRows[0].total_expenses);
+
+        const assetGroupMap     = new Map();
+        const liabilityGroupMap = new Map();
+        let totalAssets = 0, totalLiabilities = 0;
+
+        for (const row of rows) {
+            const dr  = parseFloat(row.total_dr);
+            const cr  = parseFloat(row.total_cr);
+
+            if (row.group_nature === 'ASSETS') {
+                const net = dr - cr;
+                if (!assetGroupMap.has(row.group_name))
+                    assetGroupMap.set(row.group_name, { group_name: row.group_name, rows: [], subtotal: 0 });
+                const g = assetGroupMap.get(row.group_name);
+                g.rows.push({ ledger_id: row.ledger_id, ledger_name: row.ledger_name, amount: net });
+                g.subtotal   += net;
+                totalAssets  += net;
+            } else {
+                const net = cr - dr;
+                if (!liabilityGroupMap.has(row.group_name))
+                    liabilityGroupMap.set(row.group_name, { group_name: row.group_name, rows: [], subtotal: 0 });
+                const g = liabilityGroupMap.get(row.group_name);
+                g.rows.push({ ledger_id: row.ledger_id, ledger_name: row.ledger_name, amount: net });
+                g.subtotal        += net;
+                totalLiabilities  += net;
+            }
+        }
+
+        const totalLiabilitiesAndPL = totalLiabilities + netPL;
+
+        res.render('gl-balance-sheet', {
+            title:                  'Balance Sheet',
+            user:                   req.user,
+            config:                 require('../config/app-config').APP_CONFIGS,
+            asOfDate,
+            assetGroups:            [...assetGroupMap.values()],
+            liabilityGroups:        [...liabilityGroupMap.values()],
+            totalAssets,
+            totalLiabilities,
+            netPL,
+            totalLiabilitiesAndPL,
+            isBalanced:             Math.abs(totalAssets - totalLiabilitiesAndPL) < 0.01
+        });
+    } catch (err) {
+        console.error('Balance Sheet error:', err);
+        req.flash('error', 'Failed to load Balance Sheet: ' + err.message);
+        res.redirect('/gl/day-book');
+    }
+});
+
+// ── Manual Journal ────────────────────────────────────────────────────────────
+
+const MANUAL_JOURNAL_TYPES = ['JOURNAL', 'PAYMENT', 'RECEIPT', 'CONTRA'];
+const VOUCHER_PREFIXES_MAP  = { JOURNAL:'JNL', PAYMENT:'PMT', RECEIPT:'RCT', CONTRA:'CNT' };
+
+async function getFyId(locationCode, date) {
+    const rows = await db.sequelize.query(`
+        SELECT fy_id FROM gl_financial_years
+        WHERE location_code = :locationCode
+          AND :date BETWEEN start_date AND end_date
+        LIMIT 1
+    `, { replacements: { locationCode, date }, type: db.Sequelize.QueryTypes.SELECT });
+    return rows[0] ? rows[0].fy_id : null;
+}
+
+async function nextVoucherNo(locationCode, fyId, vType) {
+    const prefix  = VOUCHER_PREFIXES_MAP[vType] || 'JNL';
+    const seqRows = await db.sequelize.query(`
+        SELECT COALESCE(MAX(
+            CAST(SUBSTRING(voucher_no, LOCATE('-', voucher_no) + 1) AS UNSIGNED)
+        ), 0) + 1 AS next_no
+        FROM gl_journal_headers
+        WHERE location_code = :locationCode
+          AND fy_id         = :fyId
+          AND voucher_type  = :vType
+          AND voucher_no IS NOT NULL
+    `, { replacements: { locationCode, fyId, vType }, type: db.Sequelize.QueryTypes.SELECT });
+    return `${prefix}-${String(seqRows[0].next_no).padStart(4, '0')}`;
+}
+
+// GET /gl/journal — list
+router.get('/journal', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const today    = new Date().toISOString().substring(0, 10);
+    const fromDate = req.query.from_date || today.substring(0, 8) + '01';
+    const toDate   = req.query.to_date   || today;
+
+    try {
+        const journals = await db.sequelize.query(`
+            SELECT
+                h.voucher_id,
+                DATE_FORMAT(h.voucher_date, '%d-%b-%Y') AS voucher_date,
+                h.voucher_no,
+                h.voucher_type,
+                h.narration,
+                h.is_reversal,
+                h.posted_by,
+                SUM(l.dr_amount) AS total_amount
+            FROM gl_journal_headers h
+            JOIN gl_journal_lines l ON l.voucher_id = h.voucher_id
+            WHERE h.location_code = :locationCode
+              AND h.source_type   = 'MANUAL_JOURNAL'
+              AND h.voucher_date  BETWEEN :fromDate AND :toDate
+            GROUP BY h.voucher_id
+            ORDER BY h.voucher_date DESC, h.voucher_id DESC
+            LIMIT 200
+        `, { replacements: { locationCode, fromDate, toDate }, type: db.Sequelize.QueryTypes.SELECT });
+
+        res.render('gl-journal-list', {
+            title:    'Manual Journals',
+            user:     req.user,
+            config:   require('../config/app-config').APP_CONFIGS,
+            fromDate,
+            toDate,
+            journals,
+            messages: req.flash()
+        });
+    } catch (err) {
+        console.error('Journal list error:', err);
+        req.flash('error', err.message);
+        res.redirect('/gl/day-book');
+    }
+});
+
+// GET /gl/journal/new — blank form
+router.get('/journal/new', [isLoginEnsured, security.isAdmin()], function(req, res) {
+    const today = new Date().toISOString().substring(0, 10);
+    res.render('gl-journal-form', {
+        title:        'New Manual Journal',
+        user:         req.user,
+        config:       require('../config/app-config').APP_CONFIGS,
+        voucher:      null,
+        lines:        [],
+        readOnly:     false,
+        voucherDate:  today,
+        MANUAL_JOURNAL_TYPES,
+        messages:     req.flash()
+    });
+});
+
+// GET /gl/journal/:id — view
+router.get('/journal/:id', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const voucherId    = parseInt(req.params.id);
+
+    try {
+        const [hRows, lines] = await Promise.all([
+            db.sequelize.query(`
+                SELECT h.*,
+                       DATE_FORMAT(h.voucher_date, '%d-%b-%Y')    AS fmt_date,
+                       DATE_FORMAT(h.voucher_date, '%Y-%m-%d')    AS raw_date,
+                       rv.voucher_no                              AS reversal_of_no
+                FROM gl_journal_headers h
+                LEFT JOIN gl_journal_headers rv ON rv.voucher_id = h.reversal_of_voucher_id
+                WHERE h.voucher_id    = :voucherId
+                  AND h.location_code = :locationCode
+            `, { replacements: { voucherId, locationCode }, type: db.Sequelize.QueryTypes.SELECT }),
+            db.sequelize.query(`
+                SELECT l.line_no, l.ledger_id, gl.ledger_name, l.dr_amount, l.cr_amount, l.narration
+                FROM gl_journal_lines l
+                JOIN gl_ledgers gl ON gl.ledger_id = l.ledger_id
+                WHERE l.voucher_id = :voucherId
+                ORDER BY l.line_no
+            `, { replacements: { voucherId }, type: db.Sequelize.QueryTypes.SELECT })
+        ]);
+
+        if (!hRows.length) {
+            req.flash('error', 'Journal not found');
+            return res.redirect('/gl/journal');
+        }
+
+        res.render('gl-journal-form', {
+            title:        `Journal ${hRows[0].voucher_no}`,
+            user:         req.user,
+            config:       require('../config/app-config').APP_CONFIGS,
+            voucher:      hRows[0],
+            lines,
+            readOnly:     true,
+            voucherDate:  hRows[0].raw_date,
+            MANUAL_JOURNAL_TYPES,
+            messages:     req.flash()
+        });
+    } catch (err) {
+        console.error('Journal view error:', err);
+        req.flash('error', err.message);
+        res.redirect('/gl/journal');
+    }
+});
+
+// POST /gl/api/journal — save new journal
+router.post('/api/journal', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const postedBy     = req.user.username || String(req.user.Person_id);
+    const { voucher_type, voucher_date, narration, lines } = req.body;
+
+    try {
+        if (!voucher_date) throw new Error('Voucher date is required');
+        if (!Array.isArray(lines) || lines.length < 2) throw new Error('At least 2 journal lines are required');
+
+        const totalDr = lines.reduce((s, l) => s + parseFloat(l.dr_amount || 0), 0);
+        const totalCr = lines.reduce((s, l) => s + parseFloat(l.cr_amount || 0), 0);
+        if (Math.abs(totalDr - totalCr) > 0.005)
+            throw new Error(`Journal does not balance: DR ${totalDr.toFixed(2)} vs CR ${totalCr.toFixed(2)}`);
+
+        const vType = MANUAL_JOURNAL_TYPES.includes(voucher_type) ? voucher_type : 'JOURNAL';
+        const fyId  = await getFyId(locationCode, voucher_date);
+        if (!fyId) throw new Error(`No financial year found for date ${voucher_date}`);
+
+        const voucherNo = await nextVoucherNo(locationCode, fyId, vType);
+
+        const [voucherId] = await db.sequelize.query(`
+            INSERT INTO gl_journal_headers
+                (location_code, fy_id, voucher_type, voucher_date, voucher_no,
+                 narration, source_type, source_id, is_reversal, is_exported, posted_by, created_by)
+            VALUES
+                (:locationCode, :fyId, :vType, :voucher_date, :voucherNo,
+                 :narration, 'MANUAL_JOURNAL', NULL, 'N', 'N', :postedBy, :postedBy)
+        `, {
+            replacements: { locationCode, fyId, vType, voucher_date, voucherNo, narration: narration || '', postedBy },
+            type: db.Sequelize.QueryTypes.INSERT
+        });
+
+        for (let i = 0; i < lines.length; i++) {
+            const { ledger_id, dr_amount, cr_amount, narration: ln } = lines[i];
+            await db.sequelize.query(`
+                INSERT INTO gl_journal_lines
+                    (voucher_id, line_no, ledger_id, dr_amount, cr_amount, narration, created_by)
+                VALUES (:voucherId, :lineNo, :ledgerId, :drAmount, :crAmount, :lineNarration, :postedBy)
+            `, {
+                replacements: {
+                    voucherId, lineNo: i + 1, ledgerId: parseInt(ledger_id),
+                    drAmount: parseFloat(dr_amount || 0), crAmount: parseFloat(cr_amount || 0),
+                    lineNarration: ln || null, postedBy
+                },
+                type: db.Sequelize.QueryTypes.INSERT
+            });
+        }
+
+        res.json({ success: true, voucher_id: voucherId, voucher_no: voucherNo });
+    } catch (err) {
+        console.error('Journal save error:', err);
+        res.status(400).json({ success: false, error: err.message });
+    }
+});
+
+// POST /gl/api/journal/:id/reverse — create reversal voucher
+router.post('/api/journal/:id/reverse', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const postedBy     = req.user.username || String(req.user.Person_id);
+    const voucherId    = parseInt(req.params.id);
+
+    try {
+        const [hRows, lines] = await Promise.all([
+            db.sequelize.query(`SELECT * FROM gl_journal_headers WHERE voucher_id = :voucherId AND location_code = :locationCode`,
+                { replacements: { voucherId, locationCode }, type: db.Sequelize.QueryTypes.SELECT }),
+            db.sequelize.query(`SELECT * FROM gl_journal_lines WHERE voucher_id = :voucherId ORDER BY line_no`,
+                { replacements: { voucherId }, type: db.Sequelize.QueryTypes.SELECT })
+        ]);
+
+        if (!hRows.length) throw new Error('Journal not found');
+        const orig = hRows[0];
+
+        const today  = new Date().toISOString().substring(0, 10);
+        const fyId   = await getFyId(locationCode, today);
+        if (!fyId) throw new Error(`No financial year found for today (${today})`);
+
+        const voucherNo = await nextVoucherNo(locationCode, fyId, orig.voucher_type);
+
+        const [reversalId] = await db.sequelize.query(`
+            INSERT INTO gl_journal_headers
+                (location_code, fy_id, voucher_type, voucher_date, voucher_no,
+                 narration, source_type, source_id, is_reversal, reversal_of_voucher_id,
+                 is_exported, posted_by, created_by)
+            VALUES
+                (:locationCode, :fyId, :vType, :today, :voucherNo,
+                 :narration, 'MANUAL_JOURNAL', NULL, 'Y', :origId,
+                 'N', :postedBy, :postedBy)
+        `, {
+            replacements: {
+                locationCode, fyId, vType: orig.voucher_type, today, voucherNo,
+                narration: `REVERSAL of ${orig.voucher_no} — ${orig.narration || ''}`,
+                origId: voucherId, postedBy
+            },
+            type: db.Sequelize.QueryTypes.INSERT
+        });
+
+        for (let i = 0; i < lines.length; i++) {
+            const l = lines[i];
+            await db.sequelize.query(`
+                INSERT INTO gl_journal_lines
+                    (voucher_id, line_no, ledger_id, dr_amount, cr_amount, narration, created_by)
+                VALUES (:reversalId, :lineNo, :ledgerId, :drAmount, :crAmount, :lineNarration, :postedBy)
+            `, {
+                replacements: {
+                    reversalId, lineNo: i + 1, ledgerId: l.ledger_id,
+                    drAmount: parseFloat(l.cr_amount || 0),
+                    crAmount: parseFloat(l.dr_amount || 0),
+                    lineNarration: l.narration, postedBy
+                },
+                type: db.Sequelize.QueryTypes.INSERT
+            });
+        }
+
+        res.json({ success: true, voucher_id: reversalId, voucher_no: voucherNo });
+    } catch (err) {
+        console.error('Journal reversal error:', err);
+        res.status(400).json({ success: false, error: err.message });
+    }
+});
+
+// ── GL Control ────────────────────────────────────────────────────────────────
+// GET /gl/control — admin dashboard: events monitor + create accounting + generate events
+
+router.get('/control', [isLoginEnsured, security.isAdmin()], function(req, res) {
+    const today = new Date().toISOString().substring(0, 10);
+    const fromDate = today.substring(0, 8) + '01';
+    res.render('gl-control', {
+        title:    'GL Control',
+        user:     req.user,
+        config:   require('../config/app-config').APP_CONFIGS,
+        fromDate,
+        toDate:   today,
+        messages: req.flash()
+    });
+});
+
+// GET /gl/api/event-summary?from_date=&to_date=
+router.get('/api/event-summary', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const { from_date, to_date } = req.query;
+
+    try {
+        const [summary, byType] = await Promise.all([
+            db.sequelize.query(`
+                SELECT
+                    COUNT(*) AS total,
+                    SUM(event_status = 'UNPROCESSED') AS unprocessed,
+                    SUM(event_status = 'PROCESSED')   AS processed,
+                    SUM(event_status = 'ERROR')        AS errors
+                FROM gl_accounting_events
+                WHERE location_code = :locationCode
+                  AND (:from_date IS NULL OR event_date >= :from_date)
+                  AND (:to_date   IS NULL OR event_date <= :to_date)
+            `, {
+                replacements: { locationCode, from_date: from_date || null, to_date: to_date || null },
+                type: db.Sequelize.QueryTypes.SELECT
+            }),
+            db.sequelize.query(`
+                SELECT source_type,
+                       COUNT(*) AS total,
+                       SUM(event_status = 'UNPROCESSED') AS unprocessed,
+                       SUM(event_status = 'PROCESSED')   AS processed,
+                       SUM(event_status = 'ERROR')        AS errors
+                FROM gl_accounting_events
+                WHERE location_code = :locationCode
+                  AND (:from_date IS NULL OR event_date >= :from_date)
+                  AND (:to_date   IS NULL OR event_date <= :to_date)
+                GROUP BY source_type
+                ORDER BY source_type
+            `, {
+                replacements: { locationCode, from_date: from_date || null, to_date: to_date || null },
+                type: db.Sequelize.QueryTypes.SELECT
+            })
+        ]);
+
+        res.json({ ...summary[0], byType });
+    } catch (err) {
+        console.error('Event summary error:', err);
+        res.status(500).json({ error: err.message });
+    }
+});
+
+// POST /gl/api/retry-event/:id — reset a single ERROR event back to UNPROCESSED
+router.post('/api/retry-event/:id', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const eventId = parseInt(req.params.id);
+
+    try {
+        const [, meta] = await db.sequelize.query(`
+            UPDATE gl_accounting_events
+            SET event_status  = 'UNPROCESSED',
+                error_message = NULL,
+                processed_at  = NULL,
+                processed_by  = NULL
+            WHERE event_id      = :eventId
+              AND location_code = :locationCode
+              AND event_status  = 'ERROR'
+        `, { replacements: { eventId, locationCode }, type: db.Sequelize.QueryTypes.UPDATE });
+
+        if (!meta?.affectedRows) {
+            return res.status(404).json({ success: false, error: 'Event not found or not in ERROR status' });
+        }
+        res.json({ success: true });
+    } catch (err) {
+        console.error('Retry event error:', err);
+        res.status(500).json({ success: false, error: err.message });
+    }
+});
+
+// POST /gl/api/generate-events — backfill missing events for date range
+router.post('/api/generate-events', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const createdBy    = req.user.username || String(req.user.Person_id);
+    const { from_date, to_date } = req.body;
+
+    if (!from_date || !to_date) {
+        return res.status(400).json({ error: 'from_date and to_date are required' });
+    }
+
+    try {
+        const result = await createAccountingService.generateMissingEvents(locationCode, from_date, to_date, createdBy);
+        res.json({ success: true, ...result });
+    } catch (err) {
+        console.error('Generate events error:', err);
+        res.status(500).json({ success: false, error: err.message });
     }
 });
 

--- a/routes/products-routes.js
+++ b/routes/products-routes.js
@@ -237,26 +237,30 @@ router.put('/api/:id', [isLoginEnsured, security.isAdmin()], async function (req
 
 // ── Product Ledger Map ────────────────────────────────────────────────────────
 
-// Map types shown in the configure modal — add new types here as needed
-const PRODUCT_MAP_TYPES = [
-    { type: 'SALES',       label: 'Sales',       group: 'sales' },
-    { type: 'PURCHASE',    label: 'Purchase',     group: 'purchase' },
-    { type: 'OUTPUT_CGST', label: 'Output CGST',  group: 'tax' },
-    { type: 'OUTPUT_SGST', label: 'Output SGST',  group: 'tax' },
-    { type: 'INPUT_CGST',  label: 'Input CGST',   group: 'tax' },
-    { type: 'INPUT_SGST',  label: 'Input SGST',   group: 'tax' },
-];
+// Maps the attribute1 group key (from m_lookup) → actual GL ledger group name.
+// Update this only if a new ledger category is added to m_lookup.
+const GROUP_LEDGER_NAMES = {
+    sales:    'Sales Accounts',
+    purchase: 'Purchase Accounts',
+    tax:      'Duties & Taxes'
+};
 
 router.get('/ledger-map', [isLoginEnsured, security.isAdmin()], async (req, res) => {
     const locationCode = req.user.location_code;
     try {
-        const [products, rawMappings, salesLedgers, purchaseLedgers, taxLedgers] = await Promise.all([
+        const [products, rawMappings, mapTypes] = await Promise.all([
             ProductLedgerMapDao.getProducts(locationCode),
             ProductLedgerMapDao.getAllMappingsRaw(locationCode),
-            getLedgersByGroup(locationCode, 'Sales Accounts'),
-            getLedgersByGroup(locationCode, 'Purchase Accounts'),
-            getLedgersByGroup(locationCode, 'Duties & Taxes')
+            ProductLedgerMapDao.getMapTypes()
         ]);
+
+        // Fetch ledger lists for each distinct group used by the current map types
+        const neededGroups = [...new Set(mapTypes.map(m => m.group))];
+        const ledgerArrays = await Promise.all(
+            neededGroups.map(g => getLedgersByGroup(locationCode, GROUP_LEDGER_NAMES[g] || g))
+        );
+        const ledgers = {};
+        neededGroups.forEach((g, i) => { ledgers[g] = ledgerArrays[i]; });
 
         // Build { productId: { MAP_TYPE: ledgerId } } lookup for the modal
         const mappingLookup = {};
@@ -271,12 +275,8 @@ router.get('/ledger-map', [isLoginEnsured, security.isAdmin()], async (req, res)
             config: config.APP_CONFIGS,
             products,
             mappingLookup,
-            mapTypes: PRODUCT_MAP_TYPES,
-            ledgers: {
-                sales:    salesLedgers,
-                purchase: purchaseLedgers,
-                tax:      taxLedgers
-            }
+            mapTypes,
+            ledgers
         });
     } catch (err) {
         console.error('Error loading product ledger map:', err);

--- a/services/create-accounting-service.js
+++ b/services/create-accounting-service.js
@@ -2,13 +2,17 @@
 // GL accounting engine — processes gl_accounting_events → gl_journal_headers + gl_journal_lines
 //
 // Event types handled:
-//   CREDIT_SALE  (source_id = tcredit_id)   — Customer DR / Sales CR + Output CGST CR + Output SGST CR
-//   CASH_SALE    (source_id = cashsales_id)  — Cash DR / Sales CR + Output CGST CR + Output SGST CR
-//   DAY_BILL     (source_id = day_bill_id)   — Cash/Digital DR / Sales CR + GST CRs per product line
-//   BANK_TXN     (source_id = t_bank_id)     — bank statement / oil-company SOA line
+//   CREDIT_SALE         (source_id = tcredit_id)       — Customer DR / Sales CR + Output CGST/SGST CR
+//   CASH_SALE           (source_id = cashsales_id)     — Cash DR / Sales CR + Output CGST/SGST CR
+//   DAY_BILL            (source_id = day_bill_id)      — Cash/Digital DR / Sales CR + GST CRs per line
+//   BANK_TXN            (source_id = t_bank_id)        — bank statement / oil-company SOA line
+//   BOWSER_CREDIT_SALE  (source_id = credit_id)        — Customer DR / Sales CR (no GST, HSD 0%)
+//   BOWSER_CASH_SALE    (source_id = cashsale_id)      — Cash DR / Sales CR
+//   BOWSER_DIGITAL_SALE (source_id = digital_id)       — Vendor DR / Sales CR
+//   LUBES_INVOICE       (source_id = lubes_hdr_id)     — Purchase DR + Input CGST/SGST DR / Supplier CR
+//   TANK_INVOICE        (source_id = t_tank_invoice.id)— Purchase DR + Charges DR / Supplier CR
 //
-// Raised automatically by DB triggers on t_credits, t_cashsales, t_day_bill,
-// t_bank_transaction, and t_bank_transaction_splits.
+// Raised automatically by DB triggers on source tables.
 // UPDATE events reverse existing vouchers and regenerate fresh ones.
 // DELETE events reverse only.
 
@@ -24,23 +28,49 @@ const VOUCHER_PREFIXES = {
     CONTRA:   'CNT'
 };
 
+// Source types that belong to a shift — blocked if t_closing is still DRAFT.
+// BANK_TXN / PURCHASE_INVOICE / MANUAL_JOURNAL are not shift-bound and always process.
+const SHIFT_BOUND_TYPES  = new Set(['CREDIT_SALE', 'CASH_SALE', 'DAY_BILL']);
+
+// Source types that belong to a bowser closing — blocked if t_bowser_closing is still DRAFT.
+const BOWSER_BOUND_TYPES = new Set(['BOWSER_CREDIT_SALE', 'BOWSER_CASH_SALE', 'BOWSER_DIGITAL_SALE']);
+
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 async function processEvents(locationCode, fromDate, toDate, processedBy) {
-    const events = await db.sequelize.query(`
-        SELECT * FROM gl_accounting_events
-        WHERE location_code = :locationCode
-          AND event_date BETWEEN :fromDate AND :toDate
-          AND event_status = 'UNPROCESSED'
-        ORDER BY event_date, event_id
-    `, {
-        replacements: { locationCode, fromDate, toDate },
-        type: QueryTypes.SELECT
-    });
+    const [events, openShiftDates, openBowserDates] = await Promise.all([
+        db.sequelize.query(`
+            SELECT * FROM gl_accounting_events
+            WHERE location_code = :locationCode
+              AND event_date BETWEEN :fromDate AND :toDate
+              AND event_status = 'UNPROCESSED'
+            ORDER BY event_date, event_id
+        `, { replacements: { locationCode, fromDate, toDate }, type: QueryTypes.SELECT }),
+        getOpenShiftDates(locationCode, fromDate, toDate),
+        getOpenBowserDates(locationCode, fromDate, toDate)
+    ]);
 
-    const summary = { processed: 0, errors: 0, skipped: 0, details: [] };
+    const summary = { processed: 0, errors: 0, skipped: 0, blocked: 0, blockedDates: [], details: [] };
 
     for (const event of events) {
+        const eventDate = typeof event.event_date === 'string'
+            ? event.event_date.substring(0, 10)
+            : event.event_date.toISOString().substring(0, 10);
+
+        if (SHIFT_BOUND_TYPES.has(event.source_type) && openShiftDates.has(eventDate)) {
+            summary.blocked++;
+            if (!summary.blockedDates.includes(eventDate)) summary.blockedDates.push(eventDate);
+            summary.details.push({ event_id: event.event_id, status: 'BLOCKED', reason: `Shift on ${eventDate} is still DRAFT` });
+            continue;
+        }
+
+        if (BOWSER_BOUND_TYPES.has(event.source_type) && openBowserDates.has(eventDate)) {
+            summary.blocked++;
+            if (!summary.blockedDates.includes(eventDate)) summary.blockedDates.push(eventDate);
+            summary.details.push({ event_id: event.event_id, status: 'BLOCKED', reason: `Bowser closing on ${eventDate} is still DRAFT` });
+            continue;
+        }
+
         try {
             const result = await processEvent(event, processedBy);
             summary.processed += result.voucherCount;
@@ -75,7 +105,178 @@ async function reprocessEvents(locationCode, fromDate, toDate, processedBy) {
     return await processEvents(locationCode, fromDate, toDate, processedBy);
 }
 
-module.exports = { processEvents, reprocessEvents };
+module.exports = { processEvents, reprocessEvents, generateMissingEvents };
+
+// ─── Generate Missing Events ──────────────────────────────────────────────────
+// Backfill tool: scan each source table for records with no event and INSERT them.
+// Safe to run multiple times — NOT EXISTS guard prevents duplicates.
+
+async function generateMissingEvents(locationCode, fromDate, toDate, createdBy) {
+    const counts = {};
+    let total = 0;
+
+    const run = async (sourceType, sql) => {
+        const [, meta] = await db.sequelize.query(sql, {
+            replacements: { locationCode, fromDate, toDate, createdBy },
+            type: QueryTypes.INSERT
+        });
+        const n = meta?.affectedRows || 0;
+        counts[sourceType] = n;
+        total += n;
+    };
+
+    await run('CREDIT_SALE', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT cl.location_code, fy.fy_id, 'CREDIT_SALE', tc.tcredit_id, 'CREATE',
+               DATE(cl.closing_date), 'UNPROCESSED', :createdBy
+        FROM t_credits tc
+        JOIN t_closing cl ON cl.closing_id = tc.closing_id
+        JOIN gl_financial_years fy ON fy.location_code = cl.location_code
+            AND DATE(cl.closing_date) BETWEEN fy.start_date AND fy.end_date
+        WHERE cl.location_code = :locationCode
+          AND DATE(cl.closing_date) BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'CREDIT_SALE' AND e.source_id = tc.tcredit_id
+          )
+    `);
+
+    await run('CASH_SALE', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT cl.location_code, fy.fy_id, 'CASH_SALE', cs.cashsales_id, 'CREATE',
+               DATE(cl.closing_date), 'UNPROCESSED', :createdBy
+        FROM t_cashsales cs
+        JOIN t_closing cl ON cl.closing_id = cs.closing_id
+        JOIN gl_financial_years fy ON fy.location_code = cl.location_code
+            AND DATE(cl.closing_date) BETWEEN fy.start_date AND fy.end_date
+        WHERE cl.location_code = :locationCode
+          AND DATE(cl.closing_date) BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'CASH_SALE' AND e.source_id = cs.cashsales_id
+          )
+    `);
+
+    await run('DAY_BILL', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT db.location_code, fy.fy_id, 'DAY_BILL', db.day_bill_id, 'CREATE',
+               db.bill_date, 'UNPROCESSED', :createdBy
+        FROM t_day_bill db
+        JOIN gl_financial_years fy ON fy.location_code = db.location_code
+            AND db.bill_date BETWEEN fy.start_date AND fy.end_date
+        WHERE db.location_code = :locationCode
+          AND db.bill_date BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'DAY_BILL' AND e.source_id = db.day_bill_id
+          )
+    `);
+
+    await run('BANK_TXN', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT mb.location_code, fy.fy_id, 'BANK_TXN', tbt.t_bank_id, 'CREATE',
+               DATE(tbt.trans_date), 'UNPROCESSED', :createdBy
+        FROM t_bank_transaction tbt
+        JOIN m_bank mb ON mb.bank_id = tbt.bank_id
+        JOIN gl_financial_years fy ON fy.location_code = mb.location_code
+            AND DATE(tbt.trans_date) BETWEEN fy.start_date AND fy.end_date
+        WHERE mb.location_code = :locationCode
+          AND DATE(tbt.trans_date) BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'BANK_TXN' AND e.source_id = tbt.t_bank_id
+          )
+    `);
+
+    await run('BOWSER_CREDIT_SALE', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT tbc.location_code, fy.fy_id, 'BOWSER_CREDIT_SALE', bc.credit_id, 'CREATE',
+               DATE(tbc.closing_date), 'UNPROCESSED', :createdBy
+        FROM t_bowser_credits bc
+        JOIN t_bowser_closing tbc ON tbc.bowser_closing_id = bc.bowser_closing_id
+        JOIN gl_financial_years fy ON fy.location_code = tbc.location_code
+            AND DATE(tbc.closing_date) BETWEEN fy.start_date AND fy.end_date
+        WHERE tbc.location_code = :locationCode
+          AND DATE(tbc.closing_date) BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'BOWSER_CREDIT_SALE' AND e.source_id = bc.credit_id
+          )
+    `);
+
+    await run('BOWSER_CASH_SALE', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT tbc.location_code, fy.fy_id, 'BOWSER_CASH_SALE', bcs.cashsale_id, 'CREATE',
+               DATE(tbc.closing_date), 'UNPROCESSED', :createdBy
+        FROM t_bowser_cashsales bcs
+        JOIN t_bowser_closing tbc ON tbc.bowser_closing_id = bcs.bowser_closing_id
+        JOIN gl_financial_years fy ON fy.location_code = tbc.location_code
+            AND DATE(tbc.closing_date) BETWEEN fy.start_date AND fy.end_date
+        WHERE tbc.location_code = :locationCode
+          AND DATE(tbc.closing_date) BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'BOWSER_CASH_SALE' AND e.source_id = bcs.cashsale_id
+          )
+    `);
+
+    await run('BOWSER_DIGITAL_SALE', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT tbc.location_code, fy.fy_id, 'BOWSER_DIGITAL_SALE', bds.digital_id, 'CREATE',
+               DATE(tbc.closing_date), 'UNPROCESSED', :createdBy
+        FROM t_bowser_digital_sales bds
+        JOIN t_bowser_closing tbc ON tbc.bowser_closing_id = bds.bowser_closing_id
+        JOIN gl_financial_years fy ON fy.location_code = tbc.location_code
+            AND DATE(tbc.closing_date) BETWEEN fy.start_date AND fy.end_date
+        WHERE tbc.location_code = :locationCode
+          AND DATE(tbc.closing_date) BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'BOWSER_DIGITAL_SALE' AND e.source_id = bds.digital_id
+          )
+    `);
+
+    await run('LUBES_INVOICE', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT lh.location_code, fy.fy_id, 'LUBES_INVOICE', lh.lubes_hdr_id, 'CREATE',
+               lh.invoice_date, 'UNPROCESSED', :createdBy
+        FROM t_lubes_inv_hdr lh
+        JOIN gl_financial_years fy ON fy.location_code = lh.location_code
+            AND lh.invoice_date BETWEEN fy.start_date AND fy.end_date
+        WHERE lh.location_code = :locationCode
+          AND lh.invoice_date BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'LUBES_INVOICE' AND e.source_id = lh.lubes_hdr_id
+          )
+    `);
+
+    await run('TANK_INVOICE', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT ti.location_id, fy.fy_id, 'TANK_INVOICE', ti.id, 'CREATE',
+               ti.invoice_date, 'UNPROCESSED', :createdBy
+        FROM t_tank_invoice ti
+        JOIN gl_financial_years fy ON fy.location_code = ti.location_id
+            AND ti.invoice_date BETWEEN fy.start_date AND fy.end_date
+        WHERE ti.location_id = :locationCode
+          AND ti.invoice_date BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'TANK_INVOICE' AND e.source_id = ti.id
+          )
+    `);
+
+    return { counts, total };
+}
 
 // ─── Event Dispatcher ─────────────────────────────────────────────────────────
 
@@ -90,10 +291,15 @@ async function processEvent(event, processedBy) {
     }
 
     switch (event.source_type) {
-        case 'CREDIT_SALE':   return await processCreditSaleEvent(event, processedBy);
-        case 'CASH_SALE':     return await processCashSaleEvent(event, processedBy);
-        case 'DAY_BILL':      return await processDayBillEvent(event, processedBy);
-        case 'BANK_TXN':      return await processBankTxnEvent(event, processedBy);
+        case 'CREDIT_SALE':         return await processCreditSaleEvent(event, processedBy);
+        case 'CASH_SALE':           return await processCashSaleEvent(event, processedBy);
+        case 'DAY_BILL':            return await processDayBillEvent(event, processedBy);
+        case 'BANK_TXN':            return await processBankTxnEvent(event, processedBy);
+        case 'BOWSER_CREDIT_SALE':  return await processBowserCreditSaleEvent(event, processedBy);
+        case 'BOWSER_CASH_SALE':    return await processBowserCashSaleEvent(event, processedBy);
+        case 'BOWSER_DIGITAL_SALE': return await processBowserDigitalSaleEvent(event, processedBy);
+        case 'LUBES_INVOICE':       return await processLubesInvoiceEvent(event, processedBy);
+        case 'TANK_INVOICE':        return await processTankInvoiceEvent(event, processedBy);
         default:
             throw new Error(`Unhandled source_type: ${event.source_type}`);
     }
@@ -375,9 +581,10 @@ async function processDayBillEvent(event, processedBy) {
 
 // ─── BANK_TXN Handler ────────────────────────────────────────────────────────
 // One voucher per classified bank transaction (real bank or oil company SOA line).
+// Voucher type derived from context: PAYMENT / RECEIPT / CONTRA / JOURNAL (oil co SOA).
 //
 // Skip conditions:
-//   • accounting_type IS NULL          — not yet classified; mark PROCESSED 0 vouchers
+//   • ledger_name IS NULL              — not yet classified; mark PROCESSED 0 vouchers
 //   • amount = 0                       — nothing to journal
 //   • is_oil_company='Y' + external_source='Bank' — SOA payment receipt line;
 //                                        the real bank statement row already journals it
@@ -393,14 +600,6 @@ async function processDayBillEvent(event, processedBy) {
 //   Oil company SOA: credit_amount>0 → Sundry Creditor CR (charge, we owe more), counterpart DR
 //                    debit_amount>0  → Sundry Creditor DR (rebate, we owe less), counterpart CR
 
-const ACCOUNTING_TYPE_VOUCHER_MAP = {
-    'Payment':  'PAYMENT',
-    'Receipt':  'RECEIPT',
-    'Contra':   'CONTRA',
-    'Journal':  'JOURNAL',
-    'Purchase': 'PURCHASE',
-};
-
 async function processBankTxnEvent(event, processedBy) {
     const { location_code, fy_id, source_id: tBankId, event_date } = event;
 
@@ -411,7 +610,6 @@ async function processBankTxnEvent(event, processedBy) {
             tbt.trans_date,
             tbt.credit_amount,
             tbt.debit_amount,
-            tbt.accounting_type,
             tbt.ledger_name,
             tbt.external_id,
             tbt.external_source,
@@ -429,8 +627,8 @@ async function processBankTxnEvent(event, processedBy) {
     if (!rows.length) throw new Error(`Bank transaction not found: t_bank_id=${tBankId}`);
     const txn = rows[0];
 
-    // Skip: transaction not yet classified
-    if (!txn.accounting_type) {
+    // Skip: transaction not yet classified (no ledger assigned)
+    if (!txn.ledger_name) {
         await markEventProcessed(event.event_id, null, processedBy);
         return { voucherCount: 0 };
     }
@@ -459,9 +657,6 @@ async function processBankTxnEvent(event, processedBy) {
         return { voucherCount: 0 };
     }
 
-    const voucherType = ACCOUNTING_TYPE_VOUCHER_MAP[txn.accounting_type];
-    if (!voucherType) throw new Error(`Unknown accounting_type: '${txn.accounting_type}' on t_bank_id=${tBankId}`);
-
     // Resolve the bank's own GL ledger
     let bankLedgerId;
     if (isOilCo) {
@@ -480,7 +675,7 @@ async function processBankTxnEvent(event, processedBy) {
 
     const narration = txn.remarks
         ? txn.remarks
-        : `${txn.accounting_type} | ${txn.bank_name} | ₹${txnAmount.toFixed(2)} | ${event_date}`;
+        : `${txn.bank_name} | ${txn.ledger_name} | ₹${txnAmount.toFixed(2)} | ${event_date}`;
 
     let lines;
 
@@ -494,6 +689,8 @@ async function processBankTxnEvent(event, processedBy) {
         }
         lines = buildTwoLineJournal(bankLedgerId, counterLedgerId, bankIsDr, txnAmount, narration);
     }
+
+    const voucherType = deriveBankVoucherType(txn, bankIsDr);
 
     const vid = await createVoucher({
         locationCode: location_code,
@@ -509,6 +706,385 @@ async function processBankTxnEvent(event, processedBy) {
 
     await markEventProcessed(event.event_id, vid, processedBy);
     return { voucherCount: 1 };
+}
+
+// ─── BOWSER_CREDIT_SALE Handler ───────────────────────────────────────────────
+// Customer DR → HSD Sales CR
+// No GST split — HSD is 0% GST.
+
+async function processBowserCreditSaleEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: creditId, event_date } = event;
+
+    const rows = await db.sequelize.query(`
+        SELECT
+            bc.credit_id,
+            bc.product_id,
+            p.product_name,
+            bc.creditlist_id,
+            cl.Company_Name AS customer_name,
+            bc.quantity,
+            bc.amount,
+            bc.bill_no
+        FROM t_bowser_credits bc
+        JOIN m_product    p  ON p.product_id    = bc.product_id
+        JOIN m_credit_list cl ON cl.creditlist_id = bc.creditlist_id
+        WHERE bc.credit_id = :creditId
+    `, { replacements: { creditId }, type: QueryTypes.SELECT });
+
+    if (!rows.length) throw new Error(`Bowser credit sale not found: credit_id=${creditId}`);
+    const row = rows[0];
+
+    const salesLedgerId = await resolveProductLedger(location_code, row.product_id, 'SALES');
+    if (!salesLedgerId) throw new Error(`Sales ledger not configured for product ${row.product_name} (id:${row.product_id})`);
+
+    const customerLedgerId = await resolveLedger(location_code, 'CREDIT', row.creditlist_id);
+    if (!customerLedgerId) throw new Error(`GL ledger not found for customer ${row.customer_name} (creditlist_id:${row.creditlist_id})`);
+
+    const amount = parseFloat(row.amount);
+    const qty    = parseFloat(row.quantity).toFixed(3);
+    const narration = `${qty} ${row.product_name} | ₹${amount.toFixed(2)} | ${row.customer_name} | Bill: ${row.bill_no || '-'}`;
+
+    const vid = await createVoucher({
+        locationCode: location_code,
+        fyId:         fy_id,
+        voucherType:  'SALES',
+        voucherDate:  event_date,
+        sourceType:   'BOWSER_CREDIT_SALE',
+        sourceId:     creditId,
+        narration,
+        lines: [
+            { ledger_id: customerLedgerId, dr_amount: amount, cr_amount: 0,      narration },
+            { ledger_id: salesLedgerId,    dr_amount: 0,      cr_amount: amount, narration }
+        ],
+        postedBy: processedBy
+    });
+
+    await markEventProcessed(event.event_id, vid, processedBy);
+    return { voucherCount: 1 };
+}
+
+// ─── BOWSER_CASH_SALE Handler ─────────────────────────────────────────────────
+// Cash DR → HSD Sales CR
+
+async function processBowserCashSaleEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: cashsaleId, event_date } = event;
+
+    const rows = await db.sequelize.query(`
+        SELECT
+            bcs.cashsale_id,
+            bcs.product_id,
+            p.product_name,
+            bcs.amount
+        FROM t_bowser_cashsales bcs
+        JOIN m_product p ON p.product_id = bcs.product_id
+        WHERE bcs.cashsale_id = :cashsaleId
+    `, { replacements: { cashsaleId }, type: QueryTypes.SELECT });
+
+    if (!rows.length) throw new Error(`Bowser cash sale not found: cashsale_id=${cashsaleId}`);
+    const row = rows[0];
+
+    if (parseFloat(row.amount) <= 0) {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const salesLedgerId = await resolveProductLedger(location_code, row.product_id, 'SALES');
+    if (!salesLedgerId) throw new Error(`Sales ledger not configured for product ${row.product_name} (id:${row.product_id})`);
+
+    const cashLedgerId = await resolveCashLedger(location_code);
+    if (!cashLedgerId) throw new Error(`Cash-in-Hand ledger not found for location ${location_code}`);
+
+    const amount    = parseFloat(row.amount);
+    const narration = `${row.product_name} Cash Sale | ₹${amount.toFixed(2)} | ${event_date}`;
+
+    const vid = await createVoucher({
+        locationCode: location_code,
+        fyId:         fy_id,
+        voucherType:  'SALES',
+        voucherDate:  event_date,
+        sourceType:   'BOWSER_CASH_SALE',
+        sourceId:     cashsaleId,
+        narration,
+        lines: [
+            { ledger_id: cashLedgerId,  dr_amount: amount, cr_amount: 0,      narration },
+            { ledger_id: salesLedgerId, dr_amount: 0,      cr_amount: amount, narration }
+        ],
+        postedBy: processedBy
+    });
+
+    await markEventProcessed(event.event_id, vid, processedBy);
+    return { voucherCount: 1 };
+}
+
+// ─── BOWSER_DIGITAL_SALE Handler ──────────────────────────────────────────────
+// Digital vendor DR → HSD Sales CR
+// Product resolved from m_bowser (via t_bowser_closing) since t_bowser_digital_sales
+// has no product_id column.
+
+async function processBowserDigitalSaleEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: digitalId, event_date } = event;
+
+    const rows = await db.sequelize.query(`
+        SELECT
+            bds.digital_id,
+            bds.digital_vendor_id,
+            bds.amount,
+            mb.product_id,
+            p.product_name,
+            cl.Company_Name AS vendor_name
+        FROM t_bowser_digital_sales bds
+        JOIN t_bowser_closing tbc ON tbc.bowser_closing_id = bds.bowser_closing_id
+        JOIN m_bowser         mb  ON mb.bowser_id          = tbc.bowser_id
+        JOIN m_product        p   ON p.product_id          = mb.product_id
+        JOIN m_credit_list    cl  ON cl.creditlist_id      = bds.digital_vendor_id
+        WHERE bds.digital_id = :digitalId
+    `, { replacements: { digitalId }, type: QueryTypes.SELECT });
+
+    if (!rows.length) throw new Error(`Bowser digital sale not found: digital_id=${digitalId}`);
+    const row = rows[0];
+
+    if (parseFloat(row.amount) <= 0) {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const salesLedgerId = await resolveProductLedger(location_code, row.product_id, 'SALES');
+    if (!salesLedgerId) throw new Error(`Sales ledger not configured for product ${row.product_name} (id:${row.product_id})`);
+
+    const vendorLedgerId = await resolveLedger(location_code, 'CREDIT', row.digital_vendor_id);
+    if (!vendorLedgerId) throw new Error(`GL ledger not found for digital vendor ${row.vendor_name} (creditlist_id:${row.digital_vendor_id})`);
+
+    const amount    = parseFloat(row.amount);
+    const narration = `${row.product_name} Digital Sale | ₹${amount.toFixed(2)} | ${row.vendor_name} | ${event_date}`;
+
+    const vid = await createVoucher({
+        locationCode: location_code,
+        fyId:         fy_id,
+        voucherType:  'SALES',
+        voucherDate:  event_date,
+        sourceType:   'BOWSER_DIGITAL_SALE',
+        sourceId:     digitalId,
+        narration,
+        lines: [
+            { ledger_id: vendorLedgerId, dr_amount: amount, cr_amount: 0,      narration },
+            { ledger_id: salesLedgerId,  dr_amount: 0,      cr_amount: amount, narration }
+        ],
+        postedBy: processedBy
+    });
+
+    await markEventProcessed(event.event_id, vid, processedBy);
+    return { voucherCount: 1 };
+}
+
+// ─── LUBES_INVOICE Handler ────────────────────────────────────────────────────
+// Supplier CR (sum of all line amounts) → Purchase DR + Input CGST DR + Input SGST DR per line.
+// Skips silently if invoice is still DRAFT — UPDATE trigger fires again when it transitions to CLOSED.
+
+async function processLubesInvoiceEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: lubesHdrId, event_date } = event;
+
+    const hdrs = await db.sequelize.query(`
+        SELECT
+            h.lubes_hdr_id,
+            h.closing_status,
+            h.invoice_date,
+            h.invoice_no,
+            s.supplier_name,
+            h.supplier_id
+        FROM t_lubes_inv_hdr h
+        JOIN m_supplier s ON s.supplier_id = h.supplier_id
+        WHERE h.lubes_hdr_id = :lubesHdrId
+    `, { replacements: { lubesHdrId }, type: QueryTypes.SELECT });
+
+    if (!hdrs.length) throw new Error(`Lubes invoice not found: lubes_hdr_id=${lubesHdrId}`);
+    const hdr = hdrs[0];
+
+    // DRAFT gate — engine will re-run when UPDATE trigger fires on DRAFT→CLOSED transition
+    if (hdr.closing_status === 'DRAFT') {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const lines_rows = await db.sequelize.query(`
+        SELECT
+            l.line_id,
+            l.product_id,
+            p.product_name,
+            l.taxable_value,
+            l.cgst_amount,
+            l.sgst_amount
+        FROM t_lubes_inv_lines l
+        JOIN m_product p ON p.product_id = l.product_id
+        WHERE l.lubes_hdr_id = :lubesHdrId
+          AND l.taxable_value > 0
+    `, { replacements: { lubesHdrId }, type: QueryTypes.SELECT });
+
+    if (!lines_rows.length) throw new Error(`No lines found for lubes invoice lubes_hdr_id=${lubesHdrId}`);
+
+    const supplierLedgerId = await resolveLedger(location_code, 'SUPPLIER', hdr.supplier_id);
+    if (!supplierLedgerId) throw new Error(`Supplier GL ledger not found for ${hdr.supplier_name} (supplier_id:${hdr.supplier_id})`);
+
+    const narration = `Lubes Invoice ${hdr.invoice_no || lubesHdrId} | ${hdr.supplier_name} | ${event_date}`;
+    const journalLines = [];
+    let totalCr = 0;
+
+    for (const ln of lines_rows) {
+        const taxable = parseFloat(ln.taxable_value);
+        const cgst    = parseFloat(ln.cgst_amount || 0);
+        const sgst    = parseFloat(ln.sgst_amount || 0);
+        totalCr      += taxable + cgst + sgst;
+
+        const purchaseLedgerId = await resolveProductLedger(location_code, ln.product_id, 'PURCHASE');
+        if (!purchaseLedgerId) throw new Error(`PURCHASE ledger not configured for product ${ln.product_name} (id:${ln.product_id})`);
+
+        const lineNarration = `${ln.product_name} | ₹${taxable.toFixed(2)} + GST | ${narration}`;
+        journalLines.push({ ledger_id: purchaseLedgerId, dr_amount: taxable, cr_amount: 0, narration: lineNarration });
+
+        if (cgst > 0) {
+            const cgstLedgerId = await resolveProductLedger(location_code, ln.product_id, 'INPUT_CGST');
+            if (!cgstLedgerId) throw new Error(`INPUT_CGST ledger not mapped for product ${ln.product_name} — configure it at /products/ledger-map`);
+            journalLines.push({ ledger_id: cgstLedgerId, dr_amount: cgst, cr_amount: 0, narration: lineNarration });
+        }
+        if (sgst > 0) {
+            const sgstLedgerId = await resolveProductLedger(location_code, ln.product_id, 'INPUT_SGST');
+            if (!sgstLedgerId) throw new Error(`INPUT_SGST ledger not mapped for product ${ln.product_name} — configure it at /products/ledger-map`);
+            journalLines.push({ ledger_id: sgstLedgerId, dr_amount: sgst, cr_amount: 0, narration: lineNarration });
+        }
+    }
+
+    // Supplier CR — sum of all line amounts (guarantees balance regardless of header rounding)
+    journalLines.push({ ledger_id: supplierLedgerId, dr_amount: 0, cr_amount: totalCr, narration });
+
+    const vid = await createVoucher({
+        locationCode: location_code,
+        fyId:         fy_id,
+        voucherType:  'PURCHASE',
+        voucherDate:  event_date,
+        sourceType:   'LUBES_INVOICE',
+        sourceId:     lubesHdrId,
+        narration,
+        lines:        journalLines,
+        postedBy:     processedBy
+    });
+
+    await markEventProcessed(event.event_id, vid, processedBy);
+    return { voucherCount: 1 };
+}
+
+// ─── TANK_INVOICE Handler ─────────────────────────────────────────────────────
+// Supplier CR (sum of product lines + charges) →
+//   Per t_tank_invoice_dtl: DR Product Purchase (total_line_amount)
+//   Per t_tank_invoice_charges: DR charge ledger by name (resolveLedgerByName)
+//
+// charge_type is free text in t_tank_invoice_charges — admin must create a GL ledger
+// with the exact same name, otherwise the engine throws a descriptive error.
+
+async function processTankInvoiceEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: invoiceId, event_date } = event;
+
+    const hdrs = await db.sequelize.query(`
+        SELECT
+            ti.id,
+            ti.invoice_no,
+            ti.invoice_date,
+            ti.supplier_id,
+            s.supplier_name
+        FROM t_tank_invoice ti
+        JOIN m_supplier s ON s.supplier_id = ti.supplier_id
+        WHERE ti.id = :invoiceId
+    `, { replacements: { invoiceId }, type: QueryTypes.SELECT });
+
+    if (!hdrs.length) throw new Error(`Tank invoice not found: id=${invoiceId}`);
+    const hdr = hdrs[0];
+
+    const supplierLedgerId = await resolveLedger(location_code, 'SUPPLIER', hdr.supplier_id);
+    if (!supplierLedgerId) throw new Error(`Supplier GL ledger not found for ${hdr.supplier_name} (supplier_id:${hdr.supplier_id})`);
+
+    const narration = `Tank Invoice ${hdr.invoice_no || invoiceId} | ${hdr.supplier_name} | ${event_date}`;
+    const journalLines = [];
+    let totalCr = 0;
+
+    // Product purchase lines
+    const dtlRows = await db.sequelize.query(`
+        SELECT
+            d.dtl_id,
+            d.product_id,
+            p.product_name,
+            d.total_line_amount
+        FROM t_tank_invoice_dtl d
+        JOIN m_product p ON p.product_id = d.product_id
+        WHERE d.invoice_id = :invoiceId
+          AND d.total_line_amount > 0
+    `, { replacements: { invoiceId }, type: QueryTypes.SELECT });
+
+    for (const dtl of dtlRows) {
+        const lineAmt = parseFloat(dtl.total_line_amount);
+        totalCr      += lineAmt;
+
+        const purchaseLedgerId = await resolveProductLedger(location_code, dtl.product_id, 'PURCHASE');
+        if (!purchaseLedgerId) throw new Error(`PURCHASE ledger not configured for product ${dtl.product_name} (id:${dtl.product_id})`);
+
+        journalLines.push({
+            ledger_id:  purchaseLedgerId,
+            dr_amount:  lineAmt,
+            cr_amount:  0,
+            narration:  `${dtl.product_name} | ₹${lineAmt.toFixed(2)} | ${narration}`
+        });
+    }
+
+    // Charge lines (free-text charge_type → GL ledger by name)
+    const chargeRows = await db.sequelize.query(`
+        SELECT charge_type, amount
+        FROM t_tank_invoice_charges
+        WHERE invoice_id = :invoiceId
+          AND amount > 0
+    `, { replacements: { invoiceId }, type: QueryTypes.SELECT });
+
+    for (const ch of chargeRows) {
+        const chargeAmt = parseFloat(ch.amount);
+        totalCr        += chargeAmt;
+
+        const info = await resolveLedgerByName(location_code, ch.charge_type);
+        if (!info) throw new Error(`GL ledger '${ch.charge_type}' not found for location ${location_code} — create a ledger with this exact name to map the charge`);
+
+        journalLines.push({
+            ledger_id:  info.ledger_id,
+            dr_amount:  chargeAmt,
+            cr_amount:  0,
+            narration:  `${ch.charge_type} | ₹${chargeAmt.toFixed(2)} | ${narration}`
+        });
+    }
+
+    if (!journalLines.length) throw new Error(`Tank invoice id=${invoiceId} has no product lines or charges to journal`);
+
+    // Supplier CR — sum of all DR lines (guarantees balance regardless of header rounding)
+    journalLines.push({ ledger_id: supplierLedgerId, dr_amount: 0, cr_amount: totalCr, narration });
+
+    const vid = await createVoucher({
+        locationCode: location_code,
+        fyId:         fy_id,
+        voucherType:  'PURCHASE',
+        voucherDate:  event_date,
+        sourceType:   'TANK_INVOICE',
+        sourceId:     invoiceId,
+        narration,
+        lines:        journalLines,
+        postedBy:     processedBy
+    });
+
+    await markEventProcessed(event.event_id, vid, processedBy);
+    return { voucherCount: 1 };
+}
+
+// Derives the Tally voucher type from bank transaction context.
+//   CONTRA  — inter-bank transfer (external_source='Bank', debit/paying side)
+//   PAYMENT — money leaves the bank (bank is CR side)
+//   RECEIPT — money enters the bank (bank is DR side)
+//   JOURNAL — oil company SOA entries (supplier account adjustments)
+function deriveBankVoucherType(txn, bankIsDr) {
+    if (txn.is_oil_company === 'Y') return 'JOURNAL';
+    if (txn.external_source === 'Bank') return 'CONTRA';
+    return bankIsDr ? 'RECEIPT' : 'PAYMENT';
 }
 
 // Returns counterpart ledger_id, or null if the event was already marked PROCESSED (skip).
@@ -802,6 +1378,39 @@ async function resolveCashLedger(locationCode) {
         type: QueryTypes.SELECT
     });
     return rows[0] ? rows[0].ledger_id : null;
+}
+
+// ─── Shift Gate ───────────────────────────────────────────────────────────────
+// Returns a Set of 'YYYY-MM-DD' dates within the range where t_closing rows
+// are still in DRAFT status.  Shift-bound event types (CREDIT_SALE, CASH_SALE,
+// DAY_BILL) are skipped for these dates — left UNPROCESSED until the shift closes.
+
+async function getOpenShiftDates(locationCode, fromDate, toDate) {
+    const rows = await db.sequelize.query(`
+        SELECT DISTINCT DATE_FORMAT(closing_date, '%Y-%m-%d') AS blocked_date
+        FROM t_closing
+        WHERE location_code  = :locationCode
+          AND closing_date   BETWEEN :fromDate AND :toDate
+          AND closing_status = 'DRAFT'
+    `, {
+        replacements: { locationCode, fromDate, toDate },
+        type: QueryTypes.SELECT
+    });
+    return new Set(rows.map(r => r.blocked_date));
+}
+
+async function getOpenBowserDates(locationCode, fromDate, toDate) {
+    const rows = await db.sequelize.query(`
+        SELECT DISTINCT DATE_FORMAT(closing_date, '%Y-%m-%d') AS blocked_date
+        FROM t_bowser_closing
+        WHERE location_code = :locationCode
+          AND closing_date  BETWEEN :fromDate AND :toDate
+          AND status        = 'DRAFT'
+    `, {
+        replacements: { locationCode, fromDate, toDate },
+        type: QueryTypes.SELECT
+    });
+    return new Set(rows.map(r => r.blocked_date));
 }
 
 // ─── Event Status Helpers ─────────────────────────────────────────────────────

--- a/views/gl-balance-sheet.pug
+++ b/views/gl-balance-sheet.pug
@@ -1,0 +1,90 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Balance Sheet
+            a.btn.btn-sm.btn-outline-secondary(href="/gl/profit-loss") &larr; P&amp;L
+
+        form.row.align-items-end.mb-3(method="GET" action="/gl/balance-sheet")
+            .col-auto
+                label.small.mb-1 As of Date
+                input.form-control.form-control-sm(type="date" name="as_of_date" value=asOfDate)
+            .col-auto.align-self-end
+                button.btn.btn-primary.btn-sm(type="submit") View
+
+        - const fmt = (n) => Math.abs(n).toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+
+        if isBalanced
+            .alert.alert-success.py-2.mb-2
+                i.bi.bi-check-circle-fill.mr-1
+                | Balance Sheet balances &mdash; Assets = Liabilities + P&amp;L = ₹#{fmt(totalAssets)}
+        else
+            .alert.alert-danger.py-2.mb-2
+                i.bi.bi-exclamation-triangle-fill.mr-1
+                | Out of balance &mdash; Assets ₹#{fmt(totalAssets)} vs Liabilities + P&amp;L ₹#{fmt(totalLiabilitiesAndPL)} (diff ₹#{Math.abs(totalAssets - totalLiabilitiesAndPL).toLocaleString('en-IN',{minimumFractionDigits:2,maximumFractionDigits:2})})
+
+        .row
+            //- LEFT: Assets
+            .col-md-6
+                h6.border-bottom.pb-1 Assets
+                if !assetGroups.length
+                    p.text-muted.small No asset entries up to this date.
+                else
+                    table.table.table-sm.table-bordered#bsAssetTable
+                        tbody
+                            each g in assetGroups
+                                tr.group-header
+                                    td.font-weight-bold(colspan="2")= g.group_name
+                                each row in g.rows
+                                    tr
+                                        td.pl-4
+                                            a(href='/gl/ledger?ledger_id=' + row.ledger_id + '&from_date=' + asOfDate.substring(0,4) + '-04-01&to_date=' + asOfDate)= row.ledger_name
+                                        td.text-right.small= fmt(row.amount)
+                                tr.group-subtotal
+                                    td.text-right.font-weight-bold.text-muted.small #{g.group_name} Total
+                                    td.text-right.font-weight-bold.small= fmt(g.subtotal)
+                        tfoot
+                            tr.font-weight-bold.table-primary
+                                td Total Assets
+                                td.text-right= fmt(totalAssets)
+
+            //- RIGHT: Liabilities + P&L
+            .col-md-6
+                h6.border-bottom.pb-1 Liabilities &amp; Equity
+                table.table.table-sm.table-bordered#bsLiabTable
+                    tbody
+                        if liabilityGroups.length
+                            each g in liabilityGroups
+                                tr.group-header
+                                    td.font-weight-bold(colspan="2")= g.group_name
+                                each row in g.rows
+                                    tr
+                                        td.pl-4
+                                            a(href='/gl/ledger?ledger_id=' + row.ledger_id + '&from_date=' + asOfDate.substring(0,4) + '-04-01&to_date=' + asOfDate)= row.ledger_name
+                                        td.text-right.small= fmt(row.amount)
+                                tr.group-subtotal
+                                    td.text-right.font-weight-bold.text-muted.small #{g.group_name} Total
+                                    td.text-right.font-weight-bold.small= fmt(g.subtotal)
+                        //- P&L rolled in as retained surplus/deficit
+                        tr.group-header
+                            td.font-weight-bold(colspan="2") Retained Earnings
+                        tr(class=(netPL >= 0 ? '' : 'table-warning'))
+                            td.pl-4
+                                a(href='/gl/profit-loss?from_date=' + asOfDate.substring(0,4) + '-04-01&to_date=' + asOfDate)
+                                    = netPL >= 0 ? 'Net Profit (from inception)' : 'Net Loss (from inception)'
+                            td.text-right.small(class=(netPL >= 0 ? '' : 'text-danger'))= fmt(netPL)
+                        tr.group-subtotal
+                            td.text-right.font-weight-bold.text-muted.small Retained Earnings Total
+                            td.text-right.font-weight-bold.small= fmt(netPL)
+                    tfoot
+                        tr.font-weight-bold.table-primary
+                            td Total Liabilities &amp; Equity
+                            td.text-right= fmt(totalLiabilitiesAndPL)
+
+    style.
+        #bsAssetTable, #bsLiabTable { font-size: 0.82rem; }
+        .group-header td  { background-color: #e9ecef; }
+        .group-subtotal td { background-color: #f8f9fa; border-top: 2px solid #dee2e6 !important; }

--- a/views/gl-control.pug
+++ b/views/gl-control.pug
@@ -1,0 +1,300 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 GL Control
+            a.btn.btn-sm.btn-outline-secondary(href="/gl/day-book") Day Book &rarr;
+
+        ul.nav.nav-tabs.mb-3#controlTabs(role="tablist")
+            li.nav-item
+                a.nav-link.active(id="tab-events" data-toggle="tab" href="#pane-events" role="tab") Events Monitor
+            li.nav-item
+                a.nav-link(id="tab-accounting" data-toggle="tab" href="#pane-accounting" role="tab") Create Accounting
+            li.nav-item
+                a.nav-link(id="tab-generate" data-toggle="tab" href="#pane-generate" role="tab") Generate Events
+
+        .tab-content
+
+            //- ── Events Monitor ──────────────────────────────────────────────
+            #pane-events.tab-pane.fade.show.active(role="tabpanel")
+
+                form.row.align-items-end.mb-3#eventsFilterForm
+                    .col-auto
+                        label.small.mb-1 From Date
+                        input.form-control.form-control-sm(type="date" id="evFrom" value=fromDate)
+                    .col-auto
+                        label.small.mb-1 To Date
+                        input.form-control.form-control-sm(type="date" id="evTo" value=toDate)
+                    .col-auto
+                        label.small.mb-1 Status
+                        select.form-control.form-control-sm#evStatus
+                            option(value="") All
+                            option(value="UNPROCESSED") Unprocessed
+                            option(value="PROCESSED") Processed
+                            option(value="ERROR") Error
+                    .col-auto.align-self-end
+                        button.btn.btn-primary.btn-sm(type="button" id="btnLoadEvents") View
+                    .col-auto.align-self-end
+                        button.btn.btn-outline-secondary.btn-sm(type="button" id="btnRefreshSummary") Refresh Summary
+
+                .row.mb-3#summaryCards(style="display:none")
+                    .col-6.col-md-3
+                        .card.text-center.py-2
+                            .small.text-muted Total
+                            .h5.mb-0#sumTotal —
+                    .col-6.col-md-3
+                        .card.text-center.py-2.border-warning
+                            .small.text-warning Unprocessed
+                            .h5.mb-0.text-warning#sumUnprocessed —
+                    .col-6.col-md-3
+                        .card.text-center.py-2.border-success
+                            .small.text-success Processed
+                            .h5.mb-0.text-success#sumProcessed —
+                    .col-6.col-md-3
+                        .card.text-center.py-2.border-danger
+                            .small.text-danger Errors
+                            .h5.mb-0.text-danger#sumErrors —
+
+                #eventsTableWrap(style="display:none")
+                    .table-responsive
+                        table.table.table-sm.table-bordered.table-hover#eventsTable
+                            thead.thead-dark
+                                tr
+                                    th(style="width:60px") ID
+                                    th(style="width:90px") Date
+                                    th Source Type
+                                    th(style="width:80px") Source ID
+                                    th(style="width:70px") Ev. Type
+                                    th(style="width:90px") Status
+                                    th Processed By
+                                    th Error
+                                    th.text-center(style="width:60px")
+                            tbody#eventsBody
+
+            //- ── Create Accounting ───────────────────────────────────────────
+            #pane-accounting.tab-pane.fade(role="tabpanel")
+
+                p.text-muted.small.mb-3
+                    | Processes UNPROCESSED events in the queue and creates journal entries.
+                    | Blocked dates (DRAFT shifts/bowser closings) are skipped automatically.
+
+                .row.align-items-end.mb-3
+                    .col-auto
+                        label.small.mb-1 From Date
+                        input.form-control.form-control-sm(type="date" id="caFrom" value=fromDate)
+                    .col-auto
+                        label.small.mb-1 To Date
+                        input.form-control.form-control-sm(type="date" id="caTo" value=toDate)
+                    .col-auto.align-self-end
+                        button.btn.btn-success.btn-sm#btnRunAccounting Run Create Accounting
+                    .col-auto.align-self-end
+                        button.btn.btn-warning.btn-sm#btnReprocess Reprocess (force redo)
+
+                #caResult(style="display:none")
+                    .card.card-body.mt-2#caResultBody
+
+            //- ── Generate Events ─────────────────────────────────────────────
+            #pane-generate.tab-pane.fade(role="tabpanel")
+
+                p.text-muted.small.mb-3
+                    | Scans all source tables for records with no event in the queue and inserts missing events.
+                    | Safe to run multiple times — duplicate events are never created.
+                    br
+                    | Use this when: a trigger failed silently, records were imported directly into the DB,
+                    | or accounting was enabled after transactions already existed.
+
+                .row.align-items-end.mb-3
+                    .col-auto
+                        label.small.mb-1 From Date
+                        input.form-control.form-control-sm(type="date" id="geFrom" value=fromDate)
+                    .col-auto
+                        label.small.mb-1 To Date
+                        input.form-control.form-control-sm(type="date" id="geTo" value=toDate)
+                    .col-auto.align-self-end
+                        button.btn.btn-primary.btn-sm#btnGenerate Generate Missing Events
+
+                #geResult(style="display:none")
+                    .card.card-body.mt-2#geResultBody
+
+    script.
+        // ── Event Summary & List ──────────────────────────────────────────────
+
+        function badgeStatus(s) {
+            const map = { UNPROCESSED: 'warning', PROCESSED: 'success', ERROR: 'danger' };
+            return `<span class="badge badge-${map[s]||'secondary'}">${s}</span>`;
+        }
+
+        function badgeType(t) {
+            const map = { CREATE:'info', UPDATE:'warning', DELETE:'danger' };
+            return `<span class="badge badge-${map[t]||'secondary'}">${t}</span>`;
+        }
+
+        async function loadSummary() {
+            const from = document.getElementById('evFrom').value;
+            const to   = document.getElementById('evTo').value;
+            const qs   = new URLSearchParams({ from_date: from, to_date: to });
+            const data = await fetch('/gl/api/event-summary?' + qs).then(r => r.json());
+            document.getElementById('sumTotal').textContent       = data.total       || 0;
+            document.getElementById('sumUnprocessed').textContent = data.unprocessed || 0;
+            document.getElementById('sumProcessed').textContent   = data.processed   || 0;
+            document.getElementById('sumErrors').textContent      = data.errors      || 0;
+            document.getElementById('summaryCards').style.display = '';
+        }
+
+        async function loadEvents() {
+            await loadSummary();
+            const from   = document.getElementById('evFrom').value;
+            const to     = document.getElementById('evTo').value;
+            const status = document.getElementById('evStatus').value;
+            const qs     = new URLSearchParams({ from_date: from, to_date: to });
+            if (status) qs.set('status', status);
+            const rows = await fetch('/gl/api/accounting-events?' + qs).then(r => r.json());
+            const tbody = document.getElementById('eventsBody');
+            tbody.innerHTML = '';
+            rows.forEach(function(r) {
+                const tr = document.createElement('tr');
+                const retryBtn = r.event_status === 'ERROR'
+                    ? `<button class="btn btn-outline-warning btn-sm btn-retry" data-id="${r.event_id}" title="Retry"><i class="bi bi-arrow-repeat"></i></button>`
+                    : '';
+                tr.innerHTML = `
+                    <td class="small">${r.event_id}</td>
+                    <td class="small">${r.event_date ? r.event_date.substring(0,10) : ''}</td>
+                    <td class="small">${r.source_type}</td>
+                    <td class="small">${r.source_id}</td>
+                    <td class="small">${badgeType(r.event_type)}</td>
+                    <td class="small">${badgeStatus(r.event_status)}</td>
+                    <td class="small">${r.processed_by || ''}</td>
+                    <td class="small text-danger" style="max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${r.error_message||''}">${r.error_message||''}</td>
+                    <td class="text-center">${retryBtn}</td>`;
+                tbody.appendChild(tr);
+            });
+            document.getElementById('eventsTableWrap').style.display = '';
+
+            tbody.querySelectorAll('.btn-retry').forEach(function(btn) {
+                btn.addEventListener('click', async function() {
+                    const id = this.dataset.id;
+                    this.disabled = true;
+                    const data = await fetch('/gl/api/retry-event/' + id, { method: 'POST' }).then(r => r.json());
+                    if (data.success) {
+                        this.closest('tr').querySelector('.badge').className = 'badge badge-warning';
+                        this.closest('tr').querySelector('.badge').textContent = 'UNPROCESSED';
+                        this.remove();
+                    } else {
+                        alert('Error: ' + data.error);
+                        this.disabled = false;
+                    }
+                });
+            });
+        }
+
+        document.getElementById('btnLoadEvents').addEventListener('click', loadEvents);
+        document.getElementById('btnRefreshSummary').addEventListener('click', loadSummary);
+
+        // Auto-load summary on page open
+        loadSummary();
+
+        // ── Create Accounting ─────────────────────────────────────────────────
+
+        async function runAccounting(reprocess) {
+            const from = document.getElementById('caFrom').value;
+            const to   = document.getElementById('caTo').value;
+            if (!from || !to) { alert('Please select a date range.'); return; }
+            const btn = document.getElementById(reprocess ? 'btnReprocess' : 'btnRunAccounting');
+            btn.disabled = true;
+            const orig = btn.textContent;
+            btn.textContent = 'Running…';
+            try {
+                const resp = await fetch('/gl/api/create-accounting', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ from_date: from, to_date: to, reprocess })
+                });
+                const data = await resp.json();
+                const wrap = document.getElementById('caResult');
+                const body = document.getElementById('caResultBody');
+                if (data.success) {
+                    const s = data.summary;
+                    body.innerHTML = `
+                        <div class="text-success font-weight-bold mb-2"><i class="bi bi-check-circle-fill mr-1"></i>Done</div>
+                        <div class="row text-center">
+                            <div class="col">
+                                <div class="small text-muted">Vouchers Created</div>
+                                <div class="h5">${s.processed}</div>
+                            </div>
+                            <div class="col">
+                                <div class="small text-muted">Blocked</div>
+                                <div class="h5 text-warning">${s.blocked}</div>
+                            </div>
+                            <div class="col">
+                                <div class="small text-muted">Skipped</div>
+                                <div class="h5">${s.skipped}</div>
+                            </div>
+                            <div class="col">
+                                <div class="small text-danger">Errors</div>
+                                <div class="h5 text-danger">${s.errors}</div>
+                            </div>
+                        </div>
+                        ${s.blockedDates && s.blockedDates.length ? `<div class="small text-muted mt-1">Blocked dates (DRAFT): ${s.blockedDates.join(', ')}</div>` : ''}
+                        ${s.errors > 0 ? `<div class="small text-danger mt-1">Check Events Monitor tab for error details.</div>` : ''}`;
+                } else {
+                    body.innerHTML = `<div class="text-danger"><i class="bi bi-exclamation-triangle mr-1"></i>${data.error}</div>`;
+                }
+                wrap.style.display = '';
+            } catch (e) {
+                alert('Network error: ' + e.message);
+            } finally {
+                btn.disabled = false;
+                btn.textContent = orig;
+            }
+        }
+
+        document.getElementById('btnRunAccounting').addEventListener('click', () => runAccounting(false));
+        document.getElementById('btnReprocess').addEventListener('click', function() {
+            if (!confirm('Reprocess will reverse and re-create ALL existing vouchers in this range. Are you sure?')) return;
+            runAccounting(true);
+        });
+
+        // ── Generate Events ───────────────────────────────────────────────────
+
+        document.getElementById('btnGenerate').addEventListener('click', async function() {
+            const from = document.getElementById('geFrom').value;
+            const to   = document.getElementById('geTo').value;
+            if (!from || !to) { alert('Please select a date range.'); return; }
+            this.disabled = true;
+            const orig = this.textContent;
+            this.textContent = 'Running…';
+            try {
+                const resp = await fetch('/gl/api/generate-events', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ from_date: from, to_date: to })
+                });
+                const data = await resp.json();
+                const wrap = document.getElementById('geResult');
+                const body = document.getElementById('geResultBody');
+                if (data.success) {
+                    const counts = data.counts || {};
+                    const rows = Object.entries(counts).map(([k, v]) =>
+                        `<tr><td class="small">${k}</td><td class="small text-right">${v}</td></tr>`
+                    ).join('');
+                    body.innerHTML = `
+                        <div class="font-weight-bold mb-2 ${data.total > 0 ? 'text-success' : 'text-muted'}">
+                            <i class="bi bi-${data.total > 0 ? 'check-circle-fill' : 'info-circle'} mr-1"></i>
+                            ${data.total} event${data.total !== 1 ? 's' : ''} generated
+                        </div>
+                        ${data.total > 0 ? `<table class="table table-sm table-bordered w-auto"><thead class="thead-light"><tr><th>Source Type</th><th class="text-right">Generated</th></tr></thead><tbody>${rows}</tbody></table>` : ''}
+                        ${data.total > 0 ? `<div class="small text-muted">Run Create Accounting to process them.</div>` : '<div class="small text-muted">No missing events found — queue is up to date.</div>'}`;
+                } else {
+                    body.innerHTML = `<div class="text-danger"><i class="bi bi-exclamation-triangle mr-1"></i>${data.error}</div>`;
+                }
+                wrap.style.display = '';
+            } catch (e) {
+                alert('Network error: ' + e.message);
+            } finally {
+                this.disabled = false;
+                this.textContent = orig;
+            }
+        });

--- a/views/gl-day-book.pug
+++ b/views/gl-day-book.pug
@@ -1,0 +1,89 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Day Book
+            a.btn.btn-sm.btn-outline-secondary(href="/home") &larr; Back
+
+        form.row.align-items-end.mb-3(method="GET" action="/gl/day-book")
+            .col-auto
+                label.small.mb-1 From Date
+                input.form-control.form-control-sm(type="date" name="from_date" value=fromDate)
+            .col-auto
+                label.small.mb-1 To Date
+                input.form-control.form-control-sm(type="date" name="to_date" value=toDate)
+            .col-auto
+                label.small.mb-1 Type
+                select.form-control.form-control-sm(name="voucher_type")
+                    option(value="" selected=!selectedType) All Types
+                    each vt in VOUCHER_TYPES
+                        option(value=vt selected=(selectedType === vt))= vt
+            .col-auto.align-self-end
+                button.btn.btn-primary.btn-sm(type="submit") View
+
+        .row.mb-3
+            .col-4
+                .card.text-center.py-2
+                    .small.text-muted Vouchers
+                    strong= vouchers.length
+            .col-4
+                .card.text-center.py-2
+                    .small.text-muted Total DR (₹)
+                    strong= grandTotalDr.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+            .col-4
+                .card.text-center.py-2
+                    .small.text-muted Total CR (₹)
+                    strong= grandTotalCr.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+
+        if !vouchers.length
+            .alert.alert-info.py-2 No vouchers found for this date range.
+        else
+            .table-responsive
+                table.table.table-bordered.table-sm#dayBookTable
+                    thead.thead-dark
+                        tr
+                            th(style="width:90px") Date
+                            th(style="width:95px") Voucher No
+                            th(style="width:80px") Type
+                            th Particulars
+                            th.text-right(style="width:110px") DR (₹)
+                            th.text-right(style="width:110px") CR (₹)
+                    tbody
+                        each v in vouchers
+                            tr.vhdr(class=(v.is_reversal === 'Y' ? 'table-warning' : 'table-light'))
+                                td.small= v.voucher_date
+                                td
+                                    strong= v.voucher_no
+                                    if v.is_reversal === 'Y'
+                                        |
+                                        span.badge.badge-warning REV
+                                td.text-center
+                                    - const typeClass = {SALES:'success',PURCHASE:'primary',PAYMENT:'danger',RECEIPT:'info',JOURNAL:'secondary',CONTRA:'dark'}[v.voucher_type] || 'secondary'
+                                    span.badge(class='badge-' + typeClass)= v.voucher_type
+                                td.small.text-muted(style="max-width:300px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title=v.narration)= v.narration
+                                td.text-right.small= v.total_dr.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+                                td.text-right.small= v.total_cr.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+                            each line in v.lines
+                                tr.vline(class=(v.is_reversal === 'Y' ? 'table-warning' : ''))
+                                    td(colspan="3")
+                                    td.small.pl-4= line.ledger_name
+                                    td.text-right.small
+                                        if line.dr_amount > 0
+                                            = line.dr_amount.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+                                    td.text-right.small
+                                        if line.cr_amount > 0
+                                            = line.cr_amount.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+                    tfoot
+                        tr.font-weight-bold.bg-light
+                            td(colspan="4") Grand Total
+                            td.text-right= grandTotalDr.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+                            td.text-right= grandTotalCr.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+
+    style.
+        #dayBookTable { font-size: 0.8rem; }
+        .vhdr td { border-bottom: none !important; }
+        .vline td { border-top: none !important; }
+        .vline td:first-child { border: none !important; }

--- a/views/gl-journal-form.pug
+++ b/views/gl-journal-form.pug
@@ -1,0 +1,257 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0= title
+            .d-flex.align-items-center
+                if voucher && !readOnly
+                    span already in read-only
+                if readOnly && voucher && voucher.is_reversal !== 'Y'
+                    button.btn.btn-sm.btn-warning.mr-2#btnReverse(data-id=voucher.voucher_id)
+                        i.bi.bi-arrow-counterclockwise.mr-1
+                        | Reverse
+                a.btn.btn-sm.btn-outline-secondary(href="/gl/journal") &larr; Back
+
+        if readOnly && voucher
+            .row.mb-3
+                .col-auto
+                    .small.text-muted Date
+                    strong= voucher.fmt_date
+                .col-auto
+                    .small.text-muted Voucher No
+                    strong= voucher.voucher_no
+                .col-auto
+                    .small.text-muted Type
+                    - const tc = {JOURNAL:'secondary',PAYMENT:'danger',RECEIPT:'info',CONTRA:'dark'}[voucher.voucher_type]||'secondary'
+                    span.badge(class='badge-'+tc)= voucher.voucher_type
+                if voucher.reversal_of_no
+                    .col-auto
+                        .small.text-muted Reversal of
+                        strong= voucher.reversal_of_no
+                .col-12.mt-1
+                    .small.text-muted Narration
+                    = voucher.narration
+
+        else
+            .row.mb-3
+                .col-md-2
+                    label.small.mb-1 Date *
+                    input.form-control.form-control-sm#voucherDate(type="date" value=voucherDate)
+                .col-md-2
+                    label.small.mb-1 Type
+                    select.form-control.form-control-sm#voucherType
+                        each vt in MANUAL_JOURNAL_TYPES
+                            option(value=vt)= vt
+                .col-md-6
+                    label.small.mb-1 Narration
+                    input.form-control.form-control-sm#narration(type="text" placeholder="Purpose of this journal entry")
+
+        .table-responsive.mt-3
+            table.table.table-sm.table-bordered#linesTable
+                thead.thead-dark
+                    tr
+                        th(style="width:30px") #
+                        th Ledger
+                        th.text-right(style="width:130px") DR (₹)
+                        th.text-right(style="width:130px") CR (₹)
+                        th Narration
+                        if !readOnly
+                            th.text-center(style="width:40px")
+                tbody#linesBody
+                    if readOnly
+                        each line in lines
+                            tr
+                                td.small.text-muted= line.line_no
+                                td.small= line.ledger_name
+                                td.text-right.small= line.dr_amount > 0 ? parseFloat(line.dr_amount).toLocaleString('en-IN',{minimumFractionDigits:2,maximumFractionDigits:2}) : ''
+                                td.text-right.small= line.cr_amount > 0 ? parseFloat(line.cr_amount).toLocaleString('en-IN',{minimumFractionDigits:2,maximumFractionDigits:2}) : ''
+                                td.small= line.narration || ''
+                tfoot
+                    tr.font-weight-bold.bg-light
+                        td(colspan="2") Total
+                        td.text-right#totalDr
+                            if readOnly
+                                = lines.reduce((s,l)=>s+parseFloat(l.dr_amount||0),0).toLocaleString('en-IN',{minimumFractionDigits:2,maximumFractionDigits:2})
+                            else
+                                | 0.00
+                        td.text-right#totalCr
+                            if readOnly
+                                = lines.reduce((s,l)=>s+parseFloat(l.cr_amount||0),0).toLocaleString('en-IN',{minimumFractionDigits:2,maximumFractionDigits:2})
+                            else
+                                | 0.00
+                        td(colspan=readOnly ? '1' : '2')
+                            if !readOnly
+                                span#balanceStatus
+
+        if !readOnly
+            .mt-2
+                button.btn.btn-sm.btn-outline-primary.mr-2#btnAddRow
+                    i.bi.bi-plus-lg.mr-1
+                    | Add Row
+                button.btn.btn-success.ml-auto#btnSave(disabled)
+                    i.bi.bi-save.mr-1
+                    | Save Journal
+
+    if !readOnly
+        script.
+            let rowCount = 0;
+
+            function fmtNum(n) {
+                return Math.abs(n).toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2});
+            }
+
+            function addRow(ledgerId, ledgerName, drAmt, crAmt, lineNarration) {
+                rowCount++;
+                const idx = rowCount;
+                const tr  = document.createElement('tr');
+                tr.dataset.rowIdx = idx;
+                tr.innerHTML = `
+                    <td class="small text-muted align-middle">${idx}</td>
+                    <td>
+                        <select class="form-control form-control-sm ledger-select" name="ledger_${idx}" style="width:100%">
+                            ${ledgerId ? `<option value="${ledgerId}" selected>${ledgerName}</option>` : '<option value="">— Search ledger —</option>'}
+                        </select>
+                    </td>
+                    <td><input type="number" class="form-control form-control-sm text-right dr-amt" min="0" step="0.01" value="${drAmt||''}" placeholder="0.00"></td>
+                    <td><input type="number" class="form-control form-control-sm text-right cr-amt" min="0" step="0.01" value="${crAmt||''}" placeholder="0.00"></td>
+                    <td><input type="text" class="form-control form-control-sm line-narr" value="${lineNarration||''}" placeholder="(optional)"></td>
+                    <td class="text-center align-middle">
+                        <button type="button" class="btn btn-outline-danger btn-sm btn-remove-row">
+                            <i class="bi bi-trash"></i>
+                        </button>
+                    </td>`;
+
+                document.getElementById('linesBody').appendChild(tr);
+
+                // Select2 for this row's ledger
+                $(tr).find('.ledger-select').select2({
+                    placeholder: '— Search ledger —',
+                    allowClear: true,
+                    minimumInputLength: 1,
+                    dropdownParent: $('body'),
+                    ajax: {
+                        url: '/gl/api/ledgers/search',
+                        dataType: 'json',
+                        delay: 250,
+                        data: (p) => ({ q: p.term }),
+                        processResults: (data) => ({
+                            results: data.map(l => ({ id: l.ledger_id, text: l.ledger_name }))
+                        })
+                    }
+                });
+
+                // DR clears CR and vice versa
+                $(tr).find('.dr-amt').on('input', function() {
+                    if (this.value) $(tr).find('.cr-amt').val('');
+                    recalc();
+                });
+                $(tr).find('.cr-amt').on('input', function() {
+                    if (this.value) $(tr).find('.dr-amt').val('');
+                    recalc();
+                });
+
+                $(tr).find('.btn-remove-row').on('click', function() {
+                    if (document.querySelectorAll('#linesBody tr').length <= 2) {
+                        alert('At least 2 lines are required.');
+                        return;
+                    }
+                    tr.remove();
+                    recalc();
+                });
+
+                recalc();
+            }
+
+            function recalc() {
+                let totalDr = 0, totalCr = 0;
+                document.querySelectorAll('#linesBody tr').forEach(function(tr) {
+                    totalDr += parseFloat(tr.querySelector('.dr-amt').value || 0);
+                    totalCr += parseFloat(tr.querySelector('.cr-amt').value || 0);
+                });
+                const diff = Math.abs(totalDr - totalCr);
+                document.getElementById('totalDr').textContent = fmtNum(totalDr);
+                document.getElementById('totalCr').textContent = fmtNum(totalCr);
+                const status = document.getElementById('balanceStatus');
+                if (diff < 0.005 && totalDr > 0) {
+                    status.innerHTML = '<span class="text-success small"><i class="bi bi-check-circle-fill"></i> Balanced</span>';
+                    document.getElementById('btnSave').disabled = false;
+                } else {
+                    status.innerHTML = diff < 0.005 ? '' :
+                        `<span class="text-danger small">Diff ₹${fmtNum(diff)}</span>`;
+                    document.getElementById('btnSave').disabled = true;
+                }
+            }
+
+            document.getElementById('btnAddRow').addEventListener('click', () => addRow());
+
+            document.getElementById('btnSave').addEventListener('click', async function() {
+                const lines = [];
+                let valid = true;
+                document.querySelectorAll('#linesBody tr').forEach(function(tr) {
+                    const ledgerId  = $(tr).find('.ledger-select').val();
+                    const drAmount  = parseFloat(tr.querySelector('.dr-amt').value || 0);
+                    const crAmount  = parseFloat(tr.querySelector('.cr-amt').value || 0);
+                    const narration = tr.querySelector('.line-narr').value;
+                    if (!ledgerId) { valid = false; return; }
+                    lines.push({ ledger_id: ledgerId, dr_amount: drAmount, cr_amount: crAmount, narration });
+                });
+                if (!valid) { alert('Please select a ledger for every line.'); return; }
+
+                const payload = {
+                    voucher_type: document.getElementById('voucherType').value,
+                    voucher_date: document.getElementById('voucherDate').value,
+                    narration:    document.getElementById('narration').value,
+                    lines
+                };
+
+                this.disabled = true;
+                this.textContent = 'Saving…';
+
+                try {
+                    const resp = await fetch('/gl/api/journal', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(payload)
+                    });
+                    const data = await resp.json();
+                    if (data.success) {
+                        window.location.href = '/gl/journal/' + data.voucher_id;
+                    } else {
+                        alert('Error: ' + data.error);
+                        this.disabled = false;
+                        this.textContent = 'Save Journal';
+                    }
+                } catch (e) {
+                    alert('Network error. Please try again.');
+                    this.disabled = false;
+                    this.textContent = 'Save Journal';
+                }
+            });
+
+            // Seed 2 blank rows on load
+            addRow(); addRow();
+
+    if readOnly && voucher && voucher.is_reversal !== 'Y'
+        script.
+            document.getElementById('btnReverse') && document.getElementById('btnReverse').addEventListener('click', async function() {
+                if (!confirm('Create a reversal entry for ' + this.dataset.id + '?')) return;
+                this.disabled = true;
+                this.textContent = 'Reversing…';
+                try {
+                    const resp = await fetch('/gl/api/journal/' + this.dataset.id + '/reverse', { method: 'POST' });
+                    const data = await resp.json();
+                    if (data.success) {
+                        window.location.href = '/gl/journal/' + data.voucher_id;
+                    } else {
+                        alert('Error: ' + data.error);
+                        this.disabled = false;
+                        this.innerHTML = '<i class="bi bi-arrow-counterclockwise mr-1"></i> Reverse';
+                    }
+                } catch (e) {
+                    alert('Network error.');
+                    this.disabled = false;
+                }
+            });

--- a/views/gl-journal-list.pug
+++ b/views/gl-journal-list.pug
@@ -1,0 +1,54 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Manual Journals
+            a.btn.btn-sm.btn-success(href="/gl/journal/new")
+                i.bi.bi-plus-lg.mr-1
+                | New Journal
+
+        form.row.align-items-end.mb-3(method="GET" action="/gl/journal")
+            .col-auto
+                label.small.mb-1 From Date
+                input.form-control.form-control-sm(type="date" name="from_date" value=fromDate)
+            .col-auto
+                label.small.mb-1 To Date
+                input.form-control.form-control-sm(type="date" name="to_date" value=toDate)
+            .col-auto.align-self-end
+                button.btn.btn-primary.btn-sm(type="submit") View
+
+        if !journals.length
+            .alert.alert-info.py-2 No manual journals found for this date range.
+        else
+            .table-responsive
+                table.table.table-sm.table-bordered.table-hover
+                    thead.thead-dark
+                        tr
+                            th(style="width:90px") Date
+                            th(style="width:100px") Voucher No
+                            th(style="width:80px") Type
+                            th Narration
+                            th.text-right(style="width:120px") Amount (₹)
+                            th(style="width:90px") Posted By
+                            th.text-center(style="width:60px")
+                    tbody
+                        each j in journals
+                            tr(class=(j.is_reversal==='Y'?'table-warning':''))
+                                td.small= j.voucher_date
+                                td.small
+                                    = j.voucher_no
+                                    if j.is_reversal === 'Y'
+                                        |
+                                        span.badge.badge-warning REV
+                                td.text-center
+                                    - const tc = {JOURNAL:'secondary',PAYMENT:'danger',RECEIPT:'info',CONTRA:'dark'}[j.voucher_type]||'secondary'
+                                    span.badge(class='badge-'+tc)= j.voucher_type
+                                td.small= j.narration
+                                td.text-right.small= parseFloat(j.total_amount).toLocaleString('en-IN',{minimumFractionDigits:2,maximumFractionDigits:2})
+                                td.small= j.posted_by
+                                td.text-center
+                                    a.btn.btn-outline-secondary.btn-sm(href='/gl/journal/'+j.voucher_id title="View")
+                                        i.bi.bi-eye

--- a/views/gl-ledger-report.pug
+++ b/views/gl-ledger-report.pug
@@ -1,0 +1,125 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Ledger Report
+            a.btn.btn-sm.btn-outline-secondary(href="/gl/day-book") &larr; Day Book
+
+        form.row.align-items-end.mb-3(method="GET" action="/gl/ledger")
+            .col-md-4
+                label.small.mb-1 Ledger
+                select#ledgerSelect.form-control.form-control-sm(name="ledger_id")
+                    if ledger
+                        option(value=ledger.ledger_id selected)= ledger.ledger_name
+                    else
+                        option(value="") — Search ledger —
+            .col-auto
+                label.small.mb-1 From Date
+                input.form-control.form-control-sm(type="date" name="from_date" value=fromDate)
+            .col-auto
+                label.small.mb-1 To Date
+                input.form-control.form-control-sm(type="date" name="to_date" value=toDate)
+            .col-auto.align-self-end
+                button.btn.btn-primary.btn-sm(type="submit") View
+
+        if !ledger
+            .alert.alert-info.py-2 Select a ledger to view its account statement.
+        else
+            .mb-2
+                span.font-weight-bold= ledger.ledger_name
+                span.text-muted.ml-2.small= ledger.group_name + ' — ' + ledger.group_nature
+
+            - const fmt = (n) => Math.abs(n).toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+            - const balLabel = (n) => n >= 0 ? fmt(n) + ' Dr' : fmt(n) + ' Cr'
+
+            .row.mb-3
+                .col-3
+                    .card.text-center.py-2
+                        .small.text-muted Opening Balance
+                        strong(class=(obNet >= 0 ? 'text-dark' : 'text-danger'))= balLabel(obNet)
+                .col-3
+                    .card.text-center.py-2
+                        .small.text-muted Period DR (₹)
+                        strong= fmt(periodDr)
+                .col-3
+                    .card.text-center.py-2
+                        .small.text-muted Period CR (₹)
+                        strong= fmt(periodCr)
+                .col-3
+                    .card.text-center.py-2
+                        .small.text-muted Closing Balance
+                        strong(class=(closingBalance >= 0 ? 'text-dark' : 'text-danger'))= balLabel(closingBalance)
+
+            if !entries.length
+                .alert.alert-info.py-2 No transactions in this date range.
+            else
+                .table-responsive
+                    table.table.table-bordered.table-sm#ledgerTable
+                        thead.thead-dark
+                            tr
+                                th(style="width:90px") Date
+                                th(style="width:95px") Voucher No
+                                th(style="width:80px") Type
+                                th Particulars
+                                th.text-right(style="width:110px") DR (₹)
+                                th.text-right(style="width:110px") CR (₹)
+                                th.text-right(style="width:120px") Balance
+                        tbody
+                            tr.table-light.font-weight-bold
+                                td(colspan="6") Opening Balance
+                                td.text-right= balLabel(obNet)
+                            each e in entries
+                                tr(class=(e.is_reversal === 'Y' ? 'table-warning' : ''))
+                                    td.small= e.voucher_date
+                                    td.small
+                                        = e.voucher_no
+                                        if e.is_reversal === 'Y'
+                                            |
+                                            span.badge.badge-warning REV
+                                    td.text-center
+                                        - const tc = {SALES:'success',PURCHASE:'primary',PAYMENT:'danger',RECEIPT:'info',JOURNAL:'secondary',CONTRA:'dark'}[e.voucher_type] || 'secondary'
+                                        span.badge(class='badge-' + tc)= e.voucher_type
+                                    td.small(style="max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title=e.narration)= e.narration
+                                    td.text-right.small
+                                        if e.dr_amount > 0
+                                            = fmt(e.dr_amount)
+                                    td.text-right.small
+                                        if e.cr_amount > 0
+                                            = fmt(e.cr_amount)
+                                    td.text-right.small.font-weight-bold= balLabel(e.balance)
+                        tfoot
+                            tr.font-weight-bold.bg-light
+                                td(colspan="4") Closing Balance
+                                td.text-right= fmt(periodDr)
+                                td.text-right= fmt(periodCr)
+                                td.text-right= balLabel(closingBalance)
+
+    script.
+        $(document).ready(function() {
+            $('#ledgerSelect').select2({
+                placeholder: '— Search ledger —',
+                allowClear: true,
+                minimumInputLength: 1,
+                ajax: {
+                    url: '/gl/api/ledgers/search',
+                    dataType: 'json',
+                    delay: 250,
+                    data: function(params) {
+                        return { q: params.term };
+                    },
+                    processResults: function(data) {
+                        return {
+                            results: data.map(function(l) {
+                                return { id: l.ledger_id, text: l.ledger_name };
+                            })
+                        };
+                    }
+                }
+            });
+        });
+
+    style.
+        #ledgerTable { font-size: 0.8rem; }

--- a/views/gl-profit-loss.pug
+++ b/views/gl-profit-loss.pug
@@ -1,0 +1,94 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Profit &amp; Loss Statement
+            a.btn.btn-sm.btn-outline-secondary(href="/gl/trial-balance") &larr; Trial Balance
+
+        form.row.align-items-end.mb-3(method="GET" action="/gl/profit-loss")
+            .col-auto
+                label.small.mb-1 From Date
+                input.form-control.form-control-sm(type="date" name="from_date" value=fromDate)
+            .col-auto
+                label.small.mb-1 To Date
+                input.form-control.form-control-sm(type="date" name="to_date" value=toDate)
+            .col-auto.align-self-end
+                button.btn.btn-primary.btn-sm(type="submit") View
+
+        - const fmt = (n) => Math.abs(n).toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+
+        .row.mb-3
+            .col-4
+                .card.text-center.py-2
+                    .small.text-muted Total Income (₹)
+                    strong.text-success= fmt(totalIncome)
+            .col-4
+                .card.text-center.py-2
+                    .small.text-muted Total Expenses (₹)
+                    strong.text-danger= fmt(totalExpenses)
+            .col-4
+                .card.text-center.py-2(class=(netPL >= 0 ? 'border-success' : 'border-danger'))
+                    .small.text-muted= netPL >= 0 ? 'Net Profit (₹)' : 'Net Loss (₹)'
+                    strong(class=(netPL >= 0 ? 'text-success' : 'text-danger'))= fmt(netPL)
+
+        .row
+            .col-md-6
+                h6.text-success.border-bottom.pb-1 Income
+                if !incomeGroups.length
+                    p.text-muted.small No income entries for this period.
+                else
+                    table.table.table-sm.table-bordered#plIncomeTable
+                        tbody
+                            each g in incomeGroups
+                                tr.group-header
+                                    td.font-weight-bold(colspan="2")= g.group_name
+                                each row in g.rows
+                                    tr
+                                        td.pl-4
+                                            a(href='/gl/ledger?ledger_id=' + row.ledger_id + '&from_date=' + fromDate + '&to_date=' + toDate)= row.ledger_name
+                                        td.text-right.small= fmt(row.amount)
+                                tr.group-subtotal
+                                    td.text-right.font-weight-bold.text-muted.small #{g.group_name} Total
+                                    td.text-right.font-weight-bold.small= fmt(g.subtotal)
+                        tfoot
+                            tr.table-success.font-weight-bold
+                                td Total Income
+                                td.text-right= fmt(totalIncome)
+
+            .col-md-6
+                h6.text-danger.border-bottom.pb-1 Expenses
+                if !expenseGroups.length
+                    p.text-muted.small No expense entries for this period.
+                else
+                    table.table.table-sm.table-bordered#plExpenseTable
+                        tbody
+                            each g in expenseGroups
+                                tr.group-header
+                                    td.font-weight-bold(colspan="2")= g.group_name
+                                each row in g.rows
+                                    tr
+                                        td.pl-4
+                                            a(href='/gl/ledger?ledger_id=' + row.ledger_id + '&from_date=' + fromDate + '&to_date=' + toDate)= row.ledger_name
+                                        td.text-right.small= fmt(row.amount)
+                                tr.group-subtotal
+                                    td.text-right.font-weight-bold.text-muted.small #{g.group_name} Total
+                                    td.text-right.font-weight-bold.small= fmt(g.subtotal)
+                        tfoot
+                            tr.table-danger.font-weight-bold
+                                td Total Expenses
+                                td.text-right= fmt(totalExpenses)
+
+        .row.mt-3
+            .col-md-6.offset-md-6
+                table.table.table-sm.table-bordered
+                    tr(class=(netPL >= 0 ? 'table-success' : 'table-danger') ).font-weight-bold
+                        td= netPL >= 0 ? 'Net Profit for the Period' : 'Net Loss for the Period'
+                        td.text-right= fmt(netPL)
+
+    style.
+        #plIncomeTable, #plExpenseTable { font-size: 0.82rem; }
+        .group-header td  { background-color: #e9ecef; }
+        .group-subtotal td { background-color: #f8f9fa; border-top: 2px solid #dee2e6 !important; }

--- a/views/gl-trial-balance.pug
+++ b/views/gl-trial-balance.pug
@@ -1,0 +1,72 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Trial Balance
+            a.btn.btn-sm.btn-outline-secondary(href="/gl/day-book") &larr; Day Book
+
+        form.row.align-items-end.mb-3(method="GET" action="/gl/trial-balance")
+            .col-auto
+                label.small.mb-1 As of Date
+                input.form-control.form-control-sm(type="date" name="as_of_date" value=asOfDate)
+            .col-auto.align-self-end
+                .form-check.mb-1
+                    input.form-check-input#showZero(type="checkbox" name="show_zero" value="1" checked=showZero)
+                    label.form-check-label.small(for="showZero") Show zero balances
+            .col-auto.align-self-end
+                button.btn.btn-primary.btn-sm(type="submit") View
+
+        if isBalanced
+            .alert.alert-success.py-2.mb-2
+                i.bi.bi-check-circle-fill.mr-1
+                | Books balance &mdash; DR = CR = ₹#{grandDr.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})}
+        else
+            .alert.alert-danger.py-2.mb-2
+                i.bi.bi-exclamation-triangle-fill.mr-1
+                | Out of balance &mdash; DR ₹#{grandDr.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})} vs CR ₹#{grandCr.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})} (diff ₹#{Math.abs(grandDr - grandCr).toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})})
+
+        - const fmt = (n) => n.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+
+        if !groups.length
+            .alert.alert-info.py-2 No ledger activity found up to this date.
+        else
+            .table-responsive
+                table.table.table-bordered.table-sm#tbTable
+                    thead.thead-dark
+                        tr
+                            th Ledger
+                            th.text-right(style="width:140px") DR (₹)
+                            th.text-right(style="width:140px") CR (₹)
+                    tbody
+                        each g in groups
+                            tr.group-header
+                                td.font-weight-bold(colspan="3")
+                                    span.badge.mr-2(class=(g.group_nature==='ASSETS'||g.group_nature==='EXPENSES'?'badge-primary':'badge-success'))= g.group_nature
+                                    = g.group_name
+                            each row in g.rows
+                                tr
+                                    td.pl-4
+                                        a(href='/gl/ledger?ledger_id=' + row.ledger_id + '&from_date=' + asOfDate.substring(0,8) + '01&to_date=' + asOfDate)= row.ledger_name
+                                    td.text-right.small
+                                        if row.dr_balance > 0
+                                            = fmt(row.dr_balance)
+                                    td.text-right.small
+                                        if row.cr_balance > 0
+                                            = fmt(row.cr_balance)
+                            tr.group-subtotal
+                                td.text-right.font-weight-bold.text-muted.small #{g.group_name} Total
+                                td.text-right.font-weight-bold.small= g.subtotal_dr > 0 ? fmt(g.subtotal_dr) : ''
+                                td.text-right.font-weight-bold.small= g.subtotal_cr > 0 ? fmt(g.subtotal_cr) : ''
+                    tfoot
+                        tr.font-weight-bold(class=(isBalanced ? 'table-success' : 'table-danger'))
+                            td Grand Total
+                            td.text-right= fmt(grandDr)
+                            td.text-right= fmt(grandCr)
+
+    style.
+        #tbTable { font-size: 0.82rem; }
+        .group-header td { background-color: #e9ecef; }
+        .group-subtotal td { background-color: #f8f9fa; border-top: 2px solid #dee2e6 !important; }


### PR DESCRIPTION
## Summary
- Day Book, Ledger Report, Trial Balance, P&L, Balance Sheet — full GL report chain
- Manual Journal: new entry, list, view, reverse
- GL Control page: Events Monitor, Create Accounting runner, Generate Events backfill (all 9 source types)
- DB triggers for sales, bowser, purchase invoices, deletes; product ledger map types from m_lookup
- Menu items for all GL pages under ACCOUNTING group

## DB migrations to run on prod
- `gl-accounting-event-triggers.sql`
- `gl-bowser-triggers.sql`
- `gl-delete-triggers.sql`
- `gl-purchase-invoice-triggers.sql`
- `gl-product-map-types-seed.sql`
- `gl-menu-items.sql`
- `gl-control-menu-item.sql`
- `gl-bank-txn-setup.sql`

## Test plan
- [ ] GL Control → Events Monitor: loads summary cards and events table
- [ ] GL Control → Generate Events: inserts missing events for a date range
- [ ] GL Control → Create Accounting: processes events and shows voucher count
- [ ] Day Book, Ledger Report, Trial Balance, P&L, Balance Sheet render correctly
- [ ] Manual Journal: create, view, reverse
- [ ] All GL menu items visible under ACCOUNTING for SuperUser

🤖 Generated with [Claude Code](https://claude.com/claude-code)