### PR TITLE
GL: period lookup on all date filters, ledger groups and ledgers master pages

### DIFF
--- a/db/migrations/gl-ledger-master-menu-items.sql
+++ b/db/migrations/gl-ledger-master-menu-items.sql
@@ -1,0 +1,25 @@
+-- ============================================================
+-- GL Ledger Master — Menu Items & Access
+-- Generated: 2026-05-02
+--
+-- Adds Ledger Groups and Ledgers pages under ACCOUNTING group.
+-- Run on dev and prod.
+-- ============================================================
+
+INSERT INTO m_menu_items
+    (menu_code, menu_name, icon, url_path, parent_code, sequence, effective_start_date, created_by, updated_by, group_code)
+VALUES
+    ('GL_LEDGER_GROUPS', 'Ledger Groups', 'bi-collection',  '/gl/ledger-groups', NULL, 9,  '2026-05-02', 'SAKTHI', 'SAKTHI', 'ACCOUNTING'),
+    ('GL_LEDGERS',       'Ledgers',       'bi-card-list',   '/gl/ledgers',       NULL, 10, '2026-05-02', 'SAKTHI', 'SAKTHI', 'ACCOUNTING');
+
+INSERT INTO m_menu_access_global
+    (role, menu_code, allowed, effective_start_date, created_by, updated_by)
+VALUES
+    ('SuperUser', 'GL_LEDGER_GROUPS', 1, '2026-05-02', 'SAKTHI', 'SAKTHI'),
+    ('SuperUser', 'GL_LEDGERS',       1, '2026-05-02', 'SAKTHI', 'SAKTHI');
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SELECT menu_code, menu_name, sequence, group_code
+FROM m_menu_items
+WHERE group_code = 'ACCOUNTING'
+ORDER BY sequence;

--- a/public/javascripts/app-report-date.js
+++ b/public/javascripts/app-report-date.js
@@ -174,3 +174,71 @@ function updateInvoiceDateRange() {
         toDateLabel.closest('td').style.display = 'none';
     }
 }
+
+// ── GL date range helpers ────────────────────────────────────────────────────
+// Used by GL report pages — pre-fills from/to date inputs without hiding them.
+
+function glSetPeriod(fromId, toId, selectId) {
+    const sel = selectId || 'glPeriod';
+    const period = document.getElementById(sel) ? document.getElementById(sel).value : 'custom';
+    const today = new Date();
+    const yr = today.getFullYear();
+    const mo = today.getMonth();
+
+    function iso(d) {
+        return new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate())).toISOString().split('T')[0];
+    }
+
+    let from, to;
+    if (period === 'this_month') {
+        from = new Date(yr, mo, 1);
+        to   = today;
+    } else if (period === 'last_month') {
+        from = new Date(yr, mo - 1, 1);
+        to   = new Date(yr, mo, 0);
+    } else if (period === 'this_fy') {
+        from = mo < 3 ? new Date(yr - 1, 3, 1) : new Date(yr, 3, 1);
+        to   = today;
+    } else if (period === 'last_fy') {
+        if (mo < 3) {
+            from = new Date(yr - 2, 3, 1);
+            to   = new Date(yr - 1, 2, 31);
+        } else {
+            from = new Date(yr - 1, 3, 1);
+            to   = new Date(yr, 2, 31);
+        }
+    } else {
+        return; // custom — user enters manually
+    }
+
+    if (fromId) document.getElementById(fromId).value = iso(from);
+    if (toId)   document.getElementById(toId).value   = iso(to);
+}
+
+// For single-date views (Trial Balance, Balance Sheet)
+function glSetAsOf(asOfId, selectId) {
+    const sel = selectId || 'glPeriodAsOf';
+    const period = document.getElementById(sel) ? document.getElementById(sel).value : 'custom';
+    const today = new Date();
+    const yr = today.getFullYear();
+    const mo = today.getMonth();
+
+    function iso(d) {
+        return new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate())).toISOString().split('T')[0];
+    }
+
+    let dt;
+    if (period === 'today') {
+        dt = today;
+    } else if (period === 'end_last_month') {
+        dt = new Date(yr, mo, 0);
+    } else if (period === 'end_this_fy') {
+        dt = mo < 3 ? new Date(yr, 2, 31) : new Date(yr + 1, 2, 31);
+    } else if (period === 'end_last_fy') {
+        dt = mo < 3 ? new Date(yr - 1, 2, 31) : new Date(yr, 2, 31);
+    } else {
+        return;
+    }
+
+    if (asOfId) document.getElementById(asOfId).value = iso(dt);
+}

--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -826,6 +826,175 @@ router.post('/api/journal/:id/reverse', [isLoginEnsured, security.isAdmin()], as
     }
 });
 
+// ── Ledger Groups ─────────────────────────────────────────────────────────────
+// GET /gl/ledger-groups
+
+router.get('/ledger-groups', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    try {
+        const groups = await db.sequelize.query(`
+            SELECT g.group_id, g.group_name, g.group_nature,
+                   COUNT(l.ledger_id) AS ledger_count
+            FROM gl_ledger_groups g
+            LEFT JOIN gl_ledgers l ON l.group_id = g.group_id AND l.active_flag = 'Y'
+            WHERE g.location_code = :locationCode
+            GROUP BY g.group_id
+            ORDER BY FIELD(g.group_nature,'ASSETS','LIABILITIES','INCOME','EXPENSES'), g.group_name
+        `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT });
+
+        res.render('gl-ledger-groups', {
+            title:    'Ledger Groups',
+            user:     req.user,
+            config:   require('../config/app-config').APP_CONFIGS,
+            groups,
+            messages: req.flash()
+        });
+    } catch (err) {
+        console.error('Ledger groups error:', err);
+        req.flash('error', err.message);
+        res.redirect('/gl/day-book');
+    }
+});
+
+router.post('/api/ledger-groups', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const { group_name, group_nature } = req.body;
+    const NATURES = ['ASSETS', 'LIABILITIES', 'INCOME', 'EXPENSES'];
+    if (!group_name || !NATURES.includes(group_nature))
+        return res.status(400).json({ success: false, error: 'group_name and valid group_nature are required' });
+    try {
+        const [[exists]] = await db.sequelize.query(
+            `SELECT group_id FROM gl_ledger_groups WHERE location_code=:locationCode AND group_name=:group_name LIMIT 1`,
+            { replacements: { locationCode, group_name }, type: db.Sequelize.QueryTypes.SELECT }
+        );
+        if (exists) return res.status(400).json({ success: false, error: 'A group with this name already exists' });
+
+        const [groupId] = await db.sequelize.query(`
+            INSERT INTO gl_ledger_groups (location_code, group_name, group_nature, created_by, updated_by)
+            VALUES (:locationCode, :group_name, :group_nature, :user, :user)
+        `, { replacements: { locationCode, group_name, group_nature, user: req.user.username }, type: db.Sequelize.QueryTypes.INSERT });
+        res.json({ success: true, group_id: groupId });
+    } catch (err) {
+        res.status(500).json({ success: false, error: err.message });
+    }
+});
+
+router.put('/api/ledger-groups/:id', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const groupId = parseInt(req.params.id);
+    const { group_name, group_nature } = req.body;
+    const NATURES = ['ASSETS', 'LIABILITIES', 'INCOME', 'EXPENSES'];
+    if (!group_name || !NATURES.includes(group_nature))
+        return res.status(400).json({ success: false, error: 'group_name and valid group_nature are required' });
+    try {
+        await db.sequelize.query(`
+            UPDATE gl_ledger_groups SET group_name=:group_name, group_nature=:group_nature, updated_by=:user
+            WHERE group_id=:groupId AND location_code=:locationCode
+        `, { replacements: { groupId, locationCode, group_name, group_nature, user: req.user.username }, type: db.Sequelize.QueryTypes.UPDATE });
+        res.json({ success: true });
+    } catch (err) {
+        res.status(500).json({ success: false, error: err.message });
+    }
+});
+
+router.delete('/api/ledger-groups/:id', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const groupId = parseInt(req.params.id);
+    try {
+        const [rows] = await db.sequelize.query(
+            `SELECT COUNT(*) AS cnt FROM gl_ledgers WHERE group_id=:groupId`,
+            { replacements: { groupId }, type: db.Sequelize.QueryTypes.SELECT }
+        );
+        if (rows.cnt > 0)
+            return res.status(400).json({ success: false, error: `Cannot delete — ${rows.cnt} ledger(s) assigned to this group` });
+        await db.sequelize.query(
+            `DELETE FROM gl_ledger_groups WHERE group_id=:groupId AND location_code=:locationCode`,
+            { replacements: { groupId, locationCode }, type: db.Sequelize.QueryTypes.DELETE }
+        );
+        res.json({ success: true });
+    } catch (err) {
+        res.status(500).json({ success: false, error: err.message });
+    }
+});
+
+// ── Ledgers ───────────────────────────────────────────────────────────────────
+// GET /gl/ledgers
+
+router.get('/ledgers', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    try {
+        const [ledgers, groups] = await Promise.all([
+            db.sequelize.query(`
+                SELECT l.ledger_id, l.ledger_name, l.active_flag,
+                       g.group_id, g.group_name, g.group_nature
+                FROM gl_ledgers l
+                JOIN gl_ledger_groups g ON g.group_id = l.group_id
+                WHERE l.location_code = :locationCode
+                ORDER BY FIELD(g.group_nature,'ASSETS','LIABILITIES','INCOME','EXPENSES'), g.group_name, l.ledger_name
+            `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT }),
+            db.sequelize.query(`
+                SELECT group_id, group_name, group_nature
+                FROM gl_ledger_groups
+                WHERE location_code = :locationCode
+                ORDER BY FIELD(group_nature,'ASSETS','LIABILITIES','INCOME','EXPENSES'), group_name
+            `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT })
+        ]);
+
+        res.render('gl-ledgers', {
+            title:    'Ledgers',
+            user:     req.user,
+            config:   require('../config/app-config').APP_CONFIGS,
+            ledgers,
+            groups,
+            messages: req.flash()
+        });
+    } catch (err) {
+        console.error('Ledgers error:', err);
+        req.flash('error', err.message);
+        res.redirect('/gl/day-book');
+    }
+});
+
+router.post('/api/ledger', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const { ledger_name, group_id } = req.body;
+    if (!ledger_name || !group_id) return res.status(400).json({ success: false, error: 'ledger_name and group_id are required' });
+    try {
+        const [exists] = await db.sequelize.query(
+            `SELECT ledger_id FROM gl_ledgers WHERE location_code=:locationCode AND ledger_name=:ledger_name LIMIT 1`,
+            { replacements: { locationCode, ledger_name }, type: db.Sequelize.QueryTypes.SELECT }
+        );
+        if (exists) return res.status(400).json({ success: false, error: 'A ledger with this name already exists' });
+
+        const [ledgerId] = await db.sequelize.query(`
+            INSERT INTO gl_ledgers (location_code, ledger_name, group_id, active_flag, created_by, updated_by)
+            VALUES (:locationCode, :ledger_name, :group_id, 'Y', :user, :user)
+        `, { replacements: { locationCode, ledger_name, group_id: parseInt(group_id), user: req.user.username }, type: db.Sequelize.QueryTypes.INSERT });
+        res.json({ success: true, ledger_id: ledgerId });
+    } catch (err) {
+        res.status(500).json({ success: false, error: err.message });
+    }
+});
+
+router.put('/api/ledger/:id', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const ledgerId = parseInt(req.params.id);
+    const { ledger_name, group_id, active_flag } = req.body;
+    if (!ledger_name || !group_id) return res.status(400).json({ success: false, error: 'ledger_name and group_id are required' });
+    try {
+        await db.sequelize.query(`
+            UPDATE gl_ledgers SET ledger_name=:ledger_name, group_id=:group_id, active_flag=:active_flag, updated_by=:user
+            WHERE ledger_id=:ledgerId AND location_code=:locationCode
+        `, {
+            replacements: { ledgerId, locationCode, ledger_name, group_id: parseInt(group_id), active_flag: active_flag === 'Y' ? 'Y' : 'N', user: req.user.username },
+            type: db.Sequelize.QueryTypes.UPDATE
+        });
+        res.json({ success: true });
+    } catch (err) {
+        res.status(500).json({ success: false, error: err.message });
+    }
+});
+
 // ── GL Control ────────────────────────────────────────────────────────────────
 // GET /gl/control — admin dashboard: events monitor + create accounting + generate events
 

--- a/views/gl-balance-sheet.pug
+++ b/views/gl-balance-sheet.pug
@@ -10,8 +10,16 @@ block content
 
         form.row.align-items-end.mb-3(method="GET" action="/gl/balance-sheet")
             .col-auto
+                label.small.mb-1 Quick Select
+                select.form-control.form-control-sm#glPeriodAsOf(onchange="glSetAsOf('glAsOf')")
+                    option(value="today") Today
+                    option(value="end_last_month") End of Last Month
+                    option(value="end_this_fy") End of This FY
+                    option(value="end_last_fy") End of Last FY
+                    option(value="custom" selected) Custom
+            .col-auto
                 label.small.mb-1 As of Date
-                input.form-control.form-control-sm(type="date" name="as_of_date" value=asOfDate)
+                input.form-control.form-control-sm#glAsOf(type="date" name="as_of_date" value=asOfDate)
             .col-auto.align-self-end
                 button.btn.btn-primary.btn-sm(type="submit") View
 

--- a/views/gl-control.pug
+++ b/views/gl-control.pug
@@ -23,6 +23,14 @@ block content
 
                 form.row.align-items-end.mb-3#eventsFilterForm
                     .col-auto
+                        label.small.mb-1 Period
+                        select.form-control.form-control-sm(onchange="glSetPeriod('evFrom','evTo',this.id)" id="evPeriod")
+                            option(value="this_month") This Month
+                            option(value="last_month") Last Month
+                            option(value="this_fy") This Financial Year
+                            option(value="last_fy") Last Financial Year
+                            option(value="custom" selected) Custom
+                    .col-auto
                         label.small.mb-1 From Date
                         input.form-control.form-control-sm(type="date" id="evFrom" value=fromDate)
                     .col-auto
@@ -83,6 +91,14 @@ block content
 
                 .row.align-items-end.mb-3
                     .col-auto
+                        label.small.mb-1 Period
+                        select.form-control.form-control-sm(onchange="glSetPeriod('caFrom','caTo',this.id)" id="caPeriod")
+                            option(value="this_month") This Month
+                            option(value="last_month") Last Month
+                            option(value="this_fy") This Financial Year
+                            option(value="last_fy") Last Financial Year
+                            option(value="custom" selected) Custom
+                    .col-auto
                         label.small.mb-1 From Date
                         input.form-control.form-control-sm(type="date" id="caFrom" value=fromDate)
                     .col-auto
@@ -107,6 +123,14 @@ block content
                     | or accounting was enabled after transactions already existed.
 
                 .row.align-items-end.mb-3
+                    .col-auto
+                        label.small.mb-1 Period
+                        select.form-control.form-control-sm(onchange="glSetPeriod('geFrom','geTo',this.id)" id="gePeriod")
+                            option(value="this_month") This Month
+                            option(value="last_month") Last Month
+                            option(value="this_fy") This Financial Year
+                            option(value="last_fy") Last Financial Year
+                            option(value="custom" selected) Custom
                     .col-auto
                         label.small.mb-1 From Date
                         input.form-control.form-control-sm(type="date" id="geFrom" value=fromDate)

--- a/views/gl-day-book.pug
+++ b/views/gl-day-book.pug
@@ -10,11 +10,19 @@ block content
 
         form.row.align-items-end.mb-3(method="GET" action="/gl/day-book")
             .col-auto
+                label.small.mb-1 Period
+                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod('glFrom','glTo')")
+                    option(value="this_month") This Month
+                    option(value="last_month") Last Month
+                    option(value="this_fy") This Financial Year
+                    option(value="last_fy") Last Financial Year
+                    option(value="custom" selected) Custom
+            .col-auto
                 label.small.mb-1 From Date
-                input.form-control.form-control-sm(type="date" name="from_date" value=fromDate)
+                input.form-control.form-control-sm#glFrom(type="date" name="from_date" value=fromDate)
             .col-auto
                 label.small.mb-1 To Date
-                input.form-control.form-control-sm(type="date" name="to_date" value=toDate)
+                input.form-control.form-control-sm#glTo(type="date" name="to_date" value=toDate)
             .col-auto
                 label.small.mb-1 Type
                 select.form-control.form-control-sm(name="voucher_type")

--- a/views/gl-journal-list.pug
+++ b/views/gl-journal-list.pug
@@ -12,11 +12,19 @@ block content
 
         form.row.align-items-end.mb-3(method="GET" action="/gl/journal")
             .col-auto
+                label.small.mb-1 Period
+                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod('glFrom','glTo')")
+                    option(value="this_month") This Month
+                    option(value="last_month") Last Month
+                    option(value="this_fy") This Financial Year
+                    option(value="last_fy") Last Financial Year
+                    option(value="custom" selected) Custom
+            .col-auto
                 label.small.mb-1 From Date
-                input.form-control.form-control-sm(type="date" name="from_date" value=fromDate)
+                input.form-control.form-control-sm#glFrom(type="date" name="from_date" value=fromDate)
             .col-auto
                 label.small.mb-1 To Date
-                input.form-control.form-control-sm(type="date" name="to_date" value=toDate)
+                input.form-control.form-control-sm#glTo(type="date" name="to_date" value=toDate)
             .col-auto.align-self-end
                 button.btn.btn-primary.btn-sm(type="submit") View
 

--- a/views/gl-ledger-groups.pug
+++ b/views/gl-ledger-groups.pug
@@ -1,0 +1,134 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Ledger Groups
+            .d-flex.gap-2
+                a.btn.btn-sm.btn-outline-secondary.mr-2(href="/gl/ledgers") Ledgers &rarr;
+                button.btn.btn-sm.btn-success#btnAddGroup
+                    i.bi.bi-plus-lg.mr-1
+                    | Add Group
+
+        if messages && messages.error && messages.error.length
+            .alert.alert-danger.py-2= messages.error[0]
+
+        - const natures = ['ASSETS','LIABILITIES','INCOME','EXPENSES']
+        - const natureBadge = { ASSETS:'primary', LIABILITIES:'warning', INCOME:'success', EXPENSES:'danger' }
+
+        each nat in natures
+            - const grps = groups.filter(g => g.group_nature === nat)
+            if grps.length
+                h6.border-bottom.pb-1.mt-3
+                    span.badge(class='badge-'+natureBadge[nat])= nat
+                .table-responsive.mb-2
+                    table.table.table-sm.table-bordered
+                        thead.thead-light
+                            tr
+                                th Group Name
+                                th.text-center(style="width:120px") Active Ledgers
+                                th.text-center(style="width:80px")
+                        tbody
+                            each g in grps
+                                tr
+                                    td= g.group_name
+                                    td.text-center.small= g.ledger_count
+                                    td.text-center
+                                        button.btn.btn-outline-primary.btn-sm.btn-edit-group.mr-1(
+                                            data-id=g.group_id
+                                            data-name=g.group_name
+                                            data-nature=g.group_nature
+                                            title="Edit")
+                                            i.bi.bi-pencil
+                                        if g.ledger_count == 0
+                                            button.btn.btn-outline-danger.btn-sm.btn-del-group(
+                                                data-id=g.group_id
+                                                data-name=g.group_name
+                                                title="Delete")
+                                                i.bi.bi-trash
+
+    //- Add / Edit Modal
+    .modal.fade#groupModal(tabindex="-1")
+        .modal-dialog
+            .modal-content
+                .modal-header
+                    h5.modal-title#groupModalTitle Add Ledger Group
+                    button.close(data-dismiss="modal" aria-label="Close")
+                        span &times;
+                .modal-body
+                    .form-group
+                        label.small Group Name *
+                        input.form-control.form-control-sm#gName(type="text" maxlength="100")
+                    .form-group
+                        label.small Nature *
+                        select.form-control.form-control-sm#gNature
+                            option(value="ASSETS") ASSETS
+                            option(value="LIABILITIES") LIABILITIES
+                            option(value="INCOME") INCOME
+                            option(value="EXPENSES") EXPENSES
+                .modal-footer
+                    button.btn.btn-secondary.btn-sm(data-dismiss="modal") Cancel
+                    button.btn.btn-primary.btn-sm#btnSaveGroup Save
+
+    script.
+        let editingGroupId = null;
+
+        document.getElementById('btnAddGroup').addEventListener('click', function() {
+            editingGroupId = null;
+            document.getElementById('groupModalTitle').textContent = 'Add Ledger Group';
+            document.getElementById('gName').value = '';
+            document.getElementById('gNature').value = 'ASSETS';
+            $('#groupModal').modal('show');
+        });
+
+        document.querySelectorAll('.btn-edit-group').forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                editingGroupId = this.dataset.id;
+                document.getElementById('groupModalTitle').textContent = 'Edit Ledger Group';
+                document.getElementById('gName').value = this.dataset.name;
+                document.getElementById('gNature').value = this.dataset.nature;
+                $('#groupModal').modal('show');
+            });
+        });
+
+        document.getElementById('btnSaveGroup').addEventListener('click', async function() {
+            const name   = document.getElementById('gName').value.trim();
+            const nature = document.getElementById('gNature').value;
+            if (!name) { alert('Group name is required.'); return; }
+
+            this.disabled = true;
+            try {
+                const url    = editingGroupId ? '/gl/api/ledger-groups/' + editingGroupId : '/gl/api/ledger-groups';
+                const method = editingGroupId ? 'PUT' : 'POST';
+                const resp   = await fetch(url, {
+                    method,
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ group_name: name, group_nature: nature })
+                });
+                const data = await resp.json();
+                if (data.success) {
+                    location.reload();
+                } else {
+                    alert('Error: ' + data.error);
+                    this.disabled = false;
+                }
+            } catch (e) {
+                alert('Network error.');
+                this.disabled = false;
+            }
+        });
+
+        document.querySelectorAll('.btn-del-group').forEach(function(btn) {
+            btn.addEventListener('click', async function() {
+                if (!confirm('Delete group "' + this.dataset.name + '"?')) return;
+                const resp = await fetch('/gl/api/ledger-groups/' + this.dataset.id, { method: 'DELETE' });
+                const data = await resp.json();
+                if (data.success) {
+                    location.reload();
+                } else {
+                    alert('Error: ' + data.error);
+                }
+            });
+        });

--- a/views/gl-ledger-report.pug
+++ b/views/gl-ledger-report.pug
@@ -17,11 +17,19 @@ block content
                     else
                         option(value="") — Search ledger —
             .col-auto
+                label.small.mb-1 Period
+                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod('glFrom','glTo')")
+                    option(value="this_month") This Month
+                    option(value="last_month") Last Month
+                    option(value="this_fy") This Financial Year
+                    option(value="last_fy") Last Financial Year
+                    option(value="custom" selected) Custom
+            .col-auto
                 label.small.mb-1 From Date
-                input.form-control.form-control-sm(type="date" name="from_date" value=fromDate)
+                input.form-control.form-control-sm#glFrom(type="date" name="from_date" value=fromDate)
             .col-auto
                 label.small.mb-1 To Date
-                input.form-control.form-control-sm(type="date" name="to_date" value=toDate)
+                input.form-control.form-control-sm#glTo(type="date" name="to_date" value=toDate)
             .col-auto.align-self-end
                 button.btn.btn-primary.btn-sm(type="submit") View
 

--- a/views/gl-ledgers.pug
+++ b/views/gl-ledgers.pug
@@ -1,0 +1,130 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Ledgers
+            .d-flex.gap-2
+                a.btn.btn-sm.btn-outline-secondary.mr-2(href="/gl/ledger-groups") &larr; Groups
+                button.btn.btn-sm.btn-success#btnAddLedger
+                    i.bi.bi-plus-lg.mr-1
+                    | Add Ledger
+
+        if messages && messages.error && messages.error.length
+            .alert.alert-danger.py-2= messages.error[0]
+
+        - const natures = ['ASSETS','LIABILITIES','INCOME','EXPENSES']
+        - const natureBadge = { ASSETS:'primary', LIABILITIES:'warning', INCOME:'success', EXPENSES:'danger' }
+
+        - const byNature = {}
+        - natures.forEach(n => { byNature[n] = {} })
+        - ledgers.forEach(function(l) { if (!byNature[l.group_nature]) byNature[l.group_nature] = {}; if (!byNature[l.group_nature][l.group_name]) byNature[l.group_nature][l.group_name] = []; byNature[l.group_nature][l.group_name].push(l); })
+
+        each nat in natures
+            - const grpMap = byNature[nat]
+            - const grpNames = Object.keys(grpMap)
+            if grpNames.length
+                h6.border-bottom.pb-1.mt-3
+                    span.badge(class='badge-'+natureBadge[nat])= nat
+                each grpName in grpNames
+                    h6.small.text-muted.mt-2.mb-1= grpName
+                    .table-responsive.mb-1
+                        table.table.table-sm.table-bordered
+                            tbody
+                                each l in grpMap[grpName]
+                                    tr(class=(l.active_flag === 'N' ? 'table-secondary text-muted' : ''))
+                                        td= l.ledger_name
+                                        td.text-center(style="width:60px")
+                                            if l.active_flag === 'N'
+                                                span.badge.badge-secondary Inactive
+                                        td.text-center(style="width:80px")
+                                            button.btn.btn-outline-primary.btn-sm.btn-edit-ledger(
+                                                data-id=l.ledger_id
+                                                data-name=l.ledger_name
+                                                data-group=l.group_id
+                                                data-active=l.active_flag
+                                                title="Edit")
+                                                i.bi.bi-pencil
+
+    //- Add / Edit Modal
+    .modal.fade#ledgerModal(tabindex="-1")
+        .modal-dialog
+            .modal-content
+                .modal-header
+                    h5.modal-title#ledgerModalTitle Add Ledger
+                    button.close(data-dismiss="modal" aria-label="Close")
+                        span &times;
+                .modal-body
+                    .form-group
+                        label.small Ledger Name *
+                        input.form-control.form-control-sm#lName(type="text" maxlength="150")
+                    .form-group
+                        label.small Group *
+                        select.form-control.form-control-sm#lGroup
+                            each g in groups
+                                option(value=g.group_id)= g.group_name + ' (' + g.group_nature + ')'
+                    .form-group#lActiveWrap
+                        .form-check
+                            input.form-check-input#lActive(type="checkbox" value="Y")
+                            label.form-check-label.small(for="lActive") Active
+                .modal-footer
+                    button.btn.btn-secondary.btn-sm(data-dismiss="modal") Cancel
+                    button.btn.btn-primary.btn-sm#btnSaveLedger Save
+
+    script.
+        let editingLedgerId = null;
+
+        document.getElementById('btnAddLedger').addEventListener('click', function() {
+            editingLedgerId = null;
+            document.getElementById('ledgerModalTitle').textContent = 'Add Ledger';
+            document.getElementById('lName').value = '';
+            document.getElementById('lGroup').selectedIndex = 0;
+            document.getElementById('lActive').checked = true;
+            document.getElementById('lActiveWrap').style.display = 'none';
+            $('#ledgerModal').modal('show');
+        });
+
+        document.querySelectorAll('.btn-edit-ledger').forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                editingLedgerId = this.dataset.id;
+                document.getElementById('ledgerModalTitle').textContent = 'Edit Ledger';
+                document.getElementById('lName').value = this.dataset.name;
+                document.getElementById('lGroup').value = this.dataset.group;
+                document.getElementById('lActive').checked = this.dataset.active === 'Y';
+                document.getElementById('lActiveWrap').style.display = '';
+                $('#ledgerModal').modal('show');
+            });
+        });
+
+        document.getElementById('btnSaveLedger').addEventListener('click', async function() {
+            const name      = document.getElementById('lName').value.trim();
+            const group_id  = document.getElementById('lGroup').value;
+            const active    = document.getElementById('lActive').checked ? 'Y' : 'N';
+            if (!name) { alert('Ledger name is required.'); return; }
+
+            this.disabled = true;
+            try {
+                const url    = editingLedgerId ? '/gl/api/ledger/' + editingLedgerId : '/gl/api/ledger';
+                const method = editingLedgerId ? 'PUT' : 'POST';
+                const body   = { ledger_name: name, group_id };
+                if (editingLedgerId) body.active_flag = active;
+
+                const resp = await fetch(url, {
+                    method,
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(body)
+                });
+                const data = await resp.json();
+                if (data.success) {
+                    location.reload();
+                } else {
+                    alert('Error: ' + data.error);
+                    this.disabled = false;
+                }
+            } catch (e) {
+                alert('Network error.');
+                this.disabled = false;
+            }
+        });

--- a/views/gl-profit-loss.pug
+++ b/views/gl-profit-loss.pug
@@ -10,11 +10,19 @@ block content
 
         form.row.align-items-end.mb-3(method="GET" action="/gl/profit-loss")
             .col-auto
+                label.small.mb-1 Period
+                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod('glFrom','glTo')")
+                    option(value="this_month") This Month
+                    option(value="last_month") Last Month
+                    option(value="this_fy") This Financial Year
+                    option(value="last_fy") Last Financial Year
+                    option(value="custom" selected) Custom
+            .col-auto
                 label.small.mb-1 From Date
-                input.form-control.form-control-sm(type="date" name="from_date" value=fromDate)
+                input.form-control.form-control-sm#glFrom(type="date" name="from_date" value=fromDate)
             .col-auto
                 label.small.mb-1 To Date
-                input.form-control.form-control-sm(type="date" name="to_date" value=toDate)
+                input.form-control.form-control-sm#glTo(type="date" name="to_date" value=toDate)
             .col-auto.align-self-end
                 button.btn.btn-primary.btn-sm(type="submit") View
 

--- a/views/gl-trial-balance.pug
+++ b/views/gl-trial-balance.pug
@@ -10,8 +10,16 @@ block content
 
         form.row.align-items-end.mb-3(method="GET" action="/gl/trial-balance")
             .col-auto
+                label.small.mb-1 Quick Select
+                select.form-control.form-control-sm#glPeriodAsOf(onchange="glSetAsOf('glAsOf')")
+                    option(value="today") Today
+                    option(value="end_last_month") End of Last Month
+                    option(value="end_this_fy") End of This FY
+                    option(value="end_last_fy") End of Last FY
+                    option(value="custom" selected) Custom
+            .col-auto
                 label.small.mb-1 As of Date
-                input.form-control.form-control-sm(type="date" name="as_of_date" value=asOfDate)
+                input.form-control.form-control-sm#glAsOf(type="date" name="as_of_date" value=asOfDate)
             .col-auto.align-self-end
                 .form-check.mb-1
                     input.form-check-input#showZero(type="checkbox" name="show_zero" value="1" checked=showZero)


### PR DESCRIPTION
## Summary
- Period select added to all GL date filter forms (Day Book, Ledger Report, P&L, Journal List, GL Control)
- Quick select (Today / End of Month / End of FY) added to Trial Balance and Balance Sheet
- Ledger Groups master page: list by nature, add/edit/delete with AJAX modal
- Ledgers master page: list grouped by nature/group, add/edit/deactivate with AJAX modal

## DB migrations to run on dev & prod
- `gl-ledger-master-menu-items.sql`

## Test plan
- [ ] Period select pre-fills dates correctly on Day Book, Ledger Report, P&L, Journal List
- [ ] Quick select works on Trial Balance and Balance Sheet
- [ ] GL Control: period select works on all 3 tabs independently
- [ ] Ledger Groups: add/edit/delete — delete blocked when ledgers exist
- [ ] Ledgers: add new ledger, edit name/group/active flag
- [ ] Both pages appear in ACCOUNTING menu for SuperUser

🤖 Generated with [Claude Code](https://claude.com/claude-code)