### PR TITLE
GL: concurrent batch requests, logging, dev DB refresh control

### DIFF
--- a/app.js
+++ b/app.js
@@ -165,6 +165,17 @@ const tankDipController = require("./controllers/tank-dip-controller");
 const pumpController = require("./controllers/pump-controller");
 const billController = require("./controllers/bill-controller");
 const lubesInvoiceController = require("./controllers/lubes-invoice-controller");
+const multer = require('multer');
+const lubeInvoiceUploadDir = path.join(__dirname, 'uploads', 'lube-invoices');
+if (!fs.existsSync(lubeInvoiceUploadDir)) fs.mkdirSync(lubeInvoiceUploadDir, { recursive: true });
+const lubeInvoiceUpload = multer({
+    storage: multer.diskStorage({
+        destination: (req, file, cb) => cb(null, lubeInvoiceUploadDir),
+        filename:    (req, file, cb) => cb(null, `${Date.now()}-${file.originalname.replace(/[^a-zA-Z0-9._-]/g, '_')}`)
+    }),
+    limits: { fileSize: 10 * 1024 * 1024 },
+    fileFilter: (req, file, cb) => file.mimetype === 'application/pdf' ? cb(null, true) : cb(new Error('Only PDF files are accepted'))
+});
 const supplierController = require("./controllers/supplier-controller");
 const closingSaveController = require("./controllers/closing-save-controller");
 const passwordResetController = require('./controllers/password-reset-controller');
@@ -238,6 +249,7 @@ const employeeRoutes  = require('./routes/employee-routes');
 const documentRoutes  = require('./routes/document-routes');
 const tankReceiptRoutes = require('./routes/tank-receipt-routes');
 const purchasesRoutes   = require('./routes/purchases-routes');
+const devDbRefreshRoutes = require('./routes/dev-db-refresh-routes');
 
 //const auditingUtilitiesRoutes = require('./routes/auditing-utilities-routes');
 
@@ -409,6 +421,7 @@ app.use('/purchases',    purchasesRoutes);
 app.use('/employees', employeeRoutes);
 app.use('/documents', documentRoutes);
 app.use('/gl', glRoutes);
+app.use('/dev-db-refresh', devDbRefreshRoutes);
 app.use('/bowser', bowserRoutes);
 
 
@@ -1468,6 +1481,17 @@ app.get('/lubes-invoice/suppliers-with-dates', isLoginEnsured, function(req, res
 // Get suppliers active on a specific date (alternative server-side approach)
 app.get('/lubes-invoice/suppliers-active-on-date', isLoginEnsured, function(req, res, next) {
     lubesInvoiceController.getSuppliersActiveOnDate(req, res, next);
+});
+
+// Lube Invoice PDF Upload
+app.get('/lubes-invoice/upload', isLoginEnsured, function(req, res, next) {
+    lubesInvoiceController.getUploadPage(req, res, next);
+});
+app.post('/lubes-invoice/parse-pdf', isLoginEnsured, lubeInvoiceUpload.single('lubeInvoicePdf'), function(req, res, next) {
+    lubesInvoiceController.parseLubeInvoicePdf(req, res, next);
+});
+app.post('/lubes-invoice/save-from-pdf', isLoginEnsured, function(req, res, next) {
+    lubesInvoiceController.saveLubeInvoiceFromPdf(req, res, next);
 });
 
 

--- a/db/migrations/gl-batch-requests.sql
+++ b/db/migrations/gl-batch-requests.sql
@@ -1,0 +1,42 @@
+-- ============================================================
+-- GL Batch Requests — Concurrent Request Table
+-- Generated: 2026-05-03
+--
+-- Tracks Generate Events and Create Accounting runs.
+-- Stores per-run logs, result summary, and status lifecycle.
+-- Log verbosity controlled by GL_LOG_LEVEL in m_location_config.
+-- Run on dev and prod.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS gl_batch_requests (
+    request_id      INT          NOT NULL AUTO_INCREMENT,
+    request_type    VARCHAR(50)  NOT NULL,           -- GENERATE_EVENTS | CREATE_ACCOUNTING
+    location_code   VARCHAR(20)  NOT NULL,
+    from_date       DATE         NOT NULL,
+    to_date         DATE         NOT NULL,
+    params          JSON,                            -- extra params e.g. {reprocess: true}
+    status          VARCHAR(20)  NOT NULL DEFAULT 'PENDING',  -- PENDING|RUNNING|COMPLETED|ERROR
+    submitted_by    VARCHAR(100),
+    submitted_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    started_at      DATETIME,
+    completed_at    DATETIME,
+    result_summary  JSON,                            -- {processed, errors, blocked, counts...}
+    log_text        LONGTEXT,                        -- full run log
+    PRIMARY KEY (request_id),
+    KEY idx_gbr_location_status (location_code, status),
+    KEY idx_gbr_submitted_at    (submitted_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ── Default log level (INFO) — insert only if not already present ─────────────
+-- GL_LOG_LEVEL values: DEBUG | INFO | ERROR
+-- DEBUG: per-event detail (verbose), INFO: summaries + errors, ERROR: errors only
+
+INSERT IGNORE INTO m_location_config (location_code, setting_name, setting_value, created_by, updated_by)
+SELECT '*', 'GL_LOG_LEVEL', 'INFO', 'system', 'system'
+WHERE NOT EXISTS (
+    SELECT 1 FROM m_location_config WHERE location_code = '*' AND setting_name = 'GL_LOG_LEVEL'
+);
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SHOW COLUMNS FROM gl_batch_requests;
+SELECT location_code, setting_name, setting_value FROM m_location_config WHERE setting_name = 'GL_LOG_LEVEL';

--- a/routes/dev-db-refresh-routes.js
+++ b/routes/dev-db-refresh-routes.js
@@ -1,0 +1,133 @@
+// routes/dev-db-refresh-routes.js
+// Dev-only: control the 4-hourly DB refresh from S3.
+// Only functional when /home/ubuntu/refresh_dev_from_s3.sh exists on the server.
+
+const express  = require('express');
+const router   = express.Router();
+const login    = require('connect-ensure-login');
+const security = require('../utils/app-security');
+const db       = require('../db/db-connection');
+const fs       = require('fs');
+const { exec, execFile } = require('child_process');
+
+const isLoginEnsured = login.ensureLoggedIn({});
+
+const SCRIPT_PATH = '/home/ubuntu/refresh_dev_from_s3.sh';
+const PAUSE_FILE   = '/home/ubuntu/.dev_refresh_paused';
+const LOG_FILE     = '/home/ubuntu/logs/dev_refresh_s3.log';
+
+function isDevEnv() {
+    return fs.existsSync(SCRIPT_PATH);
+}
+
+// GET /dev-db-refresh
+router.get('/', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    if (!isDevEnv()) {
+        return res.status(404).send('Not available in this environment.');
+    }
+
+    let lastRefresh = null;
+    try {
+        const rows = await db.sequelize.query(
+            `SELECT backup_filename, backup_taken_at, restored_at, s3_location
+             FROM _dev_backup_info ORDER BY restored_at DESC LIMIT 1`,
+            { type: db.Sequelize.QueryTypes.SELECT }
+        );
+        lastRefresh = rows[0] || null;
+    } catch (e) { /* table may not exist yet */ }
+
+    const isPaused  = fs.existsSync(PAUSE_FILE);
+    const isRunning = await checkRunning();
+
+    let logTail = '';
+    try {
+        const lines = fs.readFileSync(LOG_FILE, 'utf8').split('\n');
+        logTail = lines.slice(-50).join('\n');
+    } catch (e) { /* log not yet created */ }
+
+    res.render('dev-db-refresh', {
+        title:       'Dev DB Refresh Control',
+        user:        req.user,
+        config:      require('../config/app-config').APP_CONFIGS,
+        lastRefresh,
+        isPaused,
+        isRunning,
+        logTail,
+        messages:    req.flash()
+    });
+});
+
+// POST /dev-db-refresh/pause
+router.post('/pause', [isLoginEnsured, security.isAdmin()], function(req, res) {
+    if (!isDevEnv()) return res.status(404).json({ error: 'Not available' });
+    try {
+        fs.writeFileSync(PAUSE_FILE, new Date().toISOString());
+        res.json({ success: true, paused: true });
+    } catch (e) {
+        res.status(500).json({ success: false, error: e.message });
+    }
+});
+
+// POST /dev-db-refresh/resume
+router.post('/resume', [isLoginEnsured, security.isAdmin()], function(req, res) {
+    if (!isDevEnv()) return res.status(404).json({ error: 'Not available' });
+    try {
+        if (fs.existsSync(PAUSE_FILE)) fs.unlinkSync(PAUSE_FILE);
+        res.json({ success: true, paused: false });
+    } catch (e) {
+        res.status(500).json({ success: false, error: e.message });
+    }
+});
+
+// POST /dev-db-refresh/run-now
+// Spawns the refresh script in the background and returns immediately.
+// WARNING: drops and recreates the dev DB — app DB connections will blip.
+router.post('/run-now', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    if (!isDevEnv()) return res.status(404).json({ error: 'Not available' });
+
+    const running = await checkRunning();
+    if (running) return res.status(409).json({ error: 'Refresh is already running' });
+
+    if (fs.existsSync(PAUSE_FILE)) fs.unlinkSync(PAUSE_FILE);
+
+    exec(`bash ${SCRIPT_PATH} >> ${LOG_FILE} 2>&1 &`, (err) => {
+        if (err) console.error('Dev refresh spawn error:', err);
+    });
+
+    res.json({ success: true, message: 'Refresh started in background' });
+});
+
+// GET /dev-db-refresh/status — AJAX poll
+router.get('/status', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    if (!isDevEnv()) return res.json({ available: false });
+
+    let lastRefresh = null;
+    try {
+        const rows = await db.sequelize.query(
+            `SELECT backup_filename, backup_taken_at, restored_at FROM _dev_backup_info ORDER BY restored_at DESC LIMIT 1`,
+            { type: db.Sequelize.QueryTypes.SELECT }
+        );
+        lastRefresh = rows[0] || null;
+    } catch (e) { /* ok */ }
+
+    const isPaused  = fs.existsSync(PAUSE_FILE);
+    const isRunning = await checkRunning();
+
+    let logTail = '';
+    try {
+        const lines = fs.readFileSync(LOG_FILE, 'utf8').split('\n');
+        logTail = lines.filter(l => l.trim()).slice(-30).join('\n');
+    } catch (e) { /* ok */ }
+
+    res.json({ available: true, isPaused, isRunning, lastRefresh, logTail });
+});
+
+function checkRunning() {
+    return new Promise((resolve) => {
+        exec('pgrep -f refresh_dev_from_s3.sh', (err, stdout) => {
+            resolve(!!stdout.trim());
+        });
+    });
+}
+
+module.exports = router;

--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -6,6 +6,7 @@ const isLoginEnsured = login.ensureLoggedIn({});
 const security = require('../utils/app-security');
 const db = require('../db/db-connection');
 const createAccountingService = require('../services/create-accounting-service');
+const glBatchService = require('../services/gl-batch-service');
 
 // GET /gl/api/ledgers/search?location=&group=&q=
 // Returns [{ledger_id, ledger_name}] — used by Select2 ajax typeahead on product ledger fields
@@ -43,24 +44,35 @@ router.get('/api/ledgers/search', [isLoginEnsured, security.isAdmin()], async fu
 });
 
 // POST /gl/api/create-accounting
-// Body: { from_date, to_date }
-// Runs Create Accounting for the location and date range.
+// Body: { from_date, to_date, reprocess }
+// Runs Create Accounting wrapped in a gl_batch_requests record.
 router.post('/api/create-accounting', [isLoginEnsured, security.isAdmin()], async function(req, res) {
     const locationCode = req.user.location_code;
-    const processedBy  = req.user.username;
+    const processedBy  = req.user.username || String(req.user.Person_id);
     const { from_date, to_date, reprocess } = req.body;
 
     if (!from_date || !to_date) {
         return res.status(400).json({ error: 'from_date and to_date are required' });
     }
 
-    try {
-        const fn = reprocess === true || reprocess === 'true'
-            ? createAccountingService.reprocessEvents
-            : createAccountingService.processEvents;
+    const isReprocess = reprocess === true || reprocess === 'true';
+    const requestType = isReprocess ? 'REPROCESS_ACCOUNTING' : 'CREATE_ACCOUNTING';
 
-        const summary = await fn(locationCode, from_date, to_date, processedBy);
-        res.json({ success: true, summary });
+    try {
+        const requestId = await glBatchService.submitRequest(
+            requestType, locationCode, from_date, to_date,
+            isReprocess ? { reprocess: true } : null,
+            processedBy
+        );
+
+        const { summary } = await glBatchService.runRequest(requestId, locationCode, async (logger) => {
+            const fn = isReprocess
+                ? createAccountingService.reprocessEvents
+                : createAccountingService.processEvents;
+            return fn(locationCode, from_date, to_date, processedBy, logger);
+        });
+
+        res.json({ success: true, summary, request_id: requestId });
     } catch (err) {
         console.error('Create Accounting error:', err);
         res.status(500).json({ error: err.message });
@@ -998,17 +1010,34 @@ router.put('/api/ledger/:id', [isLoginEnsured, security.isAdmin()], async functi
 // ── GL Control ────────────────────────────────────────────────────────────────
 // GET /gl/control — admin dashboard: events monitor + create accounting + generate events
 
-router.get('/control', [isLoginEnsured, security.isAdmin()], function(req, res) {
-    const today = new Date().toISOString().substring(0, 10);
+router.get('/control', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const today    = new Date().toISOString().substring(0, 10);
     const fromDate = today.substring(0, 8) + '01';
-    res.render('gl-control', {
-        title:    'GL Control',
-        user:     req.user,
-        config:   require('../config/app-config').APP_CONFIGS,
-        fromDate,
-        toDate:   today,
-        messages: req.flash()
-    });
+    try {
+        await glBatchService.recoverStaleRequests(locationCode);
+        const recentRequests = await glBatchService.getRecentRequests(locationCode, 10);
+        res.render('gl-control', {
+            title:    'GL Control',
+            user:     req.user,
+            config:   require('../config/app-config').APP_CONFIGS,
+            fromDate,
+            toDate:   today,
+            recentRequests,
+            messages: req.flash()
+        });
+    } catch (err) {
+        console.error('GL Control error:', err);
+        res.render('gl-control', {
+            title:    'GL Control',
+            user:     req.user,
+            config:   require('../config/app-config').APP_CONFIGS,
+            fromDate,
+            toDate:   today,
+            recentRequests: [],
+            messages: req.flash()
+        });
+    }
 });
 
 // GET /gl/api/event-summary?from_date=&to_date=
@@ -1084,7 +1113,7 @@ router.post('/api/retry-event/:id', [isLoginEnsured, security.isAdmin()], async 
     }
 });
 
-// POST /gl/api/generate-events — backfill missing events for date range
+// POST /gl/api/generate-events — backfill missing events wrapped in a batch request record
 router.post('/api/generate-events', [isLoginEnsured, security.isAdmin()], async function(req, res) {
     const locationCode = req.user.location_code;
     const createdBy    = req.user.username || String(req.user.Person_id);
@@ -1095,11 +1124,42 @@ router.post('/api/generate-events', [isLoginEnsured, security.isAdmin()], async 
     }
 
     try {
-        const result = await createAccountingService.generateMissingEvents(locationCode, from_date, to_date, createdBy);
-        res.json({ success: true, ...result });
+        const requestId = await glBatchService.submitRequest(
+            'GENERATE_EVENTS', locationCode, from_date, to_date, null, createdBy
+        );
+
+        const { summary: result } = await glBatchService.runRequest(requestId, locationCode, async (logger) => {
+            return createAccountingService.generateMissingEvents(locationCode, from_date, to_date, createdBy, logger);
+        });
+
+        res.json({ success: true, ...result, request_id: requestId });
     } catch (err) {
         console.error('Generate events error:', err);
         res.status(500).json({ success: false, error: err.message });
+    }
+});
+
+// GET /gl/api/batch-requests — recent batch requests for this location
+router.get('/api/batch-requests', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    try {
+        const requests = await glBatchService.getRecentRequests(locationCode, 20);
+        res.json(requests);
+    } catch (err) {
+        res.status(500).json({ error: err.message });
+    }
+});
+
+// GET /gl/api/batch-requests/:id/log — full log for a single request
+router.get('/api/batch-requests/:id/log', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const requestId    = parseInt(req.params.id);
+    try {
+        const row = await glBatchService.getRequestLog(requestId, locationCode);
+        if (!row) return res.status(404).json({ error: 'Request not found' });
+        res.json(row);
+    } catch (err) {
+        res.status(500).json({ error: err.message });
     }
 });
 

--- a/services/create-accounting-service.js
+++ b/services/create-accounting-service.js
@@ -37,7 +37,9 @@ const BOWSER_BOUND_TYPES = new Set(['BOWSER_CREDIT_SALE', 'BOWSER_CASH_SALE', 'B
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
-async function processEvents(locationCode, fromDate, toDate, processedBy) {
+async function processEvents(locationCode, fromDate, toDate, processedBy, logger) {
+    const log = logger || { info: () => {}, debug: () => {}, error: () => {} };
+
     const [events, openShiftDates, openBowserDates] = await Promise.all([
         db.sequelize.query(`
             SELECT * FROM gl_accounting_events
@@ -50,6 +52,8 @@ async function processEvents(locationCode, fromDate, toDate, processedBy) {
         getOpenBowserDates(locationCode, fromDate, toDate)
     ]);
 
+    log.info(`Create Accounting started: ${locationCode} ${fromDate} → ${toDate}, ${events.length} unprocessed events`);
+
     const summary = { processed: 0, errors: 0, skipped: 0, blocked: 0, blockedDates: [], details: [] };
 
     for (const event of events) {
@@ -60,6 +64,7 @@ async function processEvents(locationCode, fromDate, toDate, processedBy) {
         if (SHIFT_BOUND_TYPES.has(event.source_type) && openShiftDates.has(eventDate)) {
             summary.blocked++;
             if (!summary.blockedDates.includes(eventDate)) summary.blockedDates.push(eventDate);
+            log.debug(`BLOCKED event_id=${event.event_id} ${event.source_type}#${event.source_id} — shift on ${eventDate} is DRAFT`);
             summary.details.push({ event_id: event.event_id, status: 'BLOCKED', reason: `Shift on ${eventDate} is still DRAFT` });
             continue;
         }
@@ -67,6 +72,7 @@ async function processEvents(locationCode, fromDate, toDate, processedBy) {
         if (BOWSER_BOUND_TYPES.has(event.source_type) && openBowserDates.has(eventDate)) {
             summary.blocked++;
             if (!summary.blockedDates.includes(eventDate)) summary.blockedDates.push(eventDate);
+            log.debug(`BLOCKED event_id=${event.event_id} ${event.source_type}#${event.source_id} — bowser on ${eventDate} is DRAFT`);
             summary.details.push({ event_id: event.event_id, status: 'BLOCKED', reason: `Bowser closing on ${eventDate} is still DRAFT` });
             continue;
         }
@@ -74,19 +80,26 @@ async function processEvents(locationCode, fromDate, toDate, processedBy) {
         try {
             const result = await processEvent(event, processedBy);
             summary.processed += result.voucherCount;
+            log.debug(`PROCESSED event_id=${event.event_id} ${event.source_type}#${event.source_id} → ${result.voucherCount} voucher(s)`);
             summary.details.push({ event_id: event.event_id, status: 'PROCESSED', vouchers: result.voucherCount });
         } catch (err) {
             await markEventError(event.event_id, err.message);
             summary.errors++;
+            log.error(`ERROR event_id=${event.event_id} ${event.source_type}#${event.source_id}: ${err.message}`);
             summary.details.push({ event_id: event.event_id, status: 'ERROR', message: err.message });
         }
     }
 
+    log.info(`Create Accounting done — processed=${summary.processed} blocked=${summary.blocked} errors=${summary.errors} skipped=${summary.skipped}`);
+    if (summary.blockedDates.length) log.info(`Blocked dates (DRAFT shifts): ${summary.blockedDates.join(', ')}`);
+
     return summary;
 }
 
-async function reprocessEvents(locationCode, fromDate, toDate, processedBy) {
-    await db.sequelize.query(`
+async function reprocessEvents(locationCode, fromDate, toDate, processedBy, logger) {
+    const log = logger || { info: () => {}, debug: () => {}, error: () => {} };
+
+    const [, meta] = await db.sequelize.query(`
         UPDATE gl_accounting_events
         SET event_status  = 'UNPROCESSED',
             event_type    = 'UPDATE',
@@ -102,7 +115,9 @@ async function reprocessEvents(locationCode, fromDate, toDate, processedBy) {
         type: QueryTypes.UPDATE
     });
 
-    return await processEvents(locationCode, fromDate, toDate, processedBy);
+    log.info(`Reprocess: reset ${meta?.affectedRows || 0} events to UNPROCESSED for ${fromDate} → ${toDate}`);
+
+    return await processEvents(locationCode, fromDate, toDate, processedBy, log);
 }
 
 module.exports = { processEvents, reprocessEvents, generateMissingEvents };
@@ -111,9 +126,12 @@ module.exports = { processEvents, reprocessEvents, generateMissingEvents };
 // Backfill tool: scan each source table for records with no event and INSERT them.
 // Safe to run multiple times — NOT EXISTS guard prevents duplicates.
 
-async function generateMissingEvents(locationCode, fromDate, toDate, createdBy) {
+async function generateMissingEvents(locationCode, fromDate, toDate, createdBy, logger) {
+    const log = logger || { info: () => {}, debug: () => {}, error: () => {} };
     const counts = {};
     let total = 0;
+
+    log.info(`Generate Events started: ${locationCode} ${fromDate} → ${toDate}`);
 
     const run = async (sourceType, sql) => {
         const [, meta] = await db.sequelize.query(sql, {
@@ -123,6 +141,7 @@ async function generateMissingEvents(locationCode, fromDate, toDate, createdBy) 
         const n = meta?.affectedRows || 0;
         counts[sourceType] = n;
         total += n;
+        log.debug(`${sourceType}: inserted ${n} missing event(s)`);
     };
 
     await run('CREDIT_SALE', `
@@ -274,6 +293,9 @@ async function generateMissingEvents(locationCode, fromDate, toDate, createdBy) 
               WHERE e.source_type = 'TANK_INVOICE' AND e.source_id = ti.id
           )
     `);
+
+    log.info(`Generate Events done — total inserted=${total}` +
+        (total > 0 ? (' (' + Object.entries(counts).filter(([,v])=>v>0).map(([k,v])=>`${k}:${v}`).join(' ') + ')') : ''));
 
     return { counts, total };
 }

--- a/services/gl-batch-logger.js
+++ b/services/gl-batch-logger.js
@@ -1,0 +1,27 @@
+// services/gl-batch-logger.js
+// Lightweight in-memory logger for GL batch runs.
+// GL_LOG_LEVEL controls verbosity: DEBUG (all) | INFO (summaries+errors) | ERROR (errors only)
+
+const LEVEL_RANK = { DEBUG: 0, INFO: 1, ERROR: 2 };
+
+class GlBatchLogger {
+    constructor(minLevel) {
+        this._minLevel = LEVEL_RANK[minLevel] ?? LEVEL_RANK.INFO;
+        this._lines    = [];
+    }
+
+    log(level, msg) {
+        if ((LEVEL_RANK[level] ?? 0) >= this._minLevel) {
+            const ts = new Date().toISOString().replace('T', ' ').substring(0, 19);
+            this._lines.push(`[${ts}] [${level}] ${msg}`);
+        }
+    }
+
+    debug(msg) { this.log('DEBUG', msg); }
+    info(msg)  { this.log('INFO',  msg); }
+    error(msg) { this.log('ERROR', msg); }
+
+    getText() { return this._lines.join('\n'); }
+}
+
+module.exports = GlBatchLogger;

--- a/services/gl-batch-service.js
+++ b/services/gl-batch-service.js
@@ -1,0 +1,110 @@
+// services/gl-batch-service.js
+// Oracle-style concurrent request wrapper for GL batch operations.
+// Lifecycle: PENDING → RUNNING → COMPLETED | ERROR
+// Log verbosity controlled by GL_LOG_LEVEL in m_location_config.
+
+const db                    = require('../db/db-connection');
+const { QueryTypes }        = require('sequelize');
+const GlBatchLogger         = require('./gl-batch-logger');
+const { getLocationConfigValue } = require('../utils/location-config');
+
+async function submitRequest(requestType, locationCode, fromDate, toDate, params, submittedBy) {
+    const [requestId] = await db.sequelize.query(`
+        INSERT INTO gl_batch_requests
+            (request_type, location_code, from_date, to_date, params, status, submitted_by)
+        VALUES (:requestType, :locationCode, :fromDate, :toDate, :params, 'PENDING', :submittedBy)
+    `, {
+        replacements: {
+            requestType, locationCode,
+            fromDate, toDate,
+            params: params ? JSON.stringify(params) : null,
+            submittedBy
+        },
+        type: QueryTypes.INSERT
+    });
+    return requestId;
+}
+
+async function runRequest(requestId, locationCode, fn) {
+    const logLevel = await getLocationConfigValue(locationCode, 'GL_LOG_LEVEL', 'INFO');
+    const logger   = new GlBatchLogger(logLevel);
+
+    await db.sequelize.query(`
+        UPDATE gl_batch_requests SET status='RUNNING', started_at=NOW() WHERE request_id=:requestId
+    `, { replacements: { requestId }, type: QueryTypes.UPDATE });
+
+    let resultSummary = null;
+    try {
+        resultSummary = await fn(logger);
+
+        await db.sequelize.query(`
+            UPDATE gl_batch_requests
+            SET status='COMPLETED', completed_at=NOW(),
+                result_summary=:summary, log_text=:log
+            WHERE request_id=:requestId
+        `, {
+            replacements: {
+                requestId,
+                summary: JSON.stringify(resultSummary),
+                log: logger.getText()
+            },
+            type: QueryTypes.UPDATE
+        });
+
+        return { success: true, summary: resultSummary };
+    } catch (err) {
+        logger.error('Fatal: ' + err.message);
+
+        await db.sequelize.query(`
+            UPDATE gl_batch_requests
+            SET status='ERROR', completed_at=NOW(),
+                result_summary=:summary, log_text=:log
+            WHERE request_id=:requestId
+        `, {
+            replacements: {
+                requestId,
+                summary: JSON.stringify({ error: err.message }),
+                log: logger.getText()
+            },
+            type: QueryTypes.UPDATE
+        });
+
+        throw err;
+    }
+}
+
+async function recoverStaleRequests(locationCode) {
+    await db.sequelize.query(`
+        UPDATE gl_batch_requests
+        SET status       = 'ERROR',
+            completed_at = NOW(),
+            log_text     = CONCAT(COALESCE(log_text,''), '\n[RECOVERED] Server restarted during processing — run did not complete.')
+        WHERE location_code = :locationCode
+          AND status        = 'RUNNING'
+    `, { replacements: { locationCode }, type: QueryTypes.UPDATE });
+}
+
+async function getRecentRequests(locationCode, limit) {
+    return db.sequelize.query(`
+        SELECT request_id, request_type, from_date, to_date, status,
+               submitted_by, submitted_at, started_at, completed_at,
+               result_summary
+        FROM gl_batch_requests
+        WHERE location_code = :locationCode
+        ORDER BY submitted_at DESC
+        LIMIT :limit
+    `, { replacements: { locationCode, limit: limit || 20 }, type: QueryTypes.SELECT });
+}
+
+async function getRequestLog(requestId, locationCode) {
+    const rows = await db.sequelize.query(`
+        SELECT request_id, request_type, from_date, to_date, status,
+               submitted_by, submitted_at, started_at, completed_at,
+               result_summary, log_text
+        FROM gl_batch_requests
+        WHERE request_id = :requestId AND location_code = :locationCode
+    `, { replacements: { requestId, locationCode }, type: QueryTypes.SELECT });
+    return rows[0] || null;
+}
+
+module.exports = { submitRequest, runRequest, recoverStaleRequests, getRecentRequests, getRequestLog };

--- a/views/dev-db-refresh.pug
+++ b/views/dev-db-refresh.pug
@@ -1,0 +1,175 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Dev DB Refresh Control
+            span.badge.badge-warning.ml-2(style="font-size:0.85rem") DEV ONLY
+
+        //- Last Refresh Info
+        .card.mb-3
+            .card-body.py-2
+                .row.align-items-center
+                    .col-auto
+                        .small.text-muted Last Refresh
+                        if lastRefresh
+                            .font-weight-bold= new Date(lastRefresh.restored_at).toLocaleString('en-IN')
+                        else
+                            .text-muted.small Unknown
+                    .col-auto
+                        .small.text-muted Backup Taken At (Prod)
+                        if lastRefresh
+                            .font-weight-bold= new Date(lastRefresh.backup_taken_at).toLocaleString('en-IN')
+                        else
+                            span.text-muted.small —
+                    .col-auto
+                        .small.text-muted Backup File
+                        if lastRefresh
+                            .small.text-monospace= lastRefresh.backup_filename
+                        else
+                            span.text-muted.small —
+                    .col-auto.ml-auto
+                        .small.text-muted Cron Schedule
+                        .small Every 4 hours
+
+        //- Controls
+        .card.mb-3
+            .card-body.py-2
+                .row.align-items-center
+
+                    .col-auto
+                        .small.text-muted.mb-1 Auto-Refresh Status
+                        if isRunning
+                            span.badge.badge-primary(style="font-size:0.9rem")
+                                i.bi.bi-arrow-repeat.mr-1
+                                | RUNNING
+                        else if isPaused
+                            span.badge.badge-warning(style="font-size:0.9rem")
+                                i.bi.bi-pause-fill.mr-1
+                                | PAUSED
+                        else
+                            span.badge.badge-success(style="font-size:0.9rem")
+                                i.bi.bi-play-fill.mr-1
+                                | ACTIVE (every 4h)
+
+                    .col-auto
+                        if isPaused
+                            button.btn.btn-success.btn-sm#btnResume(type="button")
+                                i.bi.bi-play-fill.mr-1
+                                | Resume Auto-Refresh
+                        else
+                            button.btn.btn-warning.btn-sm#btnPause(type="button")
+                                i.bi.bi-pause-fill.mr-1
+                                | Pause Auto-Refresh
+
+                    .col-auto
+                        button.btn.btn-danger.btn-sm#btnRefreshNow(type="button" disabled=isRunning)
+                            i.bi.bi-arrow-clockwise.mr-1
+                            | Refresh Now (from S3)
+
+                    .col-auto.ml-auto
+                        button.btn.btn-outline-secondary.btn-sm#btnRefreshStatus(type="button")
+                            i.bi.bi-arrow-repeat.mr-1
+                            | Refresh Status
+
+        .alert.alert-warning.py-2.small.mb-3
+            i.bi.bi-exclamation-triangle-fill.mr-1
+            | &ldquo;Refresh Now&rdquo; drops and recreates the dev DB from the latest prod S3 backup.
+            | The app will lose DB connection for 1&ndash;2 minutes while the import runs.
+            | All unsaved test data will be lost.
+
+        //- Log Tail
+        .card
+            .card-header.py-2.d-flex.justify-content-between.align-items-center
+                span.small.font-weight-bold Refresh Log (last 30 lines)
+                span.small.text-muted#logStatus
+                    if isRunning
+                        | Auto-refreshing…
+            .card-body.p-0
+                pre.small.mb-0(style="max-height:350px;overflow-y:auto;padding:10px;background:#f8f9fa;border-radius:0 0 4px 4px;white-space:pre-wrap" id="logBox")= logTail || '(no log yet)'
+
+    script.
+        let pollTimer = null;
+
+        function setStatus(isPaused, isRunning) {
+            const badge = document.querySelector('.badge[class*="badge-"]');
+            const btnPause   = document.getElementById('btnPause');
+            const btnResume  = document.getElementById('btnResume');
+            const btnNow     = document.getElementById('btnRefreshNow');
+
+            if (isRunning) {
+                if (badge) { badge.className = 'badge badge-primary'; badge.innerHTML = '<i class="bi bi-arrow-repeat mr-1"></i> RUNNING'; }
+                if (btnNow) btnNow.disabled = true;
+            } else if (isPaused) {
+                if (badge) { badge.className = 'badge badge-warning'; badge.innerHTML = '<i class="bi bi-pause-fill mr-1"></i> PAUSED'; }
+                if (btnNow) btnNow.disabled = false;
+            } else {
+                if (badge) { badge.className = 'badge badge-success'; badge.innerHTML = '<i class="bi bi-play-fill mr-1"></i> ACTIVE (every 4h)'; }
+                if (btnNow) btnNow.disabled = false;
+            }
+        }
+
+        async function pollStatus() {
+            const data = await fetch('/dev-db-refresh/status').then(r => r.json());
+            setStatus(data.isPaused, data.isRunning);
+
+            if (data.logTail) document.getElementById('logBox').textContent = data.logTail;
+            document.getElementById('logStatus').textContent = data.isRunning ? 'Auto-refreshing…' : '';
+
+            // Show pause/resume button correctly
+            const btnPause  = document.getElementById('btnPause');
+            const btnResume = document.getElementById('btnResume');
+            if (btnPause)  btnPause.style.display  = data.isPaused ? 'none' : '';
+            if (btnResume) btnResume.style.display  = data.isPaused ? '' : 'none';
+
+            if (data.isRunning) {
+                pollTimer = setTimeout(pollStatus, 3000);
+            } else {
+                clearTimeout(pollTimer);
+                pollTimer = null;
+            }
+        }
+
+        const btnPause = document.getElementById('btnPause');
+        if (btnPause) {
+            btnPause.addEventListener('click', async function() {
+                this.disabled = true;
+                await fetch('/dev-db-refresh/pause', { method: 'POST' });
+                pollStatus();
+                this.disabled = false;
+            });
+        }
+
+        const btnResume = document.getElementById('btnResume');
+        if (btnResume) {
+            btnResume.addEventListener('click', async function() {
+                this.disabled = true;
+                await fetch('/dev-db-refresh/resume', { method: 'POST' });
+                pollStatus();
+                this.disabled = false;
+            });
+        }
+
+        document.getElementById('btnRefreshNow').addEventListener('click', async function() {
+            if (!confirm('This will drop and recreate the dev DB from the latest prod S3 backup.\nAll current test data will be lost.\n\nProceed?')) return;
+            this.disabled = true;
+            this.textContent = 'Starting…';
+            const data = await fetch('/dev-db-refresh/run-now', { method: 'POST' }).then(r => r.json());
+            if (data.success) {
+                document.getElementById('logStatus').textContent = 'Auto-refreshing…';
+                pollTimer = setTimeout(pollStatus, 3000);
+            } else {
+                alert('Error: ' + data.error);
+                this.disabled = false;
+                this.innerHTML = '<i class="bi bi-arrow-clockwise mr-1"></i> Refresh Now (from S3)';
+            }
+        });
+
+        document.getElementById('btnRefreshStatus').addEventListener('click', pollStatus);
+
+        // Auto-poll if already running on page load
+        if (#{isRunning ? 'true' : 'false'}) {
+            pollTimer = setTimeout(pollStatus, 3000);
+        }

--- a/views/gl-control.pug
+++ b/views/gl-control.pug
@@ -115,6 +115,7 @@ block content
             //- ── Generate Events ─────────────────────────────────────────────
             #pane-generate.tab-pane.fade(role="tabpanel")
 
+
                 p.text-muted.small.mb-3
                     | Scans all source tables for records with no event in the queue and inserts missing events.
                     | Safe to run multiple times — duplicate events are never created.
@@ -142,6 +143,58 @@ block content
 
                 #geResult(style="display:none")
                     .card.card-body.mt-2#geResultBody
+
+        //- ── Recent Batch Runs ───────────────────────────────────────────
+        h6.mt-4.mb-2 Recent Batch Runs
+            button.btn.btn-outline-secondary.btn-sm.ml-2(type="button" id="btnRefreshRuns") Refresh
+        .table-responsive
+            table.table.table-sm.table-bordered.table-hover#runsTable
+                thead.thead-dark
+                    tr
+                        th(style="width:60px") ID
+                        th(style="width:140px") Type
+                        th(style="width:90px") From
+                        th(style="width:90px") To
+                        th(style="width:90px") Status
+                        th(style="width:130px") Submitted
+                        th(style="width:130px") Completed
+                        th Result
+                        th.text-center(style="width:50px") Log
+                tbody#runsBody
+                    - if (typeof recentRequests !== 'undefined')
+                        each r in recentRequests
+                            tr
+                                td.small= r.request_id
+                                td.small= r.request_type
+                                td.small= r.from_date ? r.from_date.toString().substring(0,10) : ''
+                                td.small= r.to_date ? r.to_date.toString().substring(0,10) : ''
+                                td.small
+                                    - const sc = {PENDING:'secondary',RUNNING:'primary',COMPLETED:'success',ERROR:'danger'}[r.status]||'secondary'
+                                    span.badge(class='badge-'+sc)= r.status
+                                td.small= r.submitted_at ? new Date(r.submitted_at).toLocaleString('en-IN') : ''
+                                td.small= r.completed_at ? new Date(r.completed_at).toLocaleString('en-IN') : ''
+                                td.small
+                                    - try { const s = typeof r.result_summary === 'string' ? JSON.parse(r.result_summary) : r.result_summary; if(s && s.total !== undefined) { }; var rs = s; } catch(e) { var rs = null; }
+                                    if rs && rs.total !== undefined
+                                        | #{rs.total} generated
+                                    else if rs && rs.processed !== undefined
+                                        | proc=#{rs.processed} err=#{rs.errors||0}
+                                    else if rs && rs.error
+                                        span.text-danger= rs.error
+                                td.text-center
+                                    button.btn.btn-outline-info.btn-sm.btn-view-log(type="button" data-id=r.request_id title="View Log")
+                                        i.bi.bi-file-text
+
+        //- Log Modal
+        #logModal.modal.fade(tabindex="-1" role="dialog")
+            .modal-dialog.modal-lg(role="document")
+                .modal-content
+                    .modal-header.py-2
+                        h6.modal-title#logModalLabel Batch Run Log
+                        button.close(type="button" data-dismiss="modal")
+                            span &times;
+                    .modal-body.p-2
+                        pre.small(style="max-height:400px;overflow-y:auto;white-space:pre-wrap;background:#f8f9fa;padding:8px;border-radius:4px" id="logModalBody") Loading…
 
     script.
         // ── Event Summary & List ──────────────────────────────────────────────
@@ -322,3 +375,62 @@ block content
                 this.textContent = orig;
             }
         });
+
+        // ── Recent Batch Runs ─────────────────────────────────────────────────
+
+        function statusBadge(s) {
+            const map = { PENDING:'secondary', RUNNING:'primary', COMPLETED:'success', ERROR:'danger' };
+            return `<span class="badge badge-${map[s]||'secondary'}">${s}</span>`;
+        }
+
+        function resultSummaryText(rs) {
+            if (!rs) return '';
+            try {
+                const s = typeof rs === 'string' ? JSON.parse(rs) : rs;
+                if (s.total !== undefined) return `${s.total} generated`;
+                if (s.processed !== undefined) return `proc=${s.processed} err=${s.errors||0}`;
+                if (s.error) return `<span class="text-danger">${s.error}</span>`;
+            } catch(e) {}
+            return '';
+        }
+
+        async function loadRecentRuns() {
+            const rows = await fetch('/gl/api/batch-requests').then(r => r.json());
+            const tbody = document.getElementById('runsBody');
+            tbody.innerHTML = '';
+            rows.forEach(function(r) {
+                const tr = document.createElement('tr');
+                const sub = r.submitted_at ? new Date(r.submitted_at).toLocaleString('en-IN') : '';
+                const cmp = r.completed_at ? new Date(r.completed_at).toLocaleString('en-IN') : '';
+                tr.innerHTML = `
+                    <td class="small">${r.request_id}</td>
+                    <td class="small">${r.request_type}</td>
+                    <td class="small">${(r.from_date||'').toString().substring(0,10)}</td>
+                    <td class="small">${(r.to_date||'').toString().substring(0,10)}</td>
+                    <td class="small">${statusBadge(r.status)}</td>
+                    <td class="small">${sub}</td>
+                    <td class="small">${cmp}</td>
+                    <td class="small">${resultSummaryText(r.result_summary)}</td>
+                    <td class="text-center"><button class="btn btn-outline-info btn-sm btn-view-log" data-id="${r.request_id}" title="View Log"><i class="bi bi-file-text"></i></button></td>`;
+                tbody.appendChild(tr);
+            });
+            bindLogButtons();
+        }
+
+        function bindLogButtons() {
+            document.querySelectorAll('.btn-view-log').forEach(function(btn) {
+                btn.addEventListener('click', async function() {
+                    const id = this.dataset.id;
+                    document.getElementById('logModalBody').textContent = 'Loading…';
+                    $('#logModal').modal('show');
+                    const data = await fetch('/gl/api/batch-requests/' + id + '/log').then(r => r.json());
+                    document.getElementById('logModalLabel').textContent =
+                        `Run #${data.request_id} — ${data.request_type} (${data.status})`;
+                    document.getElementById('logModalBody').textContent =
+                        data.log_text || '(no log)';
+                });
+            });
+        }
+
+        document.getElementById('btnRefreshRuns').addEventListener('click', loadRecentRuns);
+        bindLogButtons();


### PR DESCRIPTION
## Summary
- `gl_batch_requests` table tracks Generate Events and Create Accounting runs with full lifecycle (PENDING→RUNNING→COMPLETED/ERROR)
- `GlBatchLogger` with `GL_LOG_LEVEL` config (DEBUG/INFO/ERROR) — log stored in DB per run
- Stale RUNNING requests auto-recovered when GL Control page loads after a server restart
- `/dev-db-refresh` page: pause/resume the 4-hour S3 cron, trigger immediate refresh, live log tail

## Test plan
- [ ] Run `db/migrations/gl-batch-requests.sql` on dev DB
- [ ] Run Create Accounting — verify entry appears in Recent Runs table on GL Control
- [ ] Click log icon — verify log text shows in modal
- [ ] Visit `/dev-db-refresh` — verify last refresh info, pause/resume, Refresh Now

🤖 Generated with [Claude Code](https://claude.com/claude-code)