### PR TITLE
GL: fix period select not updating dates

### DIFF
--- a/public/javascripts/app-report-date.js
+++ b/public/javascripts/app-report-date.js
@@ -178,10 +178,13 @@ function updateInvoiceDateRange() {
 // ── GL date range helpers ────────────────────────────────────────────────────
 // Used by GL report pages — pre-fills from/to date inputs without hiding them.
 
-function glSetPeriod(fromId, toId, selectId) {
-    const sel = selectId || 'glPeriod';
-    const period = document.getElementById(sel) ? document.getElementById(sel).value : 'custom';
-    const today = new Date();
+// glSetPeriod(sel) — called via onchange="glSetPeriod(this)"
+// The select must have data-from and data-to attributes with the target input IDs.
+function glSetPeriod(sel) {
+    const period = sel.value;
+    const fromId = sel.dataset.from;
+    const toId   = sel.dataset.to;
+    const today  = new Date();
     const yr = today.getFullYear();
     const mo = today.getMonth();
 
@@ -208,18 +211,19 @@ function glSetPeriod(fromId, toId, selectId) {
             to   = new Date(yr, 2, 31);
         }
     } else {
-        return; // custom — user enters manually
+        return;
     }
 
     if (fromId) document.getElementById(fromId).value = iso(from);
     if (toId)   document.getElementById(toId).value   = iso(to);
 }
 
-// For single-date views (Trial Balance, Balance Sheet)
-function glSetAsOf(asOfId, selectId) {
-    const sel = selectId || 'glPeriodAsOf';
-    const period = document.getElementById(sel) ? document.getElementById(sel).value : 'custom';
-    const today = new Date();
+// glSetAsOf(sel) — for single-date views (Trial Balance, Balance Sheet)
+// The select must have a data-target attribute with the target input ID.
+function glSetAsOf(sel) {
+    const period = sel.value;
+    const asOfId = sel.dataset.target;
+    const today  = new Date();
     const yr = today.getFullYear();
     const mo = today.getMonth();
 

--- a/views/gl-balance-sheet.pug
+++ b/views/gl-balance-sheet.pug
@@ -11,7 +11,7 @@ block content
         form.row.align-items-end.mb-3(method="GET" action="/gl/balance-sheet")
             .col-auto
                 label.small.mb-1 Quick Select
-                select.form-control.form-control-sm#glPeriodAsOf(onchange="glSetAsOf('glAsOf')")
+                select.form-control.form-control-sm#glPeriodAsOf(onchange="glSetAsOf(this)" data-target="glAsOf")
                     option(value="today") Today
                     option(value="end_last_month") End of Last Month
                     option(value="end_this_fy") End of This FY

--- a/views/gl-control.pug
+++ b/views/gl-control.pug
@@ -24,7 +24,7 @@ block content
                 form.row.align-items-end.mb-3#eventsFilterForm
                     .col-auto
                         label.small.mb-1 Period
-                        select.form-control.form-control-sm(onchange="glSetPeriod('evFrom','evTo',this.id)" id="evPeriod")
+                        select.form-control.form-control-sm#evPeriod(onchange="glSetPeriod(this)" data-from="evFrom" data-to="evTo")
                             option(value="this_month") This Month
                             option(value="last_month") Last Month
                             option(value="this_fy") This Financial Year
@@ -92,7 +92,7 @@ block content
                 .row.align-items-end.mb-3
                     .col-auto
                         label.small.mb-1 Period
-                        select.form-control.form-control-sm(onchange="glSetPeriod('caFrom','caTo',this.id)" id="caPeriod")
+                        select.form-control.form-control-sm#caPeriod(onchange="glSetPeriod(this)" data-from="caFrom" data-to="caTo")
                             option(value="this_month") This Month
                             option(value="last_month") Last Month
                             option(value="this_fy") This Financial Year
@@ -125,7 +125,7 @@ block content
                 .row.align-items-end.mb-3
                     .col-auto
                         label.small.mb-1 Period
-                        select.form-control.form-control-sm(onchange="glSetPeriod('geFrom','geTo',this.id)" id="gePeriod")
+                        select.form-control.form-control-sm#gePeriod(onchange="glSetPeriod(this)" data-from="geFrom" data-to="geTo")
                             option(value="this_month") This Month
                             option(value="last_month") Last Month
                             option(value="this_fy") This Financial Year

--- a/views/gl-day-book.pug
+++ b/views/gl-day-book.pug
@@ -11,7 +11,7 @@ block content
         form.row.align-items-end.mb-3(method="GET" action="/gl/day-book")
             .col-auto
                 label.small.mb-1 Period
-                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod('glFrom','glTo')")
+                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod(this)" data-from="glFrom" data-to="glTo")
                     option(value="this_month") This Month
                     option(value="last_month") Last Month
                     option(value="this_fy") This Financial Year

--- a/views/gl-journal-list.pug
+++ b/views/gl-journal-list.pug
@@ -13,7 +13,7 @@ block content
         form.row.align-items-end.mb-3(method="GET" action="/gl/journal")
             .col-auto
                 label.small.mb-1 Period
-                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod('glFrom','glTo')")
+                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod(this)" data-from="glFrom" data-to="glTo")
                     option(value="this_month") This Month
                     option(value="last_month") Last Month
                     option(value="this_fy") This Financial Year

--- a/views/gl-ledger-report.pug
+++ b/views/gl-ledger-report.pug
@@ -18,7 +18,7 @@ block content
                         option(value="") — Search ledger —
             .col-auto
                 label.small.mb-1 Period
-                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod('glFrom','glTo')")
+                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod(this)" data-from="glFrom" data-to="glTo")
                     option(value="this_month") This Month
                     option(value="last_month") Last Month
                     option(value="this_fy") This Financial Year

--- a/views/gl-profit-loss.pug
+++ b/views/gl-profit-loss.pug
@@ -11,7 +11,7 @@ block content
         form.row.align-items-end.mb-3(method="GET" action="/gl/profit-loss")
             .col-auto
                 label.small.mb-1 Period
-                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod('glFrom','glTo')")
+                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod(this)" data-from="glFrom" data-to="glTo")
                     option(value="this_month") This Month
                     option(value="last_month") Last Month
                     option(value="this_fy") This Financial Year

--- a/views/gl-trial-balance.pug
+++ b/views/gl-trial-balance.pug
@@ -11,7 +11,7 @@ block content
         form.row.align-items-end.mb-3(method="GET" action="/gl/trial-balance")
             .col-auto
                 label.small.mb-1 Quick Select
-                select.form-control.form-control-sm#glPeriodAsOf(onchange="glSetAsOf('glAsOf')")
+                select.form-control.form-control-sm#glPeriodAsOf(onchange="glSetAsOf(this)" data-target="glAsOf")
                     option(value="today") Today
                     option(value="end_last_month") End of Last Month
                     option(value="end_this_fy") End of This FY


### PR DESCRIPTION
## Fix
Period select dropdown was not updating the from/to date inputs due to a Pug attribute rendering issue — single-quote string arguments inside double-quoted `onchange` attributes get HTML-escaped (`&#39;`), breaking the JS function call.

**Solution:** Changed from `glSetPeriod('glFrom','glTo')` to `glSetPeriod(this)` using `data-from` and `data-to` HTML attributes on the select element. Same fix applied to `glSetAsOf(this)` with `data-target`.

All 7 GL filter forms updated (Day Book, Ledger Report, P&L, Journal List, Trial Balance, Balance Sheet, GL Control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)