### PR TITLE
GL accounting engine: batch tracking, events monitor, dev DB refresh, bulk retry

### DIFF
--- a/app.js
+++ b/app.js
@@ -165,6 +165,17 @@ const tankDipController = require("./controllers/tank-dip-controller");
 const pumpController = require("./controllers/pump-controller");
 const billController = require("./controllers/bill-controller");
 const lubesInvoiceController = require("./controllers/lubes-invoice-controller");
+const multer = require('multer');
+const lubeInvoiceUploadDir = path.join(__dirname, 'uploads', 'lube-invoices');
+if (!fs.existsSync(lubeInvoiceUploadDir)) fs.mkdirSync(lubeInvoiceUploadDir, { recursive: true });
+const lubeInvoiceUpload = multer({
+    storage: multer.diskStorage({
+        destination: (req, file, cb) => cb(null, lubeInvoiceUploadDir),
+        filename:    (req, file, cb) => cb(null, `${Date.now()}-${file.originalname.replace(/[^a-zA-Z0-9._-]/g, '_')}`)
+    }),
+    limits: { fileSize: 10 * 1024 * 1024 },
+    fileFilter: (req, file, cb) => file.mimetype === 'application/pdf' ? cb(null, true) : cb(new Error('Only PDF files are accepted'))
+});
 const supplierController = require("./controllers/supplier-controller");
 const closingSaveController = require("./controllers/closing-save-controller");
 const passwordResetController = require('./controllers/password-reset-controller');
@@ -238,6 +249,7 @@ const employeeRoutes  = require('./routes/employee-routes');
 const documentRoutes  = require('./routes/document-routes');
 const tankReceiptRoutes = require('./routes/tank-receipt-routes');
 const purchasesRoutes   = require('./routes/purchases-routes');
+const devDbRefreshRoutes = require('./routes/dev-db-refresh-routes');
 
 //const auditingUtilitiesRoutes = require('./routes/auditing-utilities-routes');
 
@@ -409,6 +421,7 @@ app.use('/purchases',    purchasesRoutes);
 app.use('/employees', employeeRoutes);
 app.use('/documents', documentRoutes);
 app.use('/gl', glRoutes);
+app.use('/dev-db-refresh', devDbRefreshRoutes);
 app.use('/bowser', bowserRoutes);
 
 
@@ -1468,6 +1481,17 @@ app.get('/lubes-invoice/suppliers-with-dates', isLoginEnsured, function(req, res
 // Get suppliers active on a specific date (alternative server-side approach)
 app.get('/lubes-invoice/suppliers-active-on-date', isLoginEnsured, function(req, res, next) {
     lubesInvoiceController.getSuppliersActiveOnDate(req, res, next);
+});
+
+// Lube Invoice PDF Upload
+app.get('/lubes-invoice/upload', isLoginEnsured, function(req, res, next) {
+    lubesInvoiceController.getUploadPage(req, res, next);
+});
+app.post('/lubes-invoice/parse-pdf', isLoginEnsured, lubeInvoiceUpload.single('lubeInvoicePdf'), function(req, res, next) {
+    lubesInvoiceController.parseLubeInvoicePdf(req, res, next);
+});
+app.post('/lubes-invoice/save-from-pdf', isLoginEnsured, function(req, res, next) {
+    lubesInvoiceController.saveLubeInvoiceFromPdf(req, res, next);
 });
 
 

--- a/dao/product-dao.js
+++ b/dao/product-dao.js
@@ -60,12 +60,13 @@ module.exports = {
         
         const baseQuery = {
             attributes: [
-                'product_id', 
-                'product_name', 
-                'qty', 
-                'unit', 
+                'product_id',
+                'product_name',
+                'qty',
+                'unit',
                 'price',
                 'ledger_name',
+                'purchase_ledger_name',
                 'cgst_percent',
                 'sgst_percent',
                 'sku_name',
@@ -202,6 +203,7 @@ findPumpProducts: async (locationCode) => {
             price: product.price,
             unit: product.unit,
             ledger_name: product.ledger_name,
+            purchase_ledger_name: product.purchase_ledger_name,
             cgst_percent: product.cgst_percent,
             sgst_percent: product.sgst_percent,
             updated_by: product.updated_by,

--- a/dao/product-ledger-map-dao.js
+++ b/dao/product-ledger-map-dao.js
@@ -1,29 +1,35 @@
 const db = require('../db/db-connection');
 const { QueryTypes } = require('sequelize');
 
-const VALID_MAP_TYPES = ['SALES', 'PURCHASE', 'OUTPUT_CGST', 'OUTPUT_SGST'];
+// All map types the accounting engine supports — add new types here only
+const VALID_MAP_TYPES = ['SALES', 'PURCHASE', 'OUTPUT_CGST', 'OUTPUT_SGST', 'INPUT_CGST', 'INPUT_SGST'];
 
 module.exports = {
 
-    getAllMappings: async (locationCode) => {
+    // Returns one row per product with all current mapping ledger IDs
+    getProducts: async (locationCode) => {
         return db.sequelize.query(`
             SELECT
                 p.product_id,
                 p.product_name,
                 p.cgst_percent,
                 p.sgst_percent,
-                p.is_lube_product,
-                MAX(CASE WHEN plm.map_type = 'SALES'       THEN plm.ledger_id END) AS sales_ledger_id,
-                MAX(CASE WHEN plm.map_type = 'PURCHASE'    THEN plm.ledger_id END) AS purchase_ledger_id,
-                MAX(CASE WHEN plm.map_type = 'OUTPUT_CGST' THEN plm.ledger_id END) AS output_cgst_ledger_id,
-                MAX(CASE WHEN plm.map_type = 'OUTPUT_SGST' THEN plm.ledger_id END) AS output_sgst_ledger_id
+                p.is_lube_product
             FROM m_product p
-            LEFT JOIN gl_product_ledger_map plm
-                   ON plm.product_id    = p.product_id
-                  AND plm.location_code = :locationCode
             WHERE p.location_code = :locationCode
-            GROUP BY p.product_id, p.product_name, p.cgst_percent, p.sgst_percent, p.is_lube_product
             ORDER BY p.is_lube_product DESC, p.product_name
+        `, {
+            replacements: { locationCode },
+            type: QueryTypes.SELECT
+        });
+    },
+
+    // Returns flat rows (product_id, map_type, ledger_id) — used to build the modal lookup
+    getAllMappingsRaw: async (locationCode) => {
+        return db.sequelize.query(`
+            SELECT product_id, map_type, ledger_id
+            FROM gl_product_ledger_map
+            WHERE location_code = :locationCode
         `, {
             replacements: { locationCode },
             type: QueryTypes.SELECT

--- a/dao/product-ledger-map-dao.js
+++ b/dao/product-ledger-map-dao.js
@@ -1,0 +1,66 @@
+const db = require('../db/db-connection');
+const { QueryTypes } = require('sequelize');
+
+const VALID_MAP_TYPES = ['SALES', 'PURCHASE', 'OUTPUT_CGST', 'OUTPUT_SGST'];
+
+module.exports = {
+
+    getAllMappings: async (locationCode) => {
+        return db.sequelize.query(`
+            SELECT
+                p.product_id,
+                p.product_name,
+                p.cgst_percent,
+                p.sgst_percent,
+                p.is_lube_product,
+                MAX(CASE WHEN plm.map_type = 'SALES'       THEN plm.ledger_id END) AS sales_ledger_id,
+                MAX(CASE WHEN plm.map_type = 'PURCHASE'    THEN plm.ledger_id END) AS purchase_ledger_id,
+                MAX(CASE WHEN plm.map_type = 'OUTPUT_CGST' THEN plm.ledger_id END) AS output_cgst_ledger_id,
+                MAX(CASE WHEN plm.map_type = 'OUTPUT_SGST' THEN plm.ledger_id END) AS output_sgst_ledger_id
+            FROM m_product p
+            LEFT JOIN gl_product_ledger_map plm
+                   ON plm.product_id    = p.product_id
+                  AND plm.location_code = :locationCode
+            WHERE p.location_code = :locationCode
+            GROUP BY p.product_id, p.product_name, p.cgst_percent, p.sgst_percent, p.is_lube_product
+            ORDER BY p.is_lube_product DESC, p.product_name
+        `, {
+            replacements: { locationCode },
+            type: QueryTypes.SELECT
+        });
+    },
+
+    upsertMapping: async (locationCode, productId, mapType, ledgerId, updatedBy) => {
+        if (!VALID_MAP_TYPES.includes(mapType)) {
+            throw new Error(`Invalid map_type: ${mapType}`);
+        }
+        await db.sequelize.query(`
+            INSERT INTO gl_product_ledger_map
+                (location_code, product_id, map_type, ledger_id, created_by, updated_by)
+            VALUES
+                (:locationCode, :productId, :mapType, :ledgerId, :updatedBy, :updatedBy)
+            ON DUPLICATE KEY UPDATE
+                ledger_id  = :ledgerId,
+                updated_by = :updatedBy
+        `, {
+            replacements: { locationCode, productId, mapType, ledgerId, updatedBy },
+            type: QueryTypes.INSERT
+        });
+    },
+
+    deleteMapping: async (locationCode, productId, mapType) => {
+        if (!VALID_MAP_TYPES.includes(mapType)) {
+            throw new Error(`Invalid map_type: ${mapType}`);
+        }
+        await db.sequelize.query(`
+            DELETE FROM gl_product_ledger_map
+            WHERE location_code = :locationCode
+              AND product_id    = :productId
+              AND map_type      = :mapType
+        `, {
+            replacements: { locationCode, productId, mapType },
+            type: QueryTypes.DELETE
+        });
+    }
+
+};

--- a/dao/product-ledger-map-dao.js
+++ b/dao/product-ledger-map-dao.js
@@ -1,9 +1,6 @@
 const db = require('../db/db-connection');
 const { QueryTypes } = require('sequelize');
 
-// All map types the accounting engine supports — add new types here only
-const VALID_MAP_TYPES = ['SALES', 'PURCHASE', 'OUTPUT_CGST', 'OUTPUT_SGST', 'INPUT_CGST', 'INPUT_SGST'];
-
 module.exports = {
 
     // Returns one row per product with all current mapping ledger IDs
@@ -24,6 +21,16 @@ module.exports = {
         });
     },
 
+    // Returns map type definitions from m_lookup — drives the UI modal rows
+    getMapTypes: async () => {
+        return db.sequelize.query(`
+            SELECT tag AS type, description AS label, attribute1 AS \`group\`
+            FROM m_lookup
+            WHERE lookup_type = 'ProductMapType'
+            ORDER BY lookup_id
+        `, { type: QueryTypes.SELECT });
+    },
+
     // Returns flat rows (product_id, map_type, ledger_id) — used to build the modal lookup
     getAllMappingsRaw: async (locationCode) => {
         return db.sequelize.query(`
@@ -37,9 +44,6 @@ module.exports = {
     },
 
     upsertMapping: async (locationCode, productId, mapType, ledgerId, updatedBy) => {
-        if (!VALID_MAP_TYPES.includes(mapType)) {
-            throw new Error(`Invalid map_type: ${mapType}`);
-        }
         await db.sequelize.query(`
             INSERT INTO gl_product_ledger_map
                 (location_code, product_id, map_type, ledger_id, created_by, updated_by)
@@ -55,9 +59,6 @@ module.exports = {
     },
 
     deleteMapping: async (locationCode, productId, mapType) => {
-        if (!VALID_MAP_TYPES.includes(mapType)) {
-            throw new Error(`Invalid map_type: ${mapType}`);
-        }
         await db.sequelize.query(`
             DELETE FROM gl_product_ledger_map
             WHERE location_code = :locationCode

--- a/db/migrations/gl-accounting-event-triggers.sql
+++ b/db/migrations/gl-accounting-event-triggers.sql
@@ -1,0 +1,335 @@
+-- ============================================================
+-- GL Accounting Event Triggers
+-- Generated: 2026-04-30
+--
+-- Raises gl_accounting_events rows automatically on writes to:
+--   t_credits    → CREDIT_SALE events  (source_id = tcredit_id)
+--   t_cashsales  → CASH_SALE events    (source_id = cashsales_id)
+--   t_day_bill   → DAY_BILL events     (source_id = day_bill_id)
+--
+-- UPDATE logic (shared by all three tables):
+--   • PROCESSED event exists  → INSERT new UPDATE event (engine will reverse + redo)
+--   • UNPROCESSED event exists → flip event_type to UPDATE in-place (picks up latest data when run)
+--   • No event exists         → INSERT CREATE event (edge case: accounting never run)
+--
+-- DELETE logic (credits / cashsales only — for shift reopen):
+--   • PROCESSED event exists  → INSERT DELETE event (engine reverses)
+--   • UNPROCESSED event exists → DELETE the pending event (never journalised, nothing to reverse)
+-- ============================================================
+
+DROP TRIGGER IF EXISTS trg_credit_sale_gl_insert;
+DROP TRIGGER IF EXISTS trg_credit_sale_gl_update;
+DROP TRIGGER IF EXISTS trg_credit_sale_gl_delete;
+DROP TRIGGER IF EXISTS trg_cash_sale_gl_insert;
+DROP TRIGGER IF EXISTS trg_cash_sale_gl_update;
+DROP TRIGGER IF EXISTS trg_cash_sale_gl_delete;
+DROP TRIGGER IF EXISTS trg_day_bill_gl_insert;
+DROP TRIGGER IF EXISTS trg_day_bill_gl_update;
+
+DELIMITER $$
+
+-- ── t_credits : INSERT ────────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_credit_sale_gl_insert
+AFTER INSERT ON t_credits
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+    DECLARE v_closing_date  DATE;
+    DECLARE v_fy_id         INT;
+
+    SELECT c.location_code, DATE(c.closing_date)
+    INTO   v_location_code, v_closing_date
+    FROM   t_closing c
+    WHERE  c.closing_id = NEW.closing_id;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = v_location_code
+      AND  v_closing_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        VALUES
+            (v_location_code, v_fy_id, 'CREDIT_SALE', NEW.tcredit_id, 'CREATE', v_closing_date, 'UNPROCESSED', 'TRIGGER');
+    END IF;
+END$$
+
+-- ── t_credits : UPDATE ────────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_credit_sale_gl_update
+AFTER UPDATE ON t_credits
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_closing_date    DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    SELECT c.location_code, DATE(c.closing_date)
+    INTO   v_location_code, v_closing_date
+    FROM   t_closing c
+    WHERE  c.closing_id = NEW.closing_id;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = v_location_code
+      AND  v_closing_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'CREDIT_SALE' AND source_id = NEW.tcredit_id AND event_status = 'PROCESSED';
+
+        SELECT COUNT(*) INTO v_pending_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'CREDIT_SALE' AND source_id = NEW.tcredit_id AND event_status = 'UNPROCESSED';
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'CREDIT_SALE', NEW.tcredit_id, 'UPDATE', v_closing_date, 'UNPROCESSED', 'TRIGGER');
+        ELSEIF v_pending_count > 0 THEN
+            UPDATE gl_accounting_events
+            SET    event_type = 'UPDATE'
+            WHERE  source_type = 'CREDIT_SALE' AND source_id = NEW.tcredit_id AND event_status = 'UNPROCESSED';
+        ELSE
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'CREDIT_SALE', NEW.tcredit_id, 'CREATE', v_closing_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_credits : DELETE ────────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_credit_sale_gl_delete
+AFTER DELETE ON t_credits
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_closing_date    DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT c.location_code, DATE(c.closing_date)
+    INTO   v_location_code, v_closing_date
+    FROM   t_closing c
+    WHERE  c.closing_id = OLD.closing_id;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = v_location_code
+      AND  v_closing_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'CREDIT_SALE' AND source_id = OLD.tcredit_id AND event_status = 'PROCESSED';
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'CREDIT_SALE', OLD.tcredit_id, 'DELETE', v_closing_date, 'UNPROCESSED', 'TRIGGER');
+        ELSE
+            DELETE FROM gl_accounting_events
+            WHERE  source_type = 'CREDIT_SALE' AND source_id = OLD.tcredit_id AND event_status = 'UNPROCESSED';
+        END IF;
+    END IF;
+END$$
+
+-- ── t_cashsales : INSERT ──────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_cash_sale_gl_insert
+AFTER INSERT ON t_cashsales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+    DECLARE v_closing_date  DATE;
+    DECLARE v_fy_id         INT;
+
+    SELECT c.location_code, DATE(c.closing_date)
+    INTO   v_location_code, v_closing_date
+    FROM   t_closing c
+    WHERE  c.closing_id = NEW.closing_id;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = v_location_code
+      AND  v_closing_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        VALUES
+            (v_location_code, v_fy_id, 'CASH_SALE', NEW.cashsales_id, 'CREATE', v_closing_date, 'UNPROCESSED', 'TRIGGER');
+    END IF;
+END$$
+
+-- ── t_cashsales : UPDATE ──────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_cash_sale_gl_update
+AFTER UPDATE ON t_cashsales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_closing_date    DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    SELECT c.location_code, DATE(c.closing_date)
+    INTO   v_location_code, v_closing_date
+    FROM   t_closing c
+    WHERE  c.closing_id = NEW.closing_id;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = v_location_code
+      AND  v_closing_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'CASH_SALE' AND source_id = NEW.cashsales_id AND event_status = 'PROCESSED';
+
+        SELECT COUNT(*) INTO v_pending_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'CASH_SALE' AND source_id = NEW.cashsales_id AND event_status = 'UNPROCESSED';
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'CASH_SALE', NEW.cashsales_id, 'UPDATE', v_closing_date, 'UNPROCESSED', 'TRIGGER');
+        ELSEIF v_pending_count > 0 THEN
+            UPDATE gl_accounting_events
+            SET    event_type = 'UPDATE'
+            WHERE  source_type = 'CASH_SALE' AND source_id = NEW.cashsales_id AND event_status = 'UNPROCESSED';
+        ELSE
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'CASH_SALE', NEW.cashsales_id, 'CREATE', v_closing_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_cashsales : DELETE ──────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_cash_sale_gl_delete
+AFTER DELETE ON t_cashsales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_closing_date    DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT c.location_code, DATE(c.closing_date)
+    INTO   v_location_code, v_closing_date
+    FROM   t_closing c
+    WHERE  c.closing_id = OLD.closing_id;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = v_location_code
+      AND  v_closing_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'CASH_SALE' AND source_id = OLD.cashsales_id AND event_status = 'PROCESSED';
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'CASH_SALE', OLD.cashsales_id, 'DELETE', v_closing_date, 'UNPROCESSED', 'TRIGGER');
+        ELSE
+            DELETE FROM gl_accounting_events
+            WHERE  source_type = 'CASH_SALE' AND source_id = OLD.cashsales_id AND event_status = 'UNPROCESSED';
+        END IF;
+    END IF;
+END$$
+
+-- ── t_day_bill : INSERT ───────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_day_bill_gl_insert
+AFTER INSERT ON t_day_bill
+FOR EACH ROW
+BEGIN
+    DECLARE v_fy_id INT;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = NEW.location_code
+      AND  NEW.bill_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        VALUES
+            (NEW.location_code, v_fy_id, 'DAY_BILL', NEW.day_bill_id, 'CREATE', NEW.bill_date, 'UNPROCESSED', 'TRIGGER');
+    END IF;
+END$$
+
+-- ── t_day_bill : UPDATE ───────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_day_bill_gl_update
+AFTER UPDATE ON t_day_bill
+FOR EACH ROW
+BEGIN
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = NEW.location_code
+      AND  NEW.bill_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'DAY_BILL' AND source_id = NEW.day_bill_id AND event_status = 'PROCESSED';
+
+        SELECT COUNT(*) INTO v_pending_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'DAY_BILL' AND source_id = NEW.day_bill_id AND event_status = 'UNPROCESSED';
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (NEW.location_code, v_fy_id, 'DAY_BILL', NEW.day_bill_id, 'UPDATE', NEW.bill_date, 'UNPROCESSED', 'TRIGGER');
+        ELSEIF v_pending_count > 0 THEN
+            UPDATE gl_accounting_events
+            SET    event_type = 'UPDATE'
+            WHERE  source_type = 'DAY_BILL' AND source_id = NEW.day_bill_id AND event_status = 'UNPROCESSED';
+        ELSE
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (NEW.location_code, v_fy_id, 'DAY_BILL', NEW.day_bill_id, 'CREATE', NEW.bill_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SHOW TRIGGERS WHERE `Table` IN ('t_credits', 't_cashsales', 't_day_bill');

--- a/db/migrations/gl-bank-txn-setup.sql
+++ b/db/migrations/gl-bank-txn-setup.sql
@@ -1,0 +1,264 @@
+-- ============================================================
+-- GL Bank Transaction Event Triggers
+-- Generated: 2026-04-30
+--
+-- Raises gl_accounting_events rows automatically on writes to:
+--   t_bank_transaction        → BANK_TXN events  (source_id = t_bank_id)
+--   t_bank_transaction_splits → BANK_TXN UPDATE event on parent t_bank_id
+--
+-- Prerequisites:
+--   • m_bank.supplier_id column already exists (added in a prior migration)
+--   • Populate m_bank.supplier_id for is_oil_company='Y' rows BEFORE triggering
+--     live accounting, otherwise oil-company transactions will throw ledger errors.
+--     See the "Link oil company banks" section below for per-location UPDATE pattern.
+--
+-- INSERT trigger:
+--   Always raises a CREATE event. If accounting_type is NULL (not yet classified)
+--   the service handler will skip it (mark PROCESSED, 0 vouchers).  When the user
+--   later classifies the transaction, the UPDATE trigger fires and raises an UPDATE
+--   event which the handler processes normally.
+--
+-- UPDATE trigger (t_bank_transaction):
+--   Only fires when classification-relevant columns change:
+--     accounting_type, external_source, external_id, ledger_name, is_split
+--   Uses NULL-safe <=> operator to detect real changes.
+--   Follows the same PROCESSED/UNPROCESSED/None logic as other GL triggers.
+--
+-- UPDATE/DELETE triggers (t_bank_transaction_splits):
+--   Raise an UPDATE event on the parent t_bank_id so the handler can
+--   re-read all splits and regenerate vouchers.
+-- ============================================================
+
+
+-- ── Link oil company banks to m_supplier ─────────────────────────────────────
+-- Run this per-location to link each oil-company bank to its matching supplier.
+-- Example — IOCL bank for location SFS:
+--
+--   UPDATE m_bank SET supplier_id = (
+--       SELECT supplier_id FROM m_supplier
+--       WHERE supplier_name LIKE '%INDIANOIL%' AND location_code = 'SFS'
+--       LIMIT 1
+--   ) WHERE bank_id = <iocl_bank_id_for_sfs>;
+--
+-- BPCL example:
+--   UPDATE m_bank SET supplier_id = (
+--       SELECT supplier_id FROM m_supplier
+--       WHERE supplier_name LIKE '%BPCL%' AND location_code = 'SFS'
+--       LIMIT 1
+--   ) WHERE is_oil_company = 'Y' AND bank_name LIKE '%BPCL%' AND location_code = 'SFS';
+--
+-- After linking, verify with:
+--   SELECT bank_id, bank_name, location_code, supplier_id
+--   FROM m_bank WHERE is_oil_company = 'Y';
+-- ─────────────────────────────────────────────────────────────────────────────
+
+
+DROP TRIGGER IF EXISTS trg_bank_txn_gl_insert;
+DROP TRIGGER IF EXISTS trg_bank_txn_gl_update;
+DROP TRIGGER IF EXISTS trg_bank_txn_split_gl_insert;
+DROP TRIGGER IF EXISTS trg_bank_txn_split_gl_delete;
+
+DELIMITER $$
+
+-- ── t_bank_transaction : INSERT ───────────────────────────────────────────────
+
+CREATE TRIGGER trg_bank_txn_gl_insert
+AFTER INSERT ON t_bank_transaction
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+    DECLARE v_fy_id         INT;
+
+    SELECT mb.location_code
+    INTO   v_location_code
+    FROM   m_bank mb
+    WHERE  mb.bank_id = NEW.bank_id;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT fy.fy_id INTO v_fy_id
+        FROM   gl_financial_years fy
+        WHERE  fy.location_code = v_location_code
+          AND  NEW.trans_date BETWEEN fy.start_date AND fy.end_date
+        LIMIT 1;
+
+        IF v_fy_id IS NOT NULL THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'BANK_TXN', NEW.t_bank_id, 'CREATE', NEW.trans_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bank_transaction : UPDATE ───────────────────────────────────────────────
+-- Only fires when classification-relevant columns change.
+
+CREATE TRIGGER trg_bank_txn_gl_update
+AFTER UPDATE ON t_bank_transaction
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+    DECLARE v_cols_changed    TINYINT DEFAULT 0;
+
+    -- Check if any classification column changed (NULL-safe comparison)
+    IF NOT (NEW.external_source <=> OLD.external_source)
+    OR NOT (NEW.external_id     <=> OLD.external_id)
+    OR NOT (NEW.ledger_name     <=> OLD.ledger_name)
+    OR NOT (NEW.is_split        <=> OLD.is_split)
+    THEN
+        SET v_cols_changed = 1;
+    END IF;
+
+    IF v_cols_changed = 1 THEN
+        SELECT mb.location_code
+        INTO   v_location_code
+        FROM   m_bank mb
+        WHERE  mb.bank_id = NEW.bank_id;
+
+        IF v_location_code IS NOT NULL THEN
+            SELECT fy.fy_id INTO v_fy_id
+            FROM   gl_financial_years fy
+            WHERE  fy.location_code = v_location_code
+              AND  NEW.trans_date BETWEEN fy.start_date AND fy.end_date
+            LIMIT 1;
+
+            IF v_fy_id IS NOT NULL THEN
+                SELECT COUNT(*) INTO v_processed_count
+                FROM   gl_accounting_events
+                WHERE  source_type = 'BANK_TXN' AND source_id = NEW.t_bank_id AND event_status = 'PROCESSED';
+
+                SELECT COUNT(*) INTO v_pending_count
+                FROM   gl_accounting_events
+                WHERE  source_type = 'BANK_TXN' AND source_id = NEW.t_bank_id AND event_status = 'UNPROCESSED';
+
+                IF v_processed_count > 0 THEN
+                    INSERT INTO gl_accounting_events
+                        (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                    VALUES
+                        (v_location_code, v_fy_id, 'BANK_TXN', NEW.t_bank_id, 'UPDATE', NEW.trans_date, 'UNPROCESSED', 'TRIGGER');
+                ELSEIF v_pending_count > 0 THEN
+                    UPDATE gl_accounting_events
+                    SET    event_type = 'UPDATE'
+                    WHERE  source_type = 'BANK_TXN' AND source_id = NEW.t_bank_id AND event_status = 'UNPROCESSED';
+                ELSE
+                    INSERT INTO gl_accounting_events
+                        (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                    VALUES
+                        (v_location_code, v_fy_id, 'BANK_TXN', NEW.t_bank_id, 'CREATE', NEW.trans_date, 'UNPROCESSED', 'TRIGGER');
+                END IF;
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bank_transaction_splits : INSERT ───────────────────────────────────────
+-- A new split row means the parent transaction's accounting changes → UPDATE event.
+
+CREATE TRIGGER trg_bank_txn_split_gl_insert
+AFTER INSERT ON t_bank_transaction_splits
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_trans_date      DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    SELECT mb.location_code, tbt.trans_date
+    INTO   v_location_code, v_trans_date
+    FROM   t_bank_transaction tbt
+    JOIN   m_bank mb ON mb.bank_id = tbt.bank_id
+    WHERE  tbt.t_bank_id = NEW.t_bank_id;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT fy.fy_id INTO v_fy_id
+        FROM   gl_financial_years fy
+        WHERE  fy.location_code = v_location_code
+          AND  v_trans_date BETWEEN fy.start_date AND fy.end_date
+        LIMIT 1;
+
+        IF v_fy_id IS NOT NULL THEN
+            SELECT COUNT(*) INTO v_processed_count
+            FROM   gl_accounting_events
+            WHERE  source_type = 'BANK_TXN' AND source_id = NEW.t_bank_id AND event_status = 'PROCESSED';
+
+            SELECT COUNT(*) INTO v_pending_count
+            FROM   gl_accounting_events
+            WHERE  source_type = 'BANK_TXN' AND source_id = NEW.t_bank_id AND event_status = 'UNPROCESSED';
+
+            IF v_processed_count > 0 THEN
+                INSERT INTO gl_accounting_events
+                    (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                VALUES
+                    (v_location_code, v_fy_id, 'BANK_TXN', NEW.t_bank_id, 'UPDATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+            ELSEIF v_pending_count > 0 THEN
+                UPDATE gl_accounting_events
+                SET    event_type = 'UPDATE'
+                WHERE  source_type = 'BANK_TXN' AND source_id = NEW.t_bank_id AND event_status = 'UNPROCESSED';
+            ELSE
+                INSERT INTO gl_accounting_events
+                    (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                VALUES
+                    (v_location_code, v_fy_id, 'BANK_TXN', NEW.t_bank_id, 'CREATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bank_transaction_splits : DELETE ───────────────────────────────────────
+-- Removing a split row also changes parent accounting → UPDATE event.
+
+CREATE TRIGGER trg_bank_txn_split_gl_delete
+AFTER DELETE ON t_bank_transaction_splits
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_trans_date      DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    SELECT mb.location_code, tbt.trans_date
+    INTO   v_location_code, v_trans_date
+    FROM   t_bank_transaction tbt
+    JOIN   m_bank mb ON mb.bank_id = tbt.bank_id
+    WHERE  tbt.t_bank_id = OLD.t_bank_id;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT fy.fy_id INTO v_fy_id
+        FROM   gl_financial_years fy
+        WHERE  fy.location_code = v_location_code
+          AND  v_trans_date BETWEEN fy.start_date AND fy.end_date
+        LIMIT 1;
+
+        IF v_fy_id IS NOT NULL THEN
+            SELECT COUNT(*) INTO v_processed_count
+            FROM   gl_accounting_events
+            WHERE  source_type = 'BANK_TXN' AND source_id = OLD.t_bank_id AND event_status = 'PROCESSED';
+
+            SELECT COUNT(*) INTO v_pending_count
+            FROM   gl_accounting_events
+            WHERE  source_type = 'BANK_TXN' AND source_id = OLD.t_bank_id AND event_status = 'UNPROCESSED';
+
+            IF v_processed_count > 0 THEN
+                INSERT INTO gl_accounting_events
+                    (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                VALUES
+                    (v_location_code, v_fy_id, 'BANK_TXN', OLD.t_bank_id, 'UPDATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+            ELSEIF v_pending_count > 0 THEN
+                UPDATE gl_accounting_events
+                SET    event_type = 'UPDATE'
+                WHERE  source_type = 'BANK_TXN' AND source_id = OLD.t_bank_id AND event_status = 'UNPROCESSED';
+            -- If no event exists for a split delete, nothing to do (nothing was ever journaled)
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SHOW TRIGGERS WHERE `Table` IN ('t_bank_transaction', 't_bank_transaction_splits');

--- a/db/migrations/gl-batch-requests.sql
+++ b/db/migrations/gl-batch-requests.sql
@@ -1,0 +1,42 @@
+-- ============================================================
+-- GL Batch Requests — Concurrent Request Table
+-- Generated: 2026-05-03
+--
+-- Tracks Generate Events and Create Accounting runs.
+-- Stores per-run logs, result summary, and status lifecycle.
+-- Log verbosity controlled by GL_LOG_LEVEL in m_location_config.
+-- Run on dev and prod.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS gl_batch_requests (
+    request_id      INT          NOT NULL AUTO_INCREMENT,
+    request_type    VARCHAR(50)  NOT NULL,           -- GENERATE_EVENTS | CREATE_ACCOUNTING
+    location_code   VARCHAR(20)  NOT NULL,
+    from_date       DATE         NOT NULL,
+    to_date         DATE         NOT NULL,
+    params          JSON,                            -- extra params e.g. {reprocess: true}
+    status          VARCHAR(20)  NOT NULL DEFAULT 'PENDING',  -- PENDING|RUNNING|COMPLETED|ERROR
+    submitted_by    VARCHAR(100),
+    submitted_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    started_at      DATETIME,
+    completed_at    DATETIME,
+    result_summary  JSON,                            -- {processed, errors, blocked, counts...}
+    log_text        LONGTEXT,                        -- full run log
+    PRIMARY KEY (request_id),
+    KEY idx_gbr_location_status (location_code, status),
+    KEY idx_gbr_submitted_at    (submitted_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ── Default log level (INFO) — insert only if not already present ─────────────
+-- GL_LOG_LEVEL values: DEBUG | INFO | ERROR
+-- DEBUG: per-event detail (verbose), INFO: summaries + errors, ERROR: errors only
+
+INSERT IGNORE INTO m_location_config (location_code, setting_name, setting_value, created_by, updated_by)
+SELECT '*', 'GL_LOG_LEVEL', 'INFO', 'system', 'system'
+WHERE NOT EXISTS (
+    SELECT 1 FROM m_location_config WHERE location_code = '*' AND setting_name = 'GL_LOG_LEVEL'
+);
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SHOW COLUMNS FROM gl_batch_requests;
+SELECT location_code, setting_name, setting_value FROM m_location_config WHERE setting_name = 'GL_LOG_LEVEL';

--- a/db/migrations/gl-bowser-triggers.sql
+++ b/db/migrations/gl-bowser-triggers.sql
@@ -1,0 +1,399 @@
+-- ============================================================
+-- GL Bowser Sale Event Triggers
+-- Generated: 2026-05-02
+--
+-- Raises gl_accounting_events rows automatically on writes to:
+--   t_bowser_credits       → BOWSER_CREDIT_SALE events  (source_id = credit_id)
+--   t_bowser_cashsales     → BOWSER_CASH_SALE events    (source_id = cashsale_id)
+--   t_bowser_digital_sales → BOWSER_DIGITAL_SALE events (source_id = digital_id)
+--
+-- Location / date resolved from t_bowser_closing (joined via bowser_closing_id).
+-- DELETE triggers read location/fy/date from existing gl_accounting_events rows.
+--
+-- Bowser closing gate: the accounting engine skips BOWSER_* events for dates
+-- where t_bowser_closing.status = 'DRAFT' — same pattern as shift closing gate.
+-- ============================================================
+
+DROP TRIGGER IF EXISTS trg_bowser_credit_gl_insert;
+DROP TRIGGER IF EXISTS trg_bowser_credit_gl_update;
+DROP TRIGGER IF EXISTS trg_bowser_credit_gl_delete;
+DROP TRIGGER IF EXISTS trg_bowser_cash_gl_insert;
+DROP TRIGGER IF EXISTS trg_bowser_cash_gl_update;
+DROP TRIGGER IF EXISTS trg_bowser_cash_gl_delete;
+DROP TRIGGER IF EXISTS trg_bowser_digital_gl_insert;
+DROP TRIGGER IF EXISTS trg_bowser_digital_gl_update;
+DROP TRIGGER IF EXISTS trg_bowser_digital_gl_delete;
+
+DELIMITER $$
+
+-- ── t_bowser_credits : INSERT ─────────────────────────────────────────────────
+
+CREATE TRIGGER trg_bowser_credit_gl_insert
+AFTER INSERT ON t_bowser_credits
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+    DECLARE v_trans_date    DATE;
+    DECLARE v_fy_id         INT;
+
+    SELECT tbc.location_code, tbc.closing_date
+    INTO   v_location_code, v_trans_date
+    FROM   t_bowser_closing tbc
+    WHERE  tbc.bowser_closing_id = NEW.bowser_closing_id;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT fy.fy_id INTO v_fy_id
+        FROM   gl_financial_years fy
+        WHERE  fy.location_code = v_location_code
+          AND  v_trans_date BETWEEN fy.start_date AND fy.end_date
+        LIMIT 1;
+
+        IF v_fy_id IS NOT NULL THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'BOWSER_CREDIT_SALE', NEW.credit_id, 'CREATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bowser_credits : UPDATE ─────────────────────────────────────────────────
+-- Fires when any financially relevant column changes.
+
+CREATE TRIGGER trg_bowser_credit_gl_update
+AFTER UPDATE ON t_bowser_credits
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_trans_date      DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    IF NOT (NEW.amount       <=> OLD.amount)
+    OR NOT (NEW.product_id   <=> OLD.product_id)
+    OR NOT (NEW.creditlist_id <=> OLD.creditlist_id)
+    OR NOT (NEW.quantity     <=> OLD.quantity)
+    OR NOT (NEW.rate         <=> OLD.rate)
+    THEN
+        SELECT tbc.location_code, tbc.closing_date
+        INTO   v_location_code, v_trans_date
+        FROM   t_bowser_closing tbc
+        WHERE  tbc.bowser_closing_id = NEW.bowser_closing_id;
+
+        IF v_location_code IS NOT NULL THEN
+            SELECT fy.fy_id INTO v_fy_id
+            FROM   gl_financial_years fy
+            WHERE  fy.location_code = v_location_code
+              AND  v_trans_date BETWEEN fy.start_date AND fy.end_date
+            LIMIT 1;
+
+            IF v_fy_id IS NOT NULL THEN
+                SELECT COUNT(*) INTO v_processed_count
+                FROM   gl_accounting_events
+                WHERE  source_type = 'BOWSER_CREDIT_SALE' AND source_id = NEW.credit_id AND event_status = 'PROCESSED';
+
+                SELECT COUNT(*) INTO v_pending_count
+                FROM   gl_accounting_events
+                WHERE  source_type = 'BOWSER_CREDIT_SALE' AND source_id = NEW.credit_id AND event_status = 'UNPROCESSED';
+
+                IF v_processed_count > 0 THEN
+                    INSERT INTO gl_accounting_events
+                        (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                    VALUES
+                        (v_location_code, v_fy_id, 'BOWSER_CREDIT_SALE', NEW.credit_id, 'UPDATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+                ELSEIF v_pending_count > 0 THEN
+                    UPDATE gl_accounting_events
+                    SET    event_type = 'UPDATE'
+                    WHERE  source_type = 'BOWSER_CREDIT_SALE' AND source_id = NEW.credit_id AND event_status = 'UNPROCESSED';
+                ELSE
+                    INSERT INTO gl_accounting_events
+                        (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                    VALUES
+                        (v_location_code, v_fy_id, 'BOWSER_CREDIT_SALE', NEW.credit_id, 'CREATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+                END IF;
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bowser_credits : DELETE ─────────────────────────────────────────────────
+
+CREATE TRIGGER trg_bowser_credit_gl_delete
+AFTER DELETE ON t_bowser_credits
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'BOWSER_CREDIT_SALE' AND source_id = OLD.credit_id
+    ORDER BY event_id DESC LIMIT 1;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'BOWSER_CREDIT_SALE' AND source_id = OLD.credit_id AND event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type = 'BOWSER_CREDIT_SALE' AND source_id = OLD.credit_id AND event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'BOWSER_CREDIT_SALE', OLD.credit_id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bowser_cashsales : INSERT ───────────────────────────────────────────────
+
+CREATE TRIGGER trg_bowser_cash_gl_insert
+AFTER INSERT ON t_bowser_cashsales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+    DECLARE v_trans_date    DATE;
+    DECLARE v_fy_id         INT;
+
+    SELECT tbc.location_code, tbc.closing_date
+    INTO   v_location_code, v_trans_date
+    FROM   t_bowser_closing tbc
+    WHERE  tbc.bowser_closing_id = NEW.bowser_closing_id;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT fy.fy_id INTO v_fy_id
+        FROM   gl_financial_years fy
+        WHERE  fy.location_code = v_location_code
+          AND  v_trans_date BETWEEN fy.start_date AND fy.end_date
+        LIMIT 1;
+
+        IF v_fy_id IS NOT NULL THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'BOWSER_CASH_SALE', NEW.cashsale_id, 'CREATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bowser_cashsales : UPDATE ───────────────────────────────────────────────
+
+CREATE TRIGGER trg_bowser_cash_gl_update
+AFTER UPDATE ON t_bowser_cashsales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_trans_date      DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    IF NOT (NEW.amount     <=> OLD.amount)
+    OR NOT (NEW.product_id <=> OLD.product_id)
+    THEN
+        SELECT tbc.location_code, tbc.closing_date
+        INTO   v_location_code, v_trans_date
+        FROM   t_bowser_closing tbc
+        WHERE  tbc.bowser_closing_id = NEW.bowser_closing_id;
+
+        IF v_location_code IS NOT NULL THEN
+            SELECT fy.fy_id INTO v_fy_id
+            FROM   gl_financial_years fy
+            WHERE  fy.location_code = v_location_code
+              AND  v_trans_date BETWEEN fy.start_date AND fy.end_date
+            LIMIT 1;
+
+            IF v_fy_id IS NOT NULL THEN
+                SELECT COUNT(*) INTO v_processed_count
+                FROM   gl_accounting_events
+                WHERE  source_type = 'BOWSER_CASH_SALE' AND source_id = NEW.cashsale_id AND event_status = 'PROCESSED';
+
+                SELECT COUNT(*) INTO v_pending_count
+                FROM   gl_accounting_events
+                WHERE  source_type = 'BOWSER_CASH_SALE' AND source_id = NEW.cashsale_id AND event_status = 'UNPROCESSED';
+
+                IF v_processed_count > 0 THEN
+                    INSERT INTO gl_accounting_events
+                        (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                    VALUES
+                        (v_location_code, v_fy_id, 'BOWSER_CASH_SALE', NEW.cashsale_id, 'UPDATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+                ELSEIF v_pending_count > 0 THEN
+                    UPDATE gl_accounting_events
+                    SET    event_type = 'UPDATE'
+                    WHERE  source_type = 'BOWSER_CASH_SALE' AND source_id = NEW.cashsale_id AND event_status = 'UNPROCESSED';
+                ELSE
+                    INSERT INTO gl_accounting_events
+                        (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                    VALUES
+                        (v_location_code, v_fy_id, 'BOWSER_CASH_SALE', NEW.cashsale_id, 'CREATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+                END IF;
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bowser_cashsales : DELETE ───────────────────────────────────────────────
+
+CREATE TRIGGER trg_bowser_cash_gl_delete
+AFTER DELETE ON t_bowser_cashsales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'BOWSER_CASH_SALE' AND source_id = OLD.cashsale_id
+    ORDER BY event_id DESC LIMIT 1;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'BOWSER_CASH_SALE' AND source_id = OLD.cashsale_id AND event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type = 'BOWSER_CASH_SALE' AND source_id = OLD.cashsale_id AND event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'BOWSER_CASH_SALE', OLD.cashsale_id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bowser_digital_sales : INSERT ──────────────────────────────────────────
+
+CREATE TRIGGER trg_bowser_digital_gl_insert
+AFTER INSERT ON t_bowser_digital_sales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+    DECLARE v_trans_date    DATE;
+    DECLARE v_fy_id         INT;
+
+    SELECT tbc.location_code, tbc.closing_date
+    INTO   v_location_code, v_trans_date
+    FROM   t_bowser_closing tbc
+    WHERE  tbc.bowser_closing_id = NEW.bowser_closing_id;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT fy.fy_id INTO v_fy_id
+        FROM   gl_financial_years fy
+        WHERE  fy.location_code = v_location_code
+          AND  v_trans_date BETWEEN fy.start_date AND fy.end_date
+        LIMIT 1;
+
+        IF v_fy_id IS NOT NULL THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'BOWSER_DIGITAL_SALE', NEW.digital_id, 'CREATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bowser_digital_sales : UPDATE ──────────────────────────────────────────
+
+CREATE TRIGGER trg_bowser_digital_gl_update
+AFTER UPDATE ON t_bowser_digital_sales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_trans_date      DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    IF NOT (NEW.amount            <=> OLD.amount)
+    OR NOT (NEW.digital_vendor_id <=> OLD.digital_vendor_id)
+    THEN
+        SELECT tbc.location_code, tbc.closing_date
+        INTO   v_location_code, v_trans_date
+        FROM   t_bowser_closing tbc
+        WHERE  tbc.bowser_closing_id = NEW.bowser_closing_id;
+
+        IF v_location_code IS NOT NULL THEN
+            SELECT fy.fy_id INTO v_fy_id
+            FROM   gl_financial_years fy
+            WHERE  fy.location_code = v_location_code
+              AND  v_trans_date BETWEEN fy.start_date AND fy.end_date
+            LIMIT 1;
+
+            IF v_fy_id IS NOT NULL THEN
+                SELECT COUNT(*) INTO v_processed_count
+                FROM   gl_accounting_events
+                WHERE  source_type = 'BOWSER_DIGITAL_SALE' AND source_id = NEW.digital_id AND event_status = 'PROCESSED';
+
+                SELECT COUNT(*) INTO v_pending_count
+                FROM   gl_accounting_events
+                WHERE  source_type = 'BOWSER_DIGITAL_SALE' AND source_id = NEW.digital_id AND event_status = 'UNPROCESSED';
+
+                IF v_processed_count > 0 THEN
+                    INSERT INTO gl_accounting_events
+                        (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                    VALUES
+                        (v_location_code, v_fy_id, 'BOWSER_DIGITAL_SALE', NEW.digital_id, 'UPDATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+                ELSEIF v_pending_count > 0 THEN
+                    UPDATE gl_accounting_events
+                    SET    event_type = 'UPDATE'
+                    WHERE  source_type = 'BOWSER_DIGITAL_SALE' AND source_id = NEW.digital_id AND event_status = 'UNPROCESSED';
+                ELSE
+                    INSERT INTO gl_accounting_events
+                        (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                    VALUES
+                        (v_location_code, v_fy_id, 'BOWSER_DIGITAL_SALE', NEW.digital_id, 'CREATE', v_trans_date, 'UNPROCESSED', 'TRIGGER');
+                END IF;
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bowser_digital_sales : DELETE ──────────────────────────────────────────
+
+CREATE TRIGGER trg_bowser_digital_gl_delete
+AFTER DELETE ON t_bowser_digital_sales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'BOWSER_DIGITAL_SALE' AND source_id = OLD.digital_id
+    ORDER BY event_id DESC LIMIT 1;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'BOWSER_DIGITAL_SALE' AND source_id = OLD.digital_id AND event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type = 'BOWSER_DIGITAL_SALE' AND source_id = OLD.digital_id AND event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'BOWSER_DIGITAL_SALE', OLD.digital_id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SHOW TRIGGERS WHERE `Table` IN ('t_bowser_credits', 't_bowser_cashsales', 't_bowser_digital_sales');

--- a/db/migrations/gl-control-menu-item.sql
+++ b/db/migrations/gl-control-menu-item.sql
@@ -1,0 +1,23 @@
+-- ============================================================
+-- GL Control — Menu Item & Access
+-- Generated: 2026-05-02
+--
+-- Adds the GL Control page under the ACCOUNTING group.
+-- Run on dev and prod.
+-- ============================================================
+
+INSERT INTO m_menu_items
+    (menu_code, menu_name, icon, url_path, parent_code, sequence, effective_start_date, created_by, updated_by, group_code)
+VALUES
+    ('GL_CONTROL', 'GL Control', 'bi-sliders', '/gl/control', NULL, 8, '2026-05-02', 'SAKTHI', 'SAKTHI', 'ACCOUNTING');
+
+INSERT INTO m_menu_access_global
+    (role, menu_code, allowed, effective_start_date, created_by, updated_by)
+VALUES
+    ('SuperUser', 'GL_CONTROL', 1, '2026-05-02', 'SAKTHI', 'SAKTHI');
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SELECT menu_code, menu_name, sequence, group_code
+FROM m_menu_items
+WHERE group_code = 'ACCOUNTING'
+ORDER BY sequence;

--- a/db/migrations/gl-delete-triggers.sql
+++ b/db/migrations/gl-delete-triggers.sql
@@ -1,0 +1,184 @@
+-- ============================================================
+-- GL Delete Triggers — Source Transaction Deletion
+-- Generated: 2026-05-02
+--
+-- When a source transaction row is deleted:
+--   • UNPROCESSED / ERROR events are deleted directly —
+--     nothing was ever journaled, so nothing to reverse.
+--   • If PROCESSED events exist, a DELETE event is raised so
+--     the engine can reverse the posted vouchers.
+--
+-- location_code / fy_id / event_date are read from the
+-- existing gl_accounting_events row to avoid re-joining the
+-- source table (cleaner, works even for soft-deleted rows).
+--
+-- Covers: t_credits, t_cashsales, t_day_bill, t_bank_transaction
+-- ============================================================
+
+DROP TRIGGER IF EXISTS trg_credits_gl_delete;
+DROP TRIGGER IF EXISTS trg_cashsales_gl_delete;
+DROP TRIGGER IF EXISTS trg_day_bill_gl_delete;
+DROP TRIGGER IF EXISTS trg_bank_txn_gl_delete;
+
+DELIMITER $$
+
+-- ── t_credits : DELETE ────────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_credits_gl_delete
+AFTER DELETE ON t_credits
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'CREDIT_SALE' AND source_id = OLD.tcredit_id
+    ORDER BY event_id DESC
+    LIMIT 1;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type  = 'CREDIT_SALE'
+          AND  source_id    = OLD.tcredit_id
+          AND  event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type  = 'CREDIT_SALE'
+          AND  source_id    = OLD.tcredit_id
+          AND  event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'CREDIT_SALE', OLD.tcredit_id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_cashsales : DELETE ──────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_cashsales_gl_delete
+AFTER DELETE ON t_cashsales
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'CASH_SALE' AND source_id = OLD.cashsales_id
+    ORDER BY event_id DESC
+    LIMIT 1;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type  = 'CASH_SALE'
+          AND  source_id    = OLD.cashsales_id
+          AND  event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type  = 'CASH_SALE'
+          AND  source_id    = OLD.cashsales_id
+          AND  event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'CASH_SALE', OLD.cashsales_id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_day_bill : DELETE ───────────────────────────────────────────────────────
+
+CREATE TRIGGER trg_day_bill_gl_delete
+AFTER DELETE ON t_day_bill
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'DAY_BILL' AND source_id = OLD.day_bill_id
+    ORDER BY event_id DESC
+    LIMIT 1;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type  = 'DAY_BILL'
+          AND  source_id    = OLD.day_bill_id
+          AND  event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type  = 'DAY_BILL'
+          AND  source_id    = OLD.day_bill_id
+          AND  event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'DAY_BILL', OLD.day_bill_id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_bank_transaction : DELETE ───────────────────────────────────────────────
+
+CREATE TRIGGER trg_bank_txn_gl_delete
+AFTER DELETE ON t_bank_transaction
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'BANK_TXN' AND source_id = OLD.t_bank_id
+    ORDER BY event_id DESC
+    LIMIT 1;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type  = 'BANK_TXN'
+          AND  source_id    = OLD.t_bank_id
+          AND  event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type  = 'BANK_TXN'
+          AND  source_id    = OLD.t_bank_id
+          AND  event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'BANK_TXN', OLD.t_bank_id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SHOW TRIGGERS WHERE `Table` IN ('t_credits', 't_cashsales', 't_day_bill', 't_bank_transaction');

--- a/db/migrations/gl-ledger-master-menu-items.sql
+++ b/db/migrations/gl-ledger-master-menu-items.sql
@@ -1,0 +1,25 @@
+-- ============================================================
+-- GL Ledger Master — Menu Items & Access
+-- Generated: 2026-05-02
+--
+-- Adds Ledger Groups and Ledgers pages under ACCOUNTING group.
+-- Run on dev and prod.
+-- ============================================================
+
+INSERT INTO m_menu_items
+    (menu_code, menu_name, icon, url_path, parent_code, sequence, effective_start_date, created_by, updated_by, group_code)
+VALUES
+    ('GL_LEDGER_GROUPS', 'Ledger Groups', 'bi-collection',  '/gl/ledger-groups', NULL, 9,  '2026-05-02', 'SAKTHI', 'SAKTHI', 'ACCOUNTING'),
+    ('GL_LEDGERS',       'Ledgers',       'bi-card-list',   '/gl/ledgers',       NULL, 10, '2026-05-02', 'SAKTHI', 'SAKTHI', 'ACCOUNTING');
+
+INSERT INTO m_menu_access_global
+    (role, menu_code, allowed, effective_start_date, created_by, updated_by)
+VALUES
+    ('SuperUser', 'GL_LEDGER_GROUPS', 1, '2026-05-02', 'SAKTHI', 'SAKTHI'),
+    ('SuperUser', 'GL_LEDGERS',       1, '2026-05-02', 'SAKTHI', 'SAKTHI');
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SELECT menu_code, menu_name, sequence, group_code
+FROM m_menu_items
+WHERE group_code = 'ACCOUNTING'
+ORDER BY sequence;

--- a/db/migrations/gl-menu-items.sql
+++ b/db/migrations/gl-menu-items.sql
@@ -1,0 +1,38 @@
+-- ============================================================
+-- GL Accounting — Menu Items & Access
+-- Generated: 2026-05-02
+--
+-- Adds menu items for all GL reports and Manual Journal
+-- under the existing ACCOUNTING group.
+-- Run on dev and prod.
+-- ============================================================
+
+-- ── Menu Items ────────────────────────────────────────────────────────────────
+
+INSERT INTO m_menu_items
+    (menu_code, menu_name, icon, url_path, parent_code, sequence, effective_start_date, created_by, updated_by, group_code)
+VALUES
+    ('GL_MANUAL_JOURNAL', 'Manual Journal',  'bi-pencil-square',  '/gl/journal',         NULL, 2, '2026-05-02', 'SAKTHI', 'SAKTHI', 'ACCOUNTING'),
+    ('GL_DAY_BOOK',       'Day Book',         'bi-journal-text',   '/gl/day-book',        NULL, 3, '2026-05-02', 'SAKTHI', 'SAKTHI', 'ACCOUNTING'),
+    ('GL_LEDGER',         'Ledger Report',    'bi-book',           '/gl/ledger',          NULL, 4, '2026-05-02', 'SAKTHI', 'SAKTHI', 'ACCOUNTING'),
+    ('GL_TRIAL_BALANCE',  'Trial Balance',    'bi-clipboard-data', '/gl/trial-balance',   NULL, 5, '2026-05-02', 'SAKTHI', 'SAKTHI', 'ACCOUNTING'),
+    ('GL_PROFIT_LOSS',    'Profit & Loss',    'bi-graph-up',       '/gl/profit-loss',     NULL, 6, '2026-05-02', 'SAKTHI', 'SAKTHI', 'ACCOUNTING'),
+    ('GL_BALANCE_SHEET',  'Balance Sheet',    'bi-building',       '/gl/balance-sheet',   NULL, 7, '2026-05-02', 'SAKTHI', 'SAKTHI', 'ACCOUNTING');
+
+-- ── Global Access (SuperUser) ─────────────────────────────────────────────────
+
+INSERT INTO m_menu_access_global
+    (role, menu_code, allowed, effective_start_date, created_by, updated_by)
+VALUES
+    ('SuperUser', 'GL_MANUAL_JOURNAL', 1, '2026-05-02', 'SAKTHI', 'SAKTHI'),
+    ('SuperUser', 'GL_DAY_BOOK',       1, '2026-05-02', 'SAKTHI', 'SAKTHI'),
+    ('SuperUser', 'GL_LEDGER',         1, '2026-05-02', 'SAKTHI', 'SAKTHI'),
+    ('SuperUser', 'GL_TRIAL_BALANCE',  1, '2026-05-02', 'SAKTHI', 'SAKTHI'),
+    ('SuperUser', 'GL_PROFIT_LOSS',    1, '2026-05-02', 'SAKTHI', 'SAKTHI'),
+    ('SuperUser', 'GL_BALANCE_SHEET',  1, '2026-05-02', 'SAKTHI', 'SAKTHI');
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SELECT menu_code, menu_name, sequence, group_code
+FROM m_menu_items
+WHERE group_code = 'ACCOUNTING'
+ORDER BY sequence;

--- a/db/migrations/gl-output-gst-ledgers.sql
+++ b/db/migrations/gl-output-gst-ledgers.sql
@@ -1,0 +1,163 @@
+-- ============================================================
+-- GL Output GST Ledgers
+-- Generated: 2026-05-01
+--
+-- Seeds OUTPUT CGST and OUTPUT SGST ledgers under the
+-- "Duties & Taxes" group for every location that does not
+-- already have them.
+--
+-- Also extends trg_location_seed_data to create these two
+-- ledgers automatically when a new location is added.
+-- ============================================================
+
+-- ── Backfill all existing locations ──────────────────────────────────────────
+
+INSERT INTO gl_ledgers (location_code, ledger_name, group_id, active_flag, created_by, updated_by)
+SELECT g.location_code, 'OUTPUT CGST', g.group_id, 'Y', 'system', 'system'
+FROM gl_ledger_groups g
+WHERE g.group_name = 'Duties & Taxes'
+  AND NOT EXISTS (
+      SELECT 1 FROM gl_ledgers l
+      WHERE l.location_code = g.location_code
+        AND l.ledger_name   = 'OUTPUT CGST'
+  );
+
+INSERT INTO gl_ledgers (location_code, ledger_name, group_id, active_flag, created_by, updated_by)
+SELECT g.location_code, 'OUTPUT SGST', g.group_id, 'Y', 'system', 'system'
+FROM gl_ledger_groups g
+WHERE g.group_name = 'Duties & Taxes'
+  AND NOT EXISTS (
+      SELECT 1 FROM gl_ledgers l
+      WHERE l.location_code = g.location_code
+        AND l.ledger_name   = 'OUTPUT SGST'
+  );
+
+-- ── Extend trg_location_seed_data ────────────────────────────────────────────
+
+DROP TRIGGER IF EXISTS trg_location_seed_data;
+
+DELIMITER $$
+
+CREATE TRIGGER trg_location_seed_data
+AFTER INSERT ON m_location
+FOR EACH ROW
+BEGIN
+    DECLARE v_supplier_id     INT;
+    DECLARE v_template_id     INT;
+    DECLARE v_bank_name       VARCHAR(150);
+    DECLARE v_supplier_name   VARCHAR(200);
+    DECLARE v_dt_group_id     INT;
+
+    IF @disable_triggers IS NULL OR @disable_triggers = 0 THEN
+
+        -- Insert Petty Cash Expenses
+        INSERT INTO m_expense
+            (Expense_name, location_code, Expense_default_amt, created_by, updated_by, updation_date, creation_date)
+        VALUES
+            ('Tiffin',         NEW.location_code, 200, 'admin', 'admin', NOW(), NOW()),
+            ('Tea',            NEW.location_code,  30, 'admin', 'admin', NOW(), NOW()),
+            ('Bus Fare',       NEW.location_code,  30, 'admin', 'admin', NOW(), NOW()),
+            ('TT Driver Batta',NEW.location_code, 100, 'admin', 'admin', NOW(), NOW()),
+            ('Others',         NEW.location_code,   0, 'admin', 'admin', NOW(), NOW());
+
+        -- Insert Lookup defaults
+        INSERT INTO m_lookup
+            (lookup_type, description, tag, start_date_active, end_date_active,
+             attribute1, attribute2, attribute3, attribute4, attribute5,
+             created_by, updated_by, updation_date, creation_date, location_code, tally_export)
+        VALUES
+            ('CashFlow', 'To Bank',           'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Cashier A/C (+)',   'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Cashier A/C (-)',   'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Cash Receipt',      'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Collection',        'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Balance B/F',       'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Expense',           'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'To WithDrawals',    'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'To Deposits',       'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Shift Opening',     'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'To Bank',           'OUT', '2024-06-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Shift Cash Return', 'IN',  '2025-04-08', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Salary Payout',     'OUT', '2024-04-01', NULL, '200', NULL, NULL, NULL, 'SALARY EXPENSES', 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Salary Recovery',   'IN',  '2024-04-01', NULL, NULL, NULL, NULL, NULL, 'SALARY EXPENSES', 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Discount',          'OUT', '2025-10-30', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y');
+
+        -- Seed Output GST ledgers under Duties & Taxes
+        SELECT group_id INTO v_dt_group_id
+        FROM gl_ledger_groups
+        WHERE location_code = NEW.location_code
+          AND group_name    = 'Duties & Taxes'
+        LIMIT 1;
+
+        IF v_dt_group_id IS NOT NULL THEN
+            INSERT INTO gl_ledgers (location_code, ledger_name, group_id, active_flag, created_by, updated_by)
+            VALUES (NEW.location_code, 'OUTPUT CGST', v_dt_group_id, 'Y', 'system', 'system');
+
+            INSERT INTO gl_ledgers (location_code, ledger_name, group_id, active_flag, created_by, updated_by)
+            VALUES (NEW.location_code, 'OUTPUT SGST', v_dt_group_id, 'Y', 'system', 'system');
+        END IF;
+
+        -- Auto-create oil company supplier + SOA bank
+        -- The after_supplier_insert_ledger_rule trigger on m_supplier fires automatically.
+        IF NEW.company_name IN ('IOCL', 'BPCL', 'HPCL', 'NAYARA') THEN
+
+            SET v_supplier_name = CASE NEW.company_name
+                WHEN 'IOCL'   THEN 'Indian Oil Corporation Limited'
+                WHEN 'BPCL'   THEN 'Bharat Petroleum Corporation Limited'
+                WHEN 'HPCL'   THEN 'Hindustan Petroleum Corporation Limited'
+                WHEN 'NAYARA' THEN 'Nayara Energy Limited'
+            END;
+
+            SET v_bank_name = CASE NEW.company_name
+                WHEN 'IOCL'   THEN 'IOCL-SOA'
+                WHEN 'BPCL'   THEN 'BPCL-SOA'
+                WHEN 'HPCL'   THEN 'HPCL-SOA'
+                WHEN 'NAYARA' THEN 'NAYARA-SOA'
+            END;
+
+            -- template_id=2: IOCL SAP Account Statement
+            -- template_id=6: BPCL SAP SOA Format
+            SET v_template_id = CASE NEW.company_name
+                WHEN 'IOCL'   THEN 2
+                WHEN 'BPCL'   THEN 6
+                ELSE NULL
+            END;
+
+            INSERT INTO m_supplier
+                (supplier_name, supplier_short_name, location_id, location_code,
+                 created_by, updated_by, creation_date, updation_date)
+            VALUES (
+                v_supplier_name,
+                NEW.company_name,
+                NEW.location_id,
+                NEW.location_code,
+                'system', 'system', NOW(), NOW()
+            );
+
+            SET v_supplier_id = LAST_INSERT_ID();
+
+            INSERT INTO m_bank
+                (bank_name, bank_branch, account_number, ifsc_code,
+                 location_code, location_id, is_oil_company, active_flag, internal_flag,
+                 template_id, supplier_id, created_by, updated_by)
+            VALUES (
+                v_bank_name, 'N/A', 'N/A', 'N/A',
+                NEW.location_code, NEW.location_id, 'Y', 'Y', 'N',
+                v_template_id, v_supplier_id, 'system', 'system'
+            );
+
+        END IF;
+
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SELECT location_code,
+       SUM(CASE WHEN ledger_name = 'OUTPUT CGST' THEN 1 ELSE 0 END) AS has_cgst,
+       SUM(CASE WHEN ledger_name = 'OUTPUT SGST' THEN 1 ELSE 0 END) AS has_sgst
+FROM gl_ledgers
+WHERE ledger_name IN ('OUTPUT CGST', 'OUTPUT SGST')
+GROUP BY location_code
+ORDER BY location_code;

--- a/db/migrations/gl-product-gst-ledger-map.sql
+++ b/db/migrations/gl-product-gst-ledger-map.sql
@@ -1,0 +1,65 @@
+-- ============================================================
+-- GL Product GST Ledger Map
+-- Generated: 2026-05-01
+--
+-- Seeds OUTPUT_CGST and OUTPUT_SGST rows in gl_product_ledger_map
+-- for every product that has cgst_percent > 0 and already has
+-- a SALES mapping, pointing to the OUTPUT CGST / OUTPUT SGST
+-- ledgers under Duties & Taxes for that location.
+--
+-- Safe to re-run: INSERT IGNORE skips duplicates.
+-- ============================================================
+
+-- ── OUTPUT_CGST mappings ──────────────────────────────────────────────────────
+
+INSERT IGNORE INTO gl_product_ledger_map (location_code, product_id, map_type, ledger_id)
+SELECT
+    plm.location_code,
+    plm.product_id,
+    'OUTPUT_CGST',
+    gst_l.ledger_id
+FROM gl_product_ledger_map plm
+JOIN m_product mp ON mp.product_id = plm.product_id
+JOIN gl_ledgers gst_l ON gst_l.location_code = plm.location_code
+                      AND gst_l.ledger_name   = 'OUTPUT CGST'
+JOIN gl_ledger_groups g ON g.group_id = gst_l.group_id
+                        AND g.group_name = 'Duties & Taxes'
+WHERE plm.map_type      = 'SALES'
+  AND mp.cgst_percent   > 0;
+
+-- ── OUTPUT_SGST mappings ──────────────────────────────────────────────────────
+
+INSERT IGNORE INTO gl_product_ledger_map (location_code, product_id, map_type, ledger_id)
+SELECT
+    plm.location_code,
+    plm.product_id,
+    'OUTPUT_SGST',
+    gst_l.ledger_id
+FROM gl_product_ledger_map plm
+JOIN m_product mp ON mp.product_id = plm.product_id
+JOIN gl_ledgers gst_l ON gst_l.location_code = plm.location_code
+                      AND gst_l.ledger_name   = 'OUTPUT SGST'
+JOIN gl_ledger_groups g ON g.group_id = gst_l.group_id
+                        AND g.group_name = 'Duties & Taxes'
+WHERE plm.map_type      = 'SALES'
+  AND mp.cgst_percent   > 0;
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SELECT map_type, COUNT(*) AS rows_inserted
+FROM gl_product_ledger_map
+WHERE map_type IN ('OUTPUT_CGST', 'OUTPUT_SGST')
+GROUP BY map_type;
+
+-- Spot check: products with SALES but missing OUTPUT_CGST (should be 0 or only cgst=0 products)
+SELECT plm.location_code, plm.product_id, mp.product_name, mp.cgst_percent
+FROM gl_product_ledger_map plm
+JOIN m_product mp ON mp.product_id = plm.product_id
+WHERE plm.map_type    = 'SALES'
+  AND mp.cgst_percent > 0
+  AND NOT EXISTS (
+      SELECT 1 FROM gl_product_ledger_map plm2
+      WHERE plm2.location_code = plm.location_code
+        AND plm2.product_id    = plm.product_id
+        AND plm2.map_type      = 'OUTPUT_CGST'
+  )
+ORDER BY plm.location_code, mp.product_name;

--- a/db/migrations/gl-product-map-types-seed.sql
+++ b/db/migrations/gl-product-map-types-seed.sql
@@ -1,0 +1,30 @@
+-- ============================================================
+-- Product GL Map Types — m_lookup seed
+-- Generated: 2026-05-02
+--
+-- Moves PRODUCT_MAP_TYPES out of code into m_lookup so new
+-- map types can be added without a code deploy.
+--
+-- lookup_type : 'ProductMapType'
+-- tag         : code key used in gl_product_ledger_map.map_type
+-- description : display label shown in the UI modal
+-- attribute1  : ledger group category key (used by the route
+--               to decide which ledger dropdown to show)
+-- ============================================================
+
+-- Idempotent: remove existing rows then re-insert
+DELETE FROM m_lookup WHERE lookup_type = 'ProductMapType';
+
+INSERT INTO m_lookup (lookup_type, description, tag, attribute1, created_by) VALUES
+    ('ProductMapType', 'Sales',       'SALES',       'sales',    'SYSTEM'),
+    ('ProductMapType', 'Purchase',    'PURCHASE',    'purchase', 'SYSTEM'),
+    ('ProductMapType', 'Output CGST', 'OUTPUT_CGST', 'tax',      'SYSTEM'),
+    ('ProductMapType', 'Output SGST', 'OUTPUT_SGST', 'tax',      'SYSTEM'),
+    ('ProductMapType', 'Input CGST',  'INPUT_CGST',  'tax',      'SYSTEM'),
+    ('ProductMapType', 'Input SGST',  'INPUT_SGST',  'tax',      'SYSTEM');
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SELECT lookup_id, description, tag, attribute1
+FROM m_lookup
+WHERE lookup_type = 'ProductMapType'
+ORDER BY lookup_id;

--- a/db/migrations/gl-purchase-invoice-triggers.sql
+++ b/db/migrations/gl-purchase-invoice-triggers.sql
@@ -1,0 +1,247 @@
+-- ============================================================
+-- GL Purchase Invoice Event Triggers
+-- Generated: 2026-05-02
+--
+-- Raises gl_accounting_events rows automatically on writes to:
+--   t_lubes_inv_hdr  → LUBES_INVOICE events  (source_id = lubes_hdr_id)
+--   t_tank_invoice   → TANK_INVOICE events   (source_id = id)
+--
+-- Triggers are on HEADERS only.  Lines are read at process time.
+--
+-- LUBES_INVOICE draft gate:
+--   The engine handler checks closing_status at process time.
+--   If DRAFT  → marks PROCESSED with 0 vouchers (skip silently).
+--   If CLOSED → journals created normally.
+--   When status changes DRAFT→CLOSED the UPDATE trigger fires,
+--   raising an UPDATE event that the engine picks up.
+--
+-- TANK_INVOICE:
+--   No status column — events processed immediately on INSERT/UPDATE.
+--   location_id column stores the location_code string.
+-- ============================================================
+
+DROP TRIGGER IF EXISTS trg_lubes_inv_gl_insert;
+DROP TRIGGER IF EXISTS trg_lubes_inv_gl_update;
+DROP TRIGGER IF EXISTS trg_lubes_inv_gl_delete;
+DROP TRIGGER IF EXISTS trg_tank_inv_gl_insert;
+DROP TRIGGER IF EXISTS trg_tank_inv_gl_update;
+DROP TRIGGER IF EXISTS trg_tank_inv_gl_delete;
+
+DELIMITER $$
+
+-- ── t_lubes_inv_hdr : INSERT ──────────────────────────────────────────────────
+
+CREATE TRIGGER trg_lubes_inv_gl_insert
+AFTER INSERT ON t_lubes_inv_hdr
+FOR EACH ROW
+BEGIN
+    DECLARE v_fy_id INT;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = NEW.location_code
+      AND  NEW.invoice_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        VALUES
+            (NEW.location_code, v_fy_id, 'LUBES_INVOICE', NEW.lubes_hdr_id, 'CREATE', NEW.invoice_date, 'UNPROCESSED', 'TRIGGER');
+    END IF;
+END$$
+
+-- ── t_lubes_inv_hdr : UPDATE ──────────────────────────────────────────────────
+-- Fires when status changes (DRAFT→CLOSED is the key transition) or financial
+-- columns change.
+
+CREATE TRIGGER trg_lubes_inv_gl_update
+AFTER UPDATE ON t_lubes_inv_hdr
+FOR EACH ROW
+BEGIN
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    IF NOT (NEW.closing_status  <=> OLD.closing_status)
+    OR NOT (NEW.supplier_id     <=> OLD.supplier_id)
+    OR NOT (NEW.invoice_amount  <=> OLD.invoice_amount)
+    OR NOT (NEW.invoice_date    <=> OLD.invoice_date)
+    THEN
+        SELECT fy.fy_id INTO v_fy_id
+        FROM   gl_financial_years fy
+        WHERE  fy.location_code = NEW.location_code
+          AND  NEW.invoice_date BETWEEN fy.start_date AND fy.end_date
+        LIMIT 1;
+
+        IF v_fy_id IS NOT NULL THEN
+            SELECT COUNT(*) INTO v_processed_count
+            FROM   gl_accounting_events
+            WHERE  source_type = 'LUBES_INVOICE' AND source_id = NEW.lubes_hdr_id AND event_status = 'PROCESSED';
+
+            SELECT COUNT(*) INTO v_pending_count
+            FROM   gl_accounting_events
+            WHERE  source_type = 'LUBES_INVOICE' AND source_id = NEW.lubes_hdr_id AND event_status = 'UNPROCESSED';
+
+            IF v_processed_count > 0 THEN
+                INSERT INTO gl_accounting_events
+                    (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                VALUES
+                    (NEW.location_code, v_fy_id, 'LUBES_INVOICE', NEW.lubes_hdr_id, 'UPDATE', NEW.invoice_date, 'UNPROCESSED', 'TRIGGER');
+            ELSEIF v_pending_count > 0 THEN
+                UPDATE gl_accounting_events
+                SET    event_type = 'UPDATE'
+                WHERE  source_type = 'LUBES_INVOICE' AND source_id = NEW.lubes_hdr_id AND event_status = 'UNPROCESSED';
+            ELSE
+                INSERT INTO gl_accounting_events
+                    (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                VALUES
+                    (NEW.location_code, v_fy_id, 'LUBES_INVOICE', NEW.lubes_hdr_id, 'CREATE', NEW.invoice_date, 'UNPROCESSED', 'TRIGGER');
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+-- ── t_lubes_inv_hdr : DELETE ──────────────────────────────────────────────────
+
+CREATE TRIGGER trg_lubes_inv_gl_delete
+AFTER DELETE ON t_lubes_inv_hdr
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'LUBES_INVOICE' AND source_id = OLD.lubes_hdr_id
+    ORDER BY event_id DESC LIMIT 1;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'LUBES_INVOICE' AND source_id = OLD.lubes_hdr_id AND event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type = 'LUBES_INVOICE' AND source_id = OLD.lubes_hdr_id AND event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'LUBES_INVOICE', OLD.lubes_hdr_id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+-- ── t_tank_invoice : INSERT ───────────────────────────────────────────────────
+-- location_id stores the location_code string.
+
+CREATE TRIGGER trg_tank_inv_gl_insert
+AFTER INSERT ON t_tank_invoice
+FOR EACH ROW
+BEGIN
+    DECLARE v_fy_id INT;
+
+    SELECT fy.fy_id INTO v_fy_id
+    FROM   gl_financial_years fy
+    WHERE  fy.location_code = NEW.location_id
+      AND  NEW.invoice_date BETWEEN fy.start_date AND fy.end_date
+    LIMIT 1;
+
+    IF v_fy_id IS NOT NULL THEN
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        VALUES
+            (NEW.location_id, v_fy_id, 'TANK_INVOICE', NEW.id, 'CREATE', NEW.invoice_date, 'UNPROCESSED', 'TRIGGER');
+    END IF;
+END$$
+
+-- ── t_tank_invoice : UPDATE ───────────────────────────────────────────────────
+
+CREATE TRIGGER trg_tank_inv_gl_update
+AFTER UPDATE ON t_tank_invoice
+FOR EACH ROW
+BEGIN
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    IF NOT (NEW.total_invoice_amount <=> OLD.total_invoice_amount)
+    OR NOT (NEW.supplier_id          <=> OLD.supplier_id)
+    OR NOT (NEW.invoice_date         <=> OLD.invoice_date)
+    THEN
+        SELECT fy.fy_id INTO v_fy_id
+        FROM   gl_financial_years fy
+        WHERE  fy.location_code = NEW.location_id
+          AND  NEW.invoice_date BETWEEN fy.start_date AND fy.end_date
+        LIMIT 1;
+
+        IF v_fy_id IS NOT NULL THEN
+            SELECT COUNT(*) INTO v_processed_count
+            FROM   gl_accounting_events
+            WHERE  source_type = 'TANK_INVOICE' AND source_id = NEW.id AND event_status = 'PROCESSED';
+
+            SELECT COUNT(*) INTO v_pending_count
+            FROM   gl_accounting_events
+            WHERE  source_type = 'TANK_INVOICE' AND source_id = NEW.id AND event_status = 'UNPROCESSED';
+
+            IF v_processed_count > 0 THEN
+                INSERT INTO gl_accounting_events
+                    (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                VALUES
+                    (NEW.location_id, v_fy_id, 'TANK_INVOICE', NEW.id, 'UPDATE', NEW.invoice_date, 'UNPROCESSED', 'TRIGGER');
+            ELSEIF v_pending_count > 0 THEN
+                UPDATE gl_accounting_events
+                SET    event_type = 'UPDATE'
+                WHERE  source_type = 'TANK_INVOICE' AND source_id = NEW.id AND event_status = 'UNPROCESSED';
+            ELSE
+                INSERT INTO gl_accounting_events
+                    (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                VALUES
+                    (NEW.location_id, v_fy_id, 'TANK_INVOICE', NEW.id, 'CREATE', NEW.invoice_date, 'UNPROCESSED', 'TRIGGER');
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+-- ── t_tank_invoice : DELETE ───────────────────────────────────────────────────
+
+CREATE TRIGGER trg_tank_inv_gl_delete
+AFTER DELETE ON t_tank_invoice
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'TANK_INVOICE' AND source_id = OLD.id
+    ORDER BY event_id DESC LIMIT 1;
+
+    IF v_location_code IS NOT NULL THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'TANK_INVOICE' AND source_id = OLD.id AND event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type = 'TANK_INVOICE' AND source_id = OLD.id AND event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'TANK_INVOICE', OLD.id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SHOW TRIGGERS WHERE `Table` IN ('t_lubes_inv_hdr', 't_tank_invoice');

--- a/db/migrations/gst-split-triggers.sql
+++ b/db/migrations/gst-split-triggers.sql
@@ -1,0 +1,248 @@
+-- ============================================================
+-- GST Split Triggers
+-- Generated: 2026-05-01
+--
+-- Automatically populates GST fields on t_credits and t_cashsales
+-- on every INSERT and UPDATE, by looking up the product's
+-- cgst_percent / sgst_percent from m_product.
+--
+-- Fields populated:
+--   cgst_percent  ← m_product.cgst_percent
+--   sgst_percent  ← m_product.sgst_percent
+--   base_amount   = amount / (1 + (cgst + sgst) / 100)   [GST-exclusive]
+--   cgst_amount   = base_amount × cgst_percent / 100
+--   sgst_amount   = base_amount × sgst_percent / 100
+--
+-- For fuel (cgst_percent = 0 or NULL):
+--   base_amount = amount, all tax fields = 0
+--
+-- Fires on every INSERT and every UPDATE so corrections to amount
+-- or product_id are always reflected in the tax fields.
+--
+-- Gated by @disable_triggers: SET @disable_triggers = 1 before any
+-- bulk operation (backfill, data migration, dev refresh restore) to
+-- skip per-row lookups. Reset to 0 or NULL when done.
+-- ============================================================
+
+DROP TRIGGER IF EXISTS trg_credits_gst_before_insert;
+DROP TRIGGER IF EXISTS trg_credits_gst_before_update;
+DROP TRIGGER IF EXISTS trg_cashsales_gst_before_insert;
+DROP TRIGGER IF EXISTS trg_cashsales_gst_before_update;
+
+DELIMITER $$
+
+-- ── t_credits : BEFORE INSERT ─────────────────────────────────────────────────
+
+CREATE TRIGGER trg_credits_gst_before_insert
+BEFORE INSERT ON t_credits
+FOR EACH ROW
+BEGIN
+    DECLARE v_cgst DECIMAL(5,2) DEFAULT 0;
+    DECLARE v_sgst DECIMAL(5,2) DEFAULT 0;
+    DECLARE v_base DECIMAL(15,3);
+
+    IF @disable_triggers IS NULL OR @disable_triggers = 0 THEN
+
+        SELECT COALESCE(cgst_percent, 0), COALESCE(sgst_percent, 0)
+        INTO   v_cgst, v_sgst
+        FROM   m_product
+        WHERE  product_id = NEW.product_id
+        LIMIT 1;
+
+        SET NEW.cgst_percent = v_cgst;
+        SET NEW.sgst_percent = v_sgst;
+
+        IF v_cgst > 0 OR v_sgst > 0 THEN
+            SET v_base           = COALESCE(NEW.amount, 0) / (1 + (v_cgst + v_sgst) / 100);
+            SET NEW.base_amount  = ROUND(v_base, 3);
+            SET NEW.cgst_amount  = ROUND(v_base * v_cgst / 100, 3);
+            SET NEW.sgst_amount  = ROUND(v_base * v_sgst / 100, 3);
+        ELSE
+            SET NEW.base_amount  = COALESCE(NEW.amount, 0);
+            SET NEW.cgst_amount  = 0;
+            SET NEW.sgst_amount  = 0;
+        END IF;
+
+    END IF;
+END$$
+
+-- ── t_credits : BEFORE UPDATE ─────────────────────────────────────────────────
+
+CREATE TRIGGER trg_credits_gst_before_update
+BEFORE UPDATE ON t_credits
+FOR EACH ROW
+BEGIN
+    DECLARE v_cgst DECIMAL(5,2) DEFAULT 0;
+    DECLARE v_sgst DECIMAL(5,2) DEFAULT 0;
+    DECLARE v_base DECIMAL(15,3);
+
+    IF @disable_triggers IS NULL OR @disable_triggers = 0 THEN
+
+        SELECT COALESCE(cgst_percent, 0), COALESCE(sgst_percent, 0)
+        INTO   v_cgst, v_sgst
+        FROM   m_product
+        WHERE  product_id = NEW.product_id
+        LIMIT 1;
+
+        SET NEW.cgst_percent = v_cgst;
+        SET NEW.sgst_percent = v_sgst;
+
+        IF v_cgst > 0 OR v_sgst > 0 THEN
+            SET v_base           = COALESCE(NEW.amount, 0) / (1 + (v_cgst + v_sgst) / 100);
+            SET NEW.base_amount  = ROUND(v_base, 3);
+            SET NEW.cgst_amount  = ROUND(v_base * v_cgst / 100, 3);
+            SET NEW.sgst_amount  = ROUND(v_base * v_sgst / 100, 3);
+        ELSE
+            SET NEW.base_amount  = COALESCE(NEW.amount, 0);
+            SET NEW.cgst_amount  = 0;
+            SET NEW.sgst_amount  = 0;
+        END IF;
+
+    END IF;
+END$$
+
+-- ── t_cashsales : BEFORE INSERT ───────────────────────────────────────────────
+
+CREATE TRIGGER trg_cashsales_gst_before_insert
+BEFORE INSERT ON t_cashsales
+FOR EACH ROW
+BEGIN
+    DECLARE v_cgst DECIMAL(5,2) DEFAULT 0;
+    DECLARE v_sgst DECIMAL(5,2) DEFAULT 0;
+    DECLARE v_base DECIMAL(15,3);
+
+    IF @disable_triggers IS NULL OR @disable_triggers = 0 THEN
+
+        SELECT COALESCE(cgst_percent, 0), COALESCE(sgst_percent, 0)
+        INTO   v_cgst, v_sgst
+        FROM   m_product
+        WHERE  product_id = NEW.product_id
+        LIMIT 1;
+
+        SET NEW.cgst_percent = v_cgst;
+        SET NEW.sgst_percent = v_sgst;
+
+        IF v_cgst > 0 OR v_sgst > 0 THEN
+            SET v_base           = COALESCE(NEW.amount, 0) / (1 + (v_cgst + v_sgst) / 100);
+            SET NEW.base_amount  = ROUND(v_base, 3);
+            SET NEW.cgst_amount  = ROUND(v_base * v_cgst / 100, 3);
+            SET NEW.sgst_amount  = ROUND(v_base * v_sgst / 100, 3);
+        ELSE
+            SET NEW.base_amount  = COALESCE(NEW.amount, 0);
+            SET NEW.cgst_amount  = 0;
+            SET NEW.sgst_amount  = 0;
+        END IF;
+
+    END IF;
+END$$
+
+-- ── t_cashsales : BEFORE UPDATE ───────────────────────────────────────────────
+
+CREATE TRIGGER trg_cashsales_gst_before_update
+BEFORE UPDATE ON t_cashsales
+FOR EACH ROW
+BEGIN
+    DECLARE v_cgst DECIMAL(5,2) DEFAULT 0;
+    DECLARE v_sgst DECIMAL(5,2) DEFAULT 0;
+    DECLARE v_base DECIMAL(15,3);
+
+    IF @disable_triggers IS NULL OR @disable_triggers = 0 THEN
+
+        SELECT COALESCE(cgst_percent, 0), COALESCE(sgst_percent, 0)
+        INTO   v_cgst, v_sgst
+        FROM   m_product
+        WHERE  product_id = NEW.product_id
+        LIMIT 1;
+
+        SET NEW.cgst_percent = v_cgst;
+        SET NEW.sgst_percent = v_sgst;
+
+        IF v_cgst > 0 OR v_sgst > 0 THEN
+            SET v_base           = COALESCE(NEW.amount, 0) / (1 + (v_cgst + v_sgst) / 100);
+            SET NEW.base_amount  = ROUND(v_base, 3);
+            SET NEW.cgst_amount  = ROUND(v_base * v_cgst / 100, 3);
+            SET NEW.sgst_amount  = ROUND(v_base * v_sgst / 100, 3);
+        ELSE
+            SET NEW.base_amount  = COALESCE(NEW.amount, 0);
+            SET NEW.cgst_amount  = 0;
+            SET NEW.sgst_amount  = 0;
+        END IF;
+
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- ── Backfill existing rows ────────────────────────────────────────────────────
+-- Disable triggers for bulk backfill, then re-enable.
+
+SET @disable_triggers = 1;
+
+-- t_credits backfill
+UPDATE t_credits tc
+JOIN m_product mp ON mp.product_id = tc.product_id
+SET
+    tc.cgst_percent = COALESCE(mp.cgst_percent, 0),
+    tc.sgst_percent = COALESCE(mp.sgst_percent, 0),
+    tc.base_amount  = CASE
+                        WHEN COALESCE(mp.cgst_percent, 0) + COALESCE(mp.sgst_percent, 0) > 0
+                        THEN ROUND(tc.amount / (1 + (COALESCE(mp.cgst_percent,0) + COALESCE(mp.sgst_percent,0)) / 100), 3)
+                        ELSE tc.amount
+                      END,
+    tc.cgst_amount  = CASE
+                        WHEN COALESCE(mp.cgst_percent, 0) > 0
+                        THEN ROUND(
+                               tc.amount / (1 + (COALESCE(mp.cgst_percent,0) + COALESCE(mp.sgst_percent,0)) / 100)
+                               * COALESCE(mp.cgst_percent,0) / 100, 3)
+                        ELSE 0
+                      END,
+    tc.sgst_amount  = CASE
+                        WHEN COALESCE(mp.sgst_percent, 0) > 0
+                        THEN ROUND(
+                               tc.amount / (1 + (COALESCE(mp.cgst_percent,0) + COALESCE(mp.sgst_percent,0)) / 100)
+                               * COALESCE(mp.sgst_percent,0) / 100, 3)
+                        ELSE 0
+                      END
+WHERE tc.cgst_percent IS NULL;
+
+-- t_cashsales backfill
+UPDATE t_cashsales cs
+JOIN m_product mp ON mp.product_id = cs.product_id
+SET
+    cs.cgst_percent = COALESCE(mp.cgst_percent, 0),
+    cs.sgst_percent = COALESCE(mp.sgst_percent, 0),
+    cs.base_amount  = CASE
+                        WHEN COALESCE(mp.cgst_percent, 0) + COALESCE(mp.sgst_percent, 0) > 0
+                        THEN ROUND(cs.amount / (1 + (COALESCE(mp.cgst_percent,0) + COALESCE(mp.sgst_percent,0)) / 100), 3)
+                        ELSE cs.amount
+                      END,
+    cs.cgst_amount  = CASE
+                        WHEN COALESCE(mp.cgst_percent, 0) > 0
+                        THEN ROUND(
+                               cs.amount / (1 + (COALESCE(mp.cgst_percent,0) + COALESCE(mp.sgst_percent,0)) / 100)
+                               * COALESCE(mp.cgst_percent,0) / 100, 3)
+                        ELSE 0
+                      END,
+    cs.sgst_amount  = CASE
+                        WHEN COALESCE(mp.sgst_percent, 0) > 0
+                        THEN ROUND(
+                               cs.amount / (1 + (COALESCE(mp.cgst_percent,0) + COALESCE(mp.sgst_percent,0)) / 100)
+                               * COALESCE(mp.sgst_percent,0) / 100, 3)
+                        ELSE 0
+                      END
+WHERE cs.cgst_percent IS NULL;
+
+SET @disable_triggers = 0;
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SHOW TRIGGERS WHERE `Table` IN ('t_credits', 't_cashsales') AND Timing = 'BEFORE';
+
+SELECT 't_credits backfill' AS tbl,
+       SUM(CASE WHEN cgst_percent > 0 THEN 1 ELSE 0 END) AS gst_rows,
+       SUM(CASE WHEN cgst_percent = 0 THEN 1 ELSE 0 END) AS non_gst_rows
+FROM t_credits
+UNION ALL
+SELECT 't_cashsales backfill',
+       SUM(CASE WHEN cgst_percent > 0 THEN 1 ELSE 0 END),
+       SUM(CASE WHEN cgst_percent = 0 THEN 1 ELSE 0 END)
+FROM t_cashsales;

--- a/db/migrations/location-seed-oil-company-supplier.sql
+++ b/db/migrations/location-seed-oil-company-supplier.sql
@@ -1,0 +1,113 @@
+-- Migration: Auto-create oil company supplier + SOA bank when a location is created
+-- Extends trg_location_seed_data to INSERT into m_supplier and m_bank based on company_name.
+-- The after_supplier_insert_ledger_rule trigger on m_supplier fires automatically,
+-- so the ledger rule is created at no extra cost.
+--
+-- Oil company mapping (m_location.company_name → supplier_name / bank_name / template_id):
+--   IOCL   → Indian Oil Corporation Limited   | IOCL-SOA  | template_id=2 (IOCL SAP Account Statement)
+--   BPCL   → Bharat Petroleum Corporation Ltd | BPCL-SOA  | template_id=6 (BPCL SAP SOA Format)
+--   HPCL   → Hindustan Petroleum Corp Ltd     | HPCL-SOA  | template_id=NULL (no template yet)
+--   NAYARA → Nayara Energy Limited             | NAYARA-SOA| template_id=NULL (no template yet)
+
+DROP TRIGGER IF EXISTS trg_location_seed_data;
+
+DELIMITER $$
+
+CREATE TRIGGER trg_location_seed_data
+AFTER INSERT ON m_location
+FOR EACH ROW
+BEGIN
+    DECLARE v_supplier_id   INT;
+    DECLARE v_template_id   INT;
+    DECLARE v_bank_name     VARCHAR(150);
+    DECLARE v_supplier_name VARCHAR(200);
+
+    IF @disable_triggers IS NULL OR @disable_triggers = 0 THEN
+
+        -- Insert Petty Cash Expenses
+        INSERT INTO m_expense
+            (Expense_name, location_code, Expense_default_amt, created_by, updated_by, updation_date, creation_date)
+        VALUES
+            ('Tiffin',         NEW.location_code, 200, 'admin', 'admin', NOW(), NOW()),
+            ('Tea',            NEW.location_code,  30, 'admin', 'admin', NOW(), NOW()),
+            ('Bus Fare',       NEW.location_code,  30, 'admin', 'admin', NOW(), NOW()),
+            ('TT Driver Batta',NEW.location_code, 100, 'admin', 'admin', NOW(), NOW()),
+            ('Others',         NEW.location_code,   0, 'admin', 'admin', NOW(), NOW());
+
+        -- Insert Lookup defaults
+        INSERT INTO m_lookup
+            (lookup_type, description, tag, start_date_active, end_date_active,
+             attribute1, attribute2, attribute3, attribute4, attribute5,
+             created_by, updated_by, updation_date, creation_date, location_code, tally_export)
+        VALUES
+            ('CashFlow', 'To Bank',           'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Cashier A/C (+)',   'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Cashier A/C (-)',   'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Cash Receipt',      'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Collection',        'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Balance B/F',       'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Expense',           'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'To WithDrawals',    'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'To Deposits',       'IN',  '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Shift Opening',     'OUT', '2020-01-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'To Bank',           'OUT', '2024-06-01', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Shift Cash Return', 'IN',  '2025-04-08', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'N'),
+            ('CashFlow', 'Salary Payout',     'OUT', '2024-04-01', NULL, '200', NULL, NULL, NULL, 'SALARY EXPENSES', 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Salary Recovery',   'IN',  '2024-04-01', NULL, NULL, NULL, NULL, NULL, 'SALARY EXPENSES', 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y'),
+            ('CashFlow', 'Discount',          'OUT', '2025-10-30', NULL, NULL, NULL, NULL, NULL, NULL, 'admin', 'admin', NOW(), NOW(), NEW.location_code, 'Y');
+
+        -- Auto-create oil company supplier + SOA bank
+        -- The after_supplier_insert_ledger_rule trigger on m_supplier fires automatically.
+        IF NEW.company_name IN ('IOCL', 'BPCL', 'HPCL', 'NAYARA') THEN
+
+            SET v_supplier_name = CASE NEW.company_name
+                WHEN 'IOCL'   THEN 'Indian Oil Corporation Limited'
+                WHEN 'BPCL'   THEN 'Bharat Petroleum Corporation Limited'
+                WHEN 'HPCL'   THEN 'Hindustan Petroleum Corporation Limited'
+                WHEN 'NAYARA' THEN 'Nayara Energy Limited'
+            END;
+
+            SET v_bank_name = CASE NEW.company_name
+                WHEN 'IOCL'   THEN 'IOCL-SOA'
+                WHEN 'BPCL'   THEN 'BPCL-SOA'
+                WHEN 'HPCL'   THEN 'HPCL-SOA'
+                WHEN 'NAYARA' THEN 'NAYARA-SOA'
+            END;
+
+            -- template_id=2: IOCL SAP Account Statement
+            -- template_id=6: BPCL SAP SOA Format
+            SET v_template_id = CASE NEW.company_name
+                WHEN 'IOCL'   THEN 2
+                WHEN 'BPCL'   THEN 6
+                ELSE NULL
+            END;
+
+            INSERT INTO m_supplier
+                (supplier_name, supplier_short_name, location_id, location_code,
+                 created_by, updated_by, creation_date, updation_date)
+            VALUES (
+                v_supplier_name,
+                NEW.company_name,
+                NEW.location_id,
+                NEW.location_code,
+                'system', 'system', NOW(), NOW()
+            );
+
+            SET v_supplier_id = LAST_INSERT_ID();
+
+            INSERT INTO m_bank
+                (bank_name, bank_branch, account_number, ifsc_code,
+                 location_code, location_id, is_oil_company, active_flag, internal_flag,
+                 template_id, supplier_id, created_by, updated_by)
+            VALUES (
+                v_bank_name, 'N/A', 'N/A', 'N/A',
+                NEW.location_code, NEW.location_id, 'Y', 'Y', 'N',
+                v_template_id, v_supplier_id, 'system', 'system'
+            );
+
+        END IF;
+
+    END IF;
+END$$
+
+DELIMITER ;

--- a/db/product.js
+++ b/db/product.js
@@ -50,6 +50,10 @@ module.exports = function(sequelize, DataTypes) {
             type: DataTypes.STRING(100),
             allowNull: true
         },
+        purchase_ledger_name: {
+            type: DataTypes.STRING(100),
+            allowNull: true
+        },
         cgst_percent: {
             type: DataTypes.DECIMAL(5, 2),
             allowNull: true

--- a/db/ui-db-field-mapping.js
+++ b/db/ui-db-field-mapping.js
@@ -15,6 +15,7 @@ module.exports = {
         unit: req.body.m_product_unit_0,
         price: req.body.m_product_price_0,
         ledger_name: req.body.m_product_ledger_name_0,
+        purchase_ledger_name: req.body.m_product_purchase_ledger_name_0,
         cgst_percent: req.body.m_product_cgst_0,
         sgst_percent: req.body.m_product_sgst_0,
         sku_name: req.body.m_product_sku_name_0,

--- a/public/javascripts/app-report-date.js
+++ b/public/javascripts/app-report-date.js
@@ -178,10 +178,13 @@ function updateInvoiceDateRange() {
 // ── GL date range helpers ────────────────────────────────────────────────────
 // Used by GL report pages — pre-fills from/to date inputs without hiding them.
 
-function glSetPeriod(fromId, toId, selectId) {
-    const sel = selectId || 'glPeriod';
-    const period = document.getElementById(sel) ? document.getElementById(sel).value : 'custom';
-    const today = new Date();
+// glSetPeriod(sel) — called via onchange="glSetPeriod(this)"
+// The select must have data-from and data-to attributes with the target input IDs.
+function glSetPeriod(sel) {
+    const period = sel.value;
+    const fromId = sel.dataset.from;
+    const toId   = sel.dataset.to;
+    const today  = new Date();
     const yr = today.getFullYear();
     const mo = today.getMonth();
 
@@ -208,18 +211,19 @@ function glSetPeriod(fromId, toId, selectId) {
             to   = new Date(yr, 2, 31);
         }
     } else {
-        return; // custom — user enters manually
+        return;
     }
 
     if (fromId) document.getElementById(fromId).value = iso(from);
     if (toId)   document.getElementById(toId).value   = iso(to);
 }
 
-// For single-date views (Trial Balance, Balance Sheet)
-function glSetAsOf(asOfId, selectId) {
-    const sel = selectId || 'glPeriodAsOf';
-    const period = document.getElementById(sel) ? document.getElementById(sel).value : 'custom';
-    const today = new Date();
+// glSetAsOf(sel) — for single-date views (Trial Balance, Balance Sheet)
+// The select must have a data-target attribute with the target input ID.
+function glSetAsOf(sel) {
+    const period = sel.value;
+    const asOfId = sel.dataset.target;
+    const today  = new Date();
     const yr = today.getFullYear();
     const mo = today.getMonth();
 

--- a/public/javascripts/app-report-date.js
+++ b/public/javascripts/app-report-date.js
@@ -174,3 +174,71 @@ function updateInvoiceDateRange() {
         toDateLabel.closest('td').style.display = 'none';
     }
 }
+
+// ── GL date range helpers ────────────────────────────────────────────────────
+// Used by GL report pages — pre-fills from/to date inputs without hiding them.
+
+function glSetPeriod(fromId, toId, selectId) {
+    const sel = selectId || 'glPeriod';
+    const period = document.getElementById(sel) ? document.getElementById(sel).value : 'custom';
+    const today = new Date();
+    const yr = today.getFullYear();
+    const mo = today.getMonth();
+
+    function iso(d) {
+        return new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate())).toISOString().split('T')[0];
+    }
+
+    let from, to;
+    if (period === 'this_month') {
+        from = new Date(yr, mo, 1);
+        to   = today;
+    } else if (period === 'last_month') {
+        from = new Date(yr, mo - 1, 1);
+        to   = new Date(yr, mo, 0);
+    } else if (period === 'this_fy') {
+        from = mo < 3 ? new Date(yr - 1, 3, 1) : new Date(yr, 3, 1);
+        to   = today;
+    } else if (period === 'last_fy') {
+        if (mo < 3) {
+            from = new Date(yr - 2, 3, 1);
+            to   = new Date(yr - 1, 2, 31);
+        } else {
+            from = new Date(yr - 1, 3, 1);
+            to   = new Date(yr, 2, 31);
+        }
+    } else {
+        return; // custom — user enters manually
+    }
+
+    if (fromId) document.getElementById(fromId).value = iso(from);
+    if (toId)   document.getElementById(toId).value   = iso(to);
+}
+
+// For single-date views (Trial Balance, Balance Sheet)
+function glSetAsOf(asOfId, selectId) {
+    const sel = selectId || 'glPeriodAsOf';
+    const period = document.getElementById(sel) ? document.getElementById(sel).value : 'custom';
+    const today = new Date();
+    const yr = today.getFullYear();
+    const mo = today.getMonth();
+
+    function iso(d) {
+        return new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate())).toISOString().split('T')[0];
+    }
+
+    let dt;
+    if (period === 'today') {
+        dt = today;
+    } else if (period === 'end_last_month') {
+        dt = new Date(yr, mo, 0);
+    } else if (period === 'end_this_fy') {
+        dt = mo < 3 ? new Date(yr, 2, 31) : new Date(yr + 1, 2, 31);
+    } else if (period === 'end_last_fy') {
+        dt = mo < 3 ? new Date(yr - 1, 2, 31) : new Date(yr, 2, 31);
+    } else {
+        return;
+    }
+
+    if (asOfId) document.getElementById(asOfId).value = iso(dt);
+}

--- a/routes/dev-db-refresh-routes.js
+++ b/routes/dev-db-refresh-routes.js
@@ -1,0 +1,133 @@
+// routes/dev-db-refresh-routes.js
+// Dev-only: control the 4-hourly DB refresh from S3.
+// Only functional when /home/ubuntu/refresh_dev_from_s3.sh exists on the server.
+
+const express  = require('express');
+const router   = express.Router();
+const login    = require('connect-ensure-login');
+const security = require('../utils/app-security');
+const db       = require('../db/db-connection');
+const fs       = require('fs');
+const { exec, execFile } = require('child_process');
+
+const isLoginEnsured = login.ensureLoggedIn({});
+
+const SCRIPT_PATH = '/home/ubuntu/refresh_dev_from_s3.sh';
+const PAUSE_FILE   = '/home/ubuntu/.dev_refresh_paused';
+const LOG_FILE     = '/home/ubuntu/logs/dev_refresh_s3.log';
+
+function isDevEnv() {
+    return fs.existsSync(SCRIPT_PATH);
+}
+
+// GET /dev-db-refresh
+router.get('/', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    if (!isDevEnv()) {
+        return res.status(404).send('Not available in this environment.');
+    }
+
+    let lastRefresh = null;
+    try {
+        const rows = await db.sequelize.query(
+            `SELECT backup_filename, backup_taken_at, restored_at, s3_location
+             FROM _dev_backup_info ORDER BY restored_at DESC LIMIT 1`,
+            { type: db.Sequelize.QueryTypes.SELECT }
+        );
+        lastRefresh = rows[0] || null;
+    } catch (e) { /* table may not exist yet */ }
+
+    const isPaused  = fs.existsSync(PAUSE_FILE);
+    const isRunning = await checkRunning();
+
+    let logTail = '';
+    try {
+        const lines = fs.readFileSync(LOG_FILE, 'utf8').split('\n');
+        logTail = lines.slice(-50).join('\n');
+    } catch (e) { /* log not yet created */ }
+
+    res.render('dev-db-refresh', {
+        title:       'Dev DB Refresh Control',
+        user:        req.user,
+        config:      require('../config/app-config').APP_CONFIGS,
+        lastRefresh,
+        isPaused,
+        isRunning,
+        logTail,
+        messages:    req.flash()
+    });
+});
+
+// POST /dev-db-refresh/pause
+router.post('/pause', [isLoginEnsured, security.isAdmin()], function(req, res) {
+    if (!isDevEnv()) return res.status(404).json({ error: 'Not available' });
+    try {
+        fs.writeFileSync(PAUSE_FILE, new Date().toISOString());
+        res.json({ success: true, paused: true });
+    } catch (e) {
+        res.status(500).json({ success: false, error: e.message });
+    }
+});
+
+// POST /dev-db-refresh/resume
+router.post('/resume', [isLoginEnsured, security.isAdmin()], function(req, res) {
+    if (!isDevEnv()) return res.status(404).json({ error: 'Not available' });
+    try {
+        if (fs.existsSync(PAUSE_FILE)) fs.unlinkSync(PAUSE_FILE);
+        res.json({ success: true, paused: false });
+    } catch (e) {
+        res.status(500).json({ success: false, error: e.message });
+    }
+});
+
+// POST /dev-db-refresh/run-now
+// Spawns the refresh script in the background and returns immediately.
+// WARNING: drops and recreates the dev DB — app DB connections will blip.
+router.post('/run-now', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    if (!isDevEnv()) return res.status(404).json({ error: 'Not available' });
+
+    const running = await checkRunning();
+    if (running) return res.status(409).json({ error: 'Refresh is already running' });
+
+    if (fs.existsSync(PAUSE_FILE)) fs.unlinkSync(PAUSE_FILE);
+
+    exec(`bash ${SCRIPT_PATH} >> ${LOG_FILE} 2>&1 &`, (err) => {
+        if (err) console.error('Dev refresh spawn error:', err);
+    });
+
+    res.json({ success: true, message: 'Refresh started in background' });
+});
+
+// GET /dev-db-refresh/status — AJAX poll
+router.get('/status', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    if (!isDevEnv()) return res.json({ available: false });
+
+    let lastRefresh = null;
+    try {
+        const rows = await db.sequelize.query(
+            `SELECT backup_filename, backup_taken_at, restored_at FROM _dev_backup_info ORDER BY restored_at DESC LIMIT 1`,
+            { type: db.Sequelize.QueryTypes.SELECT }
+        );
+        lastRefresh = rows[0] || null;
+    } catch (e) { /* ok */ }
+
+    const isPaused  = fs.existsSync(PAUSE_FILE);
+    const isRunning = await checkRunning();
+
+    let logTail = '';
+    try {
+        const lines = fs.readFileSync(LOG_FILE, 'utf8').split('\n');
+        logTail = lines.filter(l => l.trim()).slice(-30).join('\n');
+    } catch (e) { /* ok */ }
+
+    res.json({ available: true, isPaused, isRunning, lastRefresh, logTail });
+});
+
+function checkRunning() {
+    return new Promise((resolve) => {
+        exec('pgrep -f refresh_dev_from_s3.sh', (err, stdout) => {
+            resolve(!!stdout.trim());
+        });
+    });
+}
+
+module.exports = router;

--- a/routes/dev-db-refresh-routes.js
+++ b/routes/dev-db-refresh-routes.js
@@ -124,7 +124,9 @@ router.get('/status', [isLoginEnsured, security.isAdmin()], async function(req, 
 
 function checkRunning() {
     return new Promise((resolve) => {
-        exec('pgrep -f refresh_dev_from_s3.sh', (err, stdout) => {
+        // Use -x with bash to match only actual bash processes running the script,
+        // excluding pgrep itself and the node process checking for it.
+        exec("pgrep -f 'bash.*refresh_dev_from_s3\\.sh'", (err, stdout) => {
             resolve(!!stdout.trim());
         });
     });

--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -79,11 +79,11 @@ router.post('/api/create-accounting', [isLoginEnsured, security.isAdmin()], asyn
     }
 });
 
-// GET /gl/api/accounting-events?from_date=&to_date=&status=
+// GET /gl/api/accounting-events?from_date=&to_date=&status=&source_type=&search=
 // Returns event queue for a date range — used by admin dashboard.
 router.get('/api/accounting-events', [isLoginEnsured, security.isAdmin()], async function(req, res) {
     const locationCode = req.user.location_code;
-    const { from_date, to_date, status } = req.query;
+    const { from_date, to_date, status, source_type, search } = req.query;
 
     try {
         const rows = await db.sequelize.query(`
@@ -93,21 +93,30 @@ router.get('/api/accounting-events', [isLoginEnsured, security.isAdmin()], async
                 e.processed_at, e.processed_by, e.voucher_id
             FROM gl_accounting_events e
             WHERE e.location_code = :locationCode
-              AND (:from_date IS NULL OR e.event_date >= :from_date)
-              AND (:to_date   IS NULL OR e.event_date <= :to_date)
-              AND (:status    IS NULL OR e.event_status = :status)
+              AND (:from_date   IS NULL OR e.event_date   >= :from_date)
+              AND (:to_date     IS NULL OR e.event_date   <= :to_date)
+              AND (:status      IS NULL OR e.event_status  = :status)
+              AND (:source_type IS NULL OR e.source_type   = :source_type)
+              AND (:search      IS NULL OR e.source_id     LIKE :searchLike
+                                       OR e.error_message  LIKE :searchLike
+                                       OR e.processed_by   LIKE :searchLike)
             ORDER BY e.event_date DESC, e.event_id DESC
-            LIMIT 500
+            LIMIT 2001
         `, {
             replacements: {
                 locationCode,
-                from_date: from_date || null,
-                to_date:   to_date   || null,
-                status:    status    || null
+                from_date:   from_date   || null,
+                to_date:     to_date     || null,
+                status:      status      || null,
+                source_type: source_type || null,
+                search:      search      || null,
+                searchLike:  search      ? `%${search}%` : null
             },
             type: db.Sequelize.QueryTypes.SELECT
         });
-        res.json(rows);
+        const hasMore = rows.length > 2000;
+        if (hasMore) rows.splice(2000);
+        res.json({ rows, hasMore });
     } catch (err) {
         console.error('Accounting events fetch error:', err);
         res.status(500).json({ error: err.message });

--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -6,6 +6,7 @@ const isLoginEnsured = login.ensureLoggedIn({});
 const security = require('../utils/app-security');
 const db = require('../db/db-connection');
 const createAccountingService = require('../services/create-accounting-service');
+const glBatchService = require('../services/gl-batch-service');
 
 // GET /gl/api/ledgers/search?location=&group=&q=
 // Returns [{ledger_id, ledger_name}] — used by Select2 ajax typeahead on product ledger fields
@@ -43,24 +44,35 @@ router.get('/api/ledgers/search', [isLoginEnsured, security.isAdmin()], async fu
 });
 
 // POST /gl/api/create-accounting
-// Body: { from_date, to_date }
-// Runs Create Accounting for the location and date range.
+// Body: { from_date, to_date, reprocess }
+// Runs Create Accounting wrapped in a gl_batch_requests record.
 router.post('/api/create-accounting', [isLoginEnsured, security.isAdmin()], async function(req, res) {
     const locationCode = req.user.location_code;
-    const processedBy  = req.user.username;
+    const processedBy  = req.user.username || String(req.user.Person_id);
     const { from_date, to_date, reprocess } = req.body;
 
     if (!from_date || !to_date) {
         return res.status(400).json({ error: 'from_date and to_date are required' });
     }
 
-    try {
-        const fn = reprocess === true || reprocess === 'true'
-            ? createAccountingService.reprocessEvents
-            : createAccountingService.processEvents;
+    const isReprocess = reprocess === true || reprocess === 'true';
+    const requestType = isReprocess ? 'REPROCESS_ACCOUNTING' : 'CREATE_ACCOUNTING';
 
-        const summary = await fn(locationCode, from_date, to_date, processedBy);
-        res.json({ success: true, summary });
+    try {
+        const requestId = await glBatchService.submitRequest(
+            requestType, locationCode, from_date, to_date,
+            isReprocess ? { reprocess: true } : null,
+            processedBy
+        );
+
+        const { summary } = await glBatchService.runRequest(requestId, locationCode, async (logger) => {
+            const fn = isReprocess
+                ? createAccountingService.reprocessEvents
+                : createAccountingService.processEvents;
+            return fn(locationCode, from_date, to_date, processedBy, logger);
+        });
+
+        res.json({ success: true, summary, request_id: requestId });
     } catch (err) {
         console.error('Create Accounting error:', err);
         res.status(500).json({ error: err.message });
@@ -998,17 +1010,34 @@ router.put('/api/ledger/:id', [isLoginEnsured, security.isAdmin()], async functi
 // ── GL Control ────────────────────────────────────────────────────────────────
 // GET /gl/control — admin dashboard: events monitor + create accounting + generate events
 
-router.get('/control', [isLoginEnsured, security.isAdmin()], function(req, res) {
-    const today = new Date().toISOString().substring(0, 10);
+router.get('/control', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const today    = new Date().toISOString().substring(0, 10);
     const fromDate = today.substring(0, 8) + '01';
-    res.render('gl-control', {
-        title:    'GL Control',
-        user:     req.user,
-        config:   require('../config/app-config').APP_CONFIGS,
-        fromDate,
-        toDate:   today,
-        messages: req.flash()
-    });
+    try {
+        await glBatchService.recoverStaleRequests(locationCode);
+        const recentRequests = await glBatchService.getRecentRequests(locationCode, 10);
+        res.render('gl-control', {
+            title:    'GL Control',
+            user:     req.user,
+            config:   require('../config/app-config').APP_CONFIGS,
+            fromDate,
+            toDate:   today,
+            recentRequests,
+            messages: req.flash()
+        });
+    } catch (err) {
+        console.error('GL Control error:', err);
+        res.render('gl-control', {
+            title:    'GL Control',
+            user:     req.user,
+            config:   require('../config/app-config').APP_CONFIGS,
+            fromDate,
+            toDate:   today,
+            recentRequests: [],
+            messages: req.flash()
+        });
+    }
 });
 
 // GET /gl/api/event-summary?from_date=&to_date=
@@ -1084,7 +1113,7 @@ router.post('/api/retry-event/:id', [isLoginEnsured, security.isAdmin()], async 
     }
 });
 
-// POST /gl/api/generate-events — backfill missing events for date range
+// POST /gl/api/generate-events — backfill missing events wrapped in a batch request record
 router.post('/api/generate-events', [isLoginEnsured, security.isAdmin()], async function(req, res) {
     const locationCode = req.user.location_code;
     const createdBy    = req.user.username || String(req.user.Person_id);
@@ -1095,11 +1124,42 @@ router.post('/api/generate-events', [isLoginEnsured, security.isAdmin()], async 
     }
 
     try {
-        const result = await createAccountingService.generateMissingEvents(locationCode, from_date, to_date, createdBy);
-        res.json({ success: true, ...result });
+        const requestId = await glBatchService.submitRequest(
+            'GENERATE_EVENTS', locationCode, from_date, to_date, null, createdBy
+        );
+
+        const { summary: result } = await glBatchService.runRequest(requestId, locationCode, async (logger) => {
+            return createAccountingService.generateMissingEvents(locationCode, from_date, to_date, createdBy, logger);
+        });
+
+        res.json({ success: true, ...result, request_id: requestId });
     } catch (err) {
         console.error('Generate events error:', err);
         res.status(500).json({ success: false, error: err.message });
+    }
+});
+
+// GET /gl/api/batch-requests — recent batch requests for this location
+router.get('/api/batch-requests', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    try {
+        const requests = await glBatchService.getRecentRequests(locationCode, 20);
+        res.json(requests);
+    } catch (err) {
+        res.status(500).json({ error: err.message });
+    }
+});
+
+// GET /gl/api/batch-requests/:id/log — full log for a single request
+router.get('/api/batch-requests/:id/log', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const requestId    = parseInt(req.params.id);
+    try {
+        const row = await glBatchService.getRequestLog(requestId, locationCode);
+        if (!row) return res.status(404).json({ error: 'Request not found' });
+        res.json(row);
+    } catch (err) {
+        res.status(500).json({ error: err.message });
     }
 });
 

--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -1122,6 +1122,43 @@ router.post('/api/retry-event/:id', [isLoginEnsured, security.isAdmin()], async 
     }
 });
 
+// POST /gl/api/retry-events — bulk reset ERROR events back to UNPROCESSED
+router.post('/api/retry-events', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const { event_ids } = req.body;
+
+    if (!Array.isArray(event_ids) || !event_ids.length) {
+        return res.status(400).json({ success: false, error: 'event_ids array required' });
+    }
+
+    const ids = event_ids.map(id => parseInt(id)).filter(id => !isNaN(id));
+    if (!ids.length) {
+        return res.status(400).json({ success: false, error: 'No valid event IDs provided' });
+    }
+
+    try {
+        const placeholders = ids.map((_, i) => `:id${i}`).join(', ');
+        const replacements = { locationCode };
+        ids.forEach((id, i) => { replacements[`id${i}`] = id; });
+
+        const [, meta] = await db.sequelize.query(`
+            UPDATE gl_accounting_events
+            SET event_status  = 'UNPROCESSED',
+                error_message = NULL,
+                processed_at  = NULL,
+                processed_by  = NULL
+            WHERE event_id      IN (${placeholders})
+              AND location_code = :locationCode
+              AND event_status  = 'ERROR'
+        `, { replacements, type: db.Sequelize.QueryTypes.UPDATE });
+
+        res.json({ success: true, updated: meta?.affectedRows || 0 });
+    } catch (err) {
+        console.error('Bulk retry events error:', err);
+        res.status(500).json({ success: false, error: err.message });
+    }
+});
+
 // POST /gl/api/generate-events — backfill missing events wrapped in a batch request record
 router.post('/api/generate-events', [isLoginEnsured, security.isAdmin()], async function(req, res) {
     const locationCode = req.user.location_code;

--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -5,6 +5,7 @@ const login = require('connect-ensure-login');
 const isLoginEnsured = login.ensureLoggedIn({});
 const security = require('../utils/app-security');
 const db = require('../db/db-connection');
+const createAccountingService = require('../services/create-accounting-service');
 
 // GET /gl/api/ledgers/search?location=&group=&q=
 // Returns [{ledger_id, ledger_name}] — used by Select2 ajax typeahead on product ledger fields
@@ -38,6 +39,898 @@ router.get('/api/ledgers/search', [isLoginEnsured, security.isAdmin()], async fu
     } catch (error) {
         console.error('Error searching ledgers:', error);
         res.status(500).json({ error: 'Failed to search ledgers' });
+    }
+});
+
+// POST /gl/api/create-accounting
+// Body: { from_date, to_date }
+// Runs Create Accounting for the location and date range.
+router.post('/api/create-accounting', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const processedBy  = req.user.username;
+    const { from_date, to_date, reprocess } = req.body;
+
+    if (!from_date || !to_date) {
+        return res.status(400).json({ error: 'from_date and to_date are required' });
+    }
+
+    try {
+        const fn = reprocess === true || reprocess === 'true'
+            ? createAccountingService.reprocessEvents
+            : createAccountingService.processEvents;
+
+        const summary = await fn(locationCode, from_date, to_date, processedBy);
+        res.json({ success: true, summary });
+    } catch (err) {
+        console.error('Create Accounting error:', err);
+        res.status(500).json({ error: err.message });
+    }
+});
+
+// GET /gl/api/accounting-events?from_date=&to_date=&status=
+// Returns event queue for a date range — used by admin dashboard.
+router.get('/api/accounting-events', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const { from_date, to_date, status } = req.query;
+
+    try {
+        const rows = await db.sequelize.query(`
+            SELECT
+                e.event_id, e.source_type, e.source_id, e.event_type,
+                e.event_status, e.event_date, e.error_message,
+                e.processed_at, e.processed_by, e.voucher_id
+            FROM gl_accounting_events e
+            WHERE e.location_code = :locationCode
+              AND (:from_date IS NULL OR e.event_date >= :from_date)
+              AND (:to_date   IS NULL OR e.event_date <= :to_date)
+              AND (:status    IS NULL OR e.event_status = :status)
+            ORDER BY e.event_date DESC, e.event_id DESC
+            LIMIT 500
+        `, {
+            replacements: {
+                locationCode,
+                from_date: from_date || null,
+                to_date:   to_date   || null,
+                status:    status    || null
+            },
+            type: db.Sequelize.QueryTypes.SELECT
+        });
+        res.json(rows);
+    } catch (err) {
+        console.error('Accounting events fetch error:', err);
+        res.status(500).json({ error: err.message });
+    }
+});
+
+// ── Day Book ──────────────────────────────────────────────────────────────────
+// GET /gl/day-book?from_date=&to_date=&voucher_type=
+
+const VOUCHER_TYPES = ['SALES', 'PURCHASE', 'PAYMENT', 'RECEIPT', 'JOURNAL', 'CONTRA'];
+
+router.get('/day-book', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const today    = new Date().toISOString().substring(0, 10);
+    const fromDate = req.query.from_date    || today;
+    const toDate   = req.query.to_date      || today;
+    const selectedType = req.query.voucher_type || null;
+
+    try {
+        const rows = await db.sequelize.query(`
+            SELECT
+                h.voucher_id,
+                DATE_FORMAT(h.voucher_date, '%d-%b-%Y') AS voucher_date,
+                h.voucher_no,
+                h.voucher_type,
+                h.narration,
+                h.source_type,
+                h.is_reversal,
+                l.line_no,
+                gl.ledger_name,
+                l.dr_amount,
+                l.cr_amount,
+                l.narration AS line_narration
+            FROM gl_journal_headers h
+            JOIN gl_journal_lines l  ON l.voucher_id = h.voucher_id
+            JOIN gl_ledgers gl       ON gl.ledger_id  = l.ledger_id
+            WHERE h.location_code = :locationCode
+              AND h.voucher_date  BETWEEN :fromDate AND :toDate
+              AND (:selectedType IS NULL OR h.voucher_type = :selectedType)
+            ORDER BY h.voucher_date, h.voucher_id, l.line_no
+        `, {
+            replacements: { locationCode, fromDate, toDate, selectedType },
+            type: db.Sequelize.QueryTypes.SELECT
+        });
+
+        // Group lines under their voucher header
+        const voucherMap = new Map();
+        for (const row of rows) {
+            if (!voucherMap.has(row.voucher_id)) {
+                voucherMap.set(row.voucher_id, {
+                    voucher_id:   row.voucher_id,
+                    voucher_date: row.voucher_date,
+                    voucher_no:   row.voucher_no,
+                    voucher_type: row.voucher_type,
+                    narration:    row.narration,
+                    source_type:  row.source_type,
+                    is_reversal:  row.is_reversal,
+                    total_dr:     0,
+                    total_cr:     0,
+                    lines:        []
+                });
+            }
+            const v    = voucherMap.get(row.voucher_id);
+            const dr   = parseFloat(row.dr_amount || 0);
+            const cr   = parseFloat(row.cr_amount || 0);
+            v.total_dr += dr;
+            v.total_cr += cr;
+            v.lines.push({ line_no: row.line_no, ledger_name: row.ledger_name, dr_amount: dr, cr_amount: cr });
+        }
+
+        const vouchers      = [...voucherMap.values()];
+        const grandTotalDr  = vouchers.reduce((s, v) => s + v.total_dr, 0);
+        const grandTotalCr  = vouchers.reduce((s, v) => s + v.total_cr, 0);
+
+        res.render('gl-day-book', {
+            title:       'Day Book',
+            user:        req.user,
+            config:      require('../config/app-config').APP_CONFIGS,
+            fromDate,
+            toDate,
+            selectedType,
+            vouchers,
+            grandTotalDr,
+            grandTotalCr,
+            VOUCHER_TYPES
+        });
+    } catch (err) {
+        console.error('Day Book error:', err);
+        req.flash('error', 'Failed to load Day Book: ' + err.message);
+        res.redirect('/home');
+    }
+});
+
+// ── Ledger Report ─────────────────────────────────────────────────────────────
+// GET /gl/ledger?ledger_id=&from_date=&to_date=
+
+router.get('/ledger', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const today    = new Date().toISOString().substring(0, 10);
+    const fromDate = req.query.from_date || today;
+    const toDate   = req.query.to_date   || today;
+    const ledgerId = req.query.ledger_id ? parseInt(req.query.ledger_id) : null;
+
+    let ledger = null, entries = [], obNet = 0, periodDr = 0, periodCr = 0;
+
+    try {
+        if (ledgerId) {
+            // Fetch ledger meta
+            const ledgerRows = await db.sequelize.query(`
+                SELECT l.ledger_id, l.ledger_name, g.group_name, g.group_nature
+                FROM gl_ledgers l
+                JOIN gl_ledger_groups g ON g.group_id = l.group_id
+                WHERE l.ledger_id = :ledgerId AND l.location_code = :locationCode
+            `, { replacements: { ledgerId, locationCode }, type: db.Sequelize.QueryTypes.SELECT });
+
+            if (!ledgerRows.length) throw new Error(`Ledger not found: ${ledgerId}`);
+            ledger = ledgerRows[0];
+
+            // Opening balance = all entries before fromDate
+            const obRows = await db.sequelize.query(`
+                SELECT
+                    COALESCE(SUM(l.dr_amount), 0) AS ob_dr,
+                    COALESCE(SUM(l.cr_amount), 0) AS ob_cr
+                FROM gl_journal_lines l
+                JOIN gl_journal_headers h ON h.voucher_id = l.voucher_id
+                WHERE l.ledger_id      = :ledgerId
+                  AND h.location_code  = :locationCode
+                  AND h.voucher_date   < :fromDate
+            `, { replacements: { ledgerId, locationCode, fromDate }, type: db.Sequelize.QueryTypes.SELECT });
+
+            obNet = parseFloat(obRows[0].ob_dr) - parseFloat(obRows[0].ob_cr);
+
+            // Period entries
+            const rows = await db.sequelize.query(`
+                SELECT
+                    DATE_FORMAT(h.voucher_date, '%d-%b-%Y') AS voucher_date,
+                    h.voucher_no,
+                    h.voucher_type,
+                    h.is_reversal,
+                    COALESCE(l.narration, h.narration) AS narration,
+                    l.dr_amount,
+                    l.cr_amount
+                FROM gl_journal_lines l
+                JOIN gl_journal_headers h ON h.voucher_id = l.voucher_id
+                WHERE l.ledger_id     = :ledgerId
+                  AND h.location_code = :locationCode
+                  AND h.voucher_date  BETWEEN :fromDate AND :toDate
+                ORDER BY h.voucher_date, h.voucher_id, l.line_no
+            `, { replacements: { ledgerId, locationCode, fromDate, toDate }, type: db.Sequelize.QueryTypes.SELECT });
+
+            // Compute running balance
+            let running = obNet;
+            for (const row of rows) {
+                const dr  = parseFloat(row.dr_amount || 0);
+                const cr  = parseFloat(row.cr_amount || 0);
+                running  += dr - cr;
+                periodDr += dr;
+                periodCr += cr;
+                entries.push({
+                    voucher_date: row.voucher_date,
+                    voucher_no:   row.voucher_no,
+                    voucher_type: row.voucher_type,
+                    is_reversal:  row.is_reversal,
+                    narration:    row.narration,
+                    dr_amount:    dr,
+                    cr_amount:    cr,
+                    balance:      running
+                });
+            }
+        }
+
+        res.render('gl-ledger-report', {
+            title:       'Ledger Report',
+            user:        req.user,
+            config:      require('../config/app-config').APP_CONFIGS,
+            fromDate,
+            toDate,
+            ledgerId,
+            ledger,
+            obNet,
+            entries,
+            periodDr,
+            periodCr,
+            closingBalance: obNet + periodDr - periodCr,
+            VOUCHER_TYPES
+        });
+    } catch (err) {
+        console.error('Ledger report error:', err);
+        req.flash('error', 'Failed to load Ledger Report: ' + err.message);
+        res.redirect('/gl/day-book');
+    }
+});
+
+// ── Trial Balance ─────────────────────────────────────────────────────────────
+// GET /gl/trial-balance?as_of_date=&show_zero=1
+
+const NATURE_ORDER = { ASSETS: 1, LIABILITIES: 2, INCOME: 3, EXPENSES: 4 };
+
+router.get('/trial-balance', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const today     = new Date().toISOString().substring(0, 10);
+    const asOfDate  = req.query.as_of_date || today;
+    const showZero  = req.query.show_zero === '1';
+
+    try {
+        const rows = await db.sequelize.query(`
+            SELECT
+                g.group_name,
+                g.group_nature,
+                l.ledger_id,
+                l.ledger_name,
+                COALESCE(b.total_dr, 0) AS total_dr,
+                COALESCE(b.total_cr, 0) AS total_cr
+            FROM gl_ledgers l
+            JOIN gl_ledger_groups g ON g.group_id = l.group_id
+            LEFT JOIN (
+                SELECT jl.ledger_id,
+                       SUM(jl.dr_amount) AS total_dr,
+                       SUM(jl.cr_amount) AS total_cr
+                FROM gl_journal_lines jl
+                JOIN gl_journal_headers jh ON jh.voucher_id = jl.voucher_id
+                WHERE jh.location_code = :locationCode
+                  AND jh.voucher_date  <= :asOfDate
+                GROUP BY jl.ledger_id
+            ) b ON b.ledger_id = l.ledger_id
+            WHERE l.location_code = :locationCode
+              AND l.active_flag   = 'Y'
+            ORDER BY
+                FIELD(g.group_nature, 'ASSETS', 'LIABILITIES', 'INCOME', 'EXPENSES'),
+                g.group_name,
+                l.ledger_name
+        `, { replacements: { locationCode, asOfDate }, type: db.Sequelize.QueryTypes.SELECT });
+
+        // Group ledgers and compute net DR/CR balance per ledger
+        const groupMap = new Map();
+        let grandDr = 0, grandCr = 0;
+
+        for (const row of rows) {
+            const net   = parseFloat(row.total_dr) - parseFloat(row.total_cr);
+            const drBal = net > 0 ?  net : 0;
+            const crBal = net < 0 ? -net : 0;
+
+            if (!showZero && drBal === 0 && crBal === 0) continue;
+
+            if (!groupMap.has(row.group_name)) {
+                groupMap.set(row.group_name, {
+                    group_name:   row.group_name,
+                    group_nature: row.group_nature,
+                    rows:         [],
+                    subtotal_dr:  0,
+                    subtotal_cr:  0
+                });
+            }
+            const g = groupMap.get(row.group_name);
+            g.rows.push({ ledger_id: row.ledger_id, ledger_name: row.ledger_name, dr_balance: drBal, cr_balance: crBal });
+            g.subtotal_dr += drBal;
+            g.subtotal_cr += crBal;
+            grandDr       += drBal;
+            grandCr       += crBal;
+        }
+
+        // Sort groups by nature order
+        const groups = [...groupMap.values()].sort((a, b) =>
+            (NATURE_ORDER[a.group_nature] || 9) - (NATURE_ORDER[b.group_nature] || 9)
+        );
+
+        res.render('gl-trial-balance', {
+            title:      'Trial Balance',
+            user:       req.user,
+            config:     require('../config/app-config').APP_CONFIGS,
+            asOfDate,
+            showZero,
+            groups,
+            grandDr,
+            grandCr,
+            isBalanced: Math.abs(grandDr - grandCr) < 0.01
+        });
+    } catch (err) {
+        console.error('Trial Balance error:', err);
+        req.flash('error', 'Failed to load Trial Balance: ' + err.message);
+        res.redirect('/gl/day-book');
+    }
+});
+
+// ── Profit & Loss ─────────────────────────────────────────────────────────────
+// GET /gl/profit-loss?from_date=&to_date=
+
+router.get('/profit-loss', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const today  = new Date();
+    const fyYear = today.getMonth() >= 3 ? today.getFullYear() : today.getFullYear() - 1;
+    const fromDate = req.query.from_date || `${fyYear}-04-01`;
+    const toDate   = req.query.to_date   || `${fyYear + 1}-03-31`;
+
+    try {
+        const rows = await db.sequelize.query(`
+            SELECT
+                g.group_name,
+                g.group_nature,
+                l.ledger_id,
+                l.ledger_name,
+                COALESCE(b.total_dr, 0) AS total_dr,
+                COALESCE(b.total_cr, 0) AS total_cr
+            FROM gl_ledgers l
+            JOIN gl_ledger_groups g ON g.group_id = l.group_id
+            LEFT JOIN (
+                SELECT jl.ledger_id,
+                       SUM(jl.dr_amount) AS total_dr,
+                       SUM(jl.cr_amount) AS total_cr
+                FROM gl_journal_lines jl
+                JOIN gl_journal_headers jh ON jh.voucher_id = jl.voucher_id
+                WHERE jh.location_code = :locationCode
+                  AND jh.voucher_date  BETWEEN :fromDate AND :toDate
+                GROUP BY jl.ledger_id
+            ) b ON b.ledger_id = l.ledger_id
+            WHERE l.location_code = :locationCode
+              AND l.active_flag   = 'Y'
+              AND g.group_nature  IN ('INCOME', 'EXPENSES')
+              AND (b.total_dr IS NOT NULL OR b.total_cr IS NOT NULL)
+            ORDER BY g.group_nature DESC, g.group_name, l.ledger_name
+        `, { replacements: { locationCode, fromDate, toDate }, type: db.Sequelize.QueryTypes.SELECT });
+
+        const incomeGroupMap  = new Map();
+        const expenseGroupMap = new Map();
+        let totalIncome = 0, totalExpenses = 0;
+
+        for (const row of rows) {
+            const dr  = parseFloat(row.total_dr);
+            const cr  = parseFloat(row.total_cr);
+
+            if (row.group_nature === 'INCOME') {
+                const net = cr - dr;
+                if (!incomeGroupMap.has(row.group_name))
+                    incomeGroupMap.set(row.group_name, { group_name: row.group_name, rows: [], subtotal: 0 });
+                const g = incomeGroupMap.get(row.group_name);
+                g.rows.push({ ledger_id: row.ledger_id, ledger_name: row.ledger_name, amount: net });
+                g.subtotal  += net;
+                totalIncome += net;
+            } else {
+                const net = dr - cr;
+                if (!expenseGroupMap.has(row.group_name))
+                    expenseGroupMap.set(row.group_name, { group_name: row.group_name, rows: [], subtotal: 0 });
+                const g = expenseGroupMap.get(row.group_name);
+                g.rows.push({ ledger_id: row.ledger_id, ledger_name: row.ledger_name, amount: net });
+                g.subtotal    += net;
+                totalExpenses += net;
+            }
+        }
+
+        res.render('gl-profit-loss', {
+            title:          'Profit & Loss',
+            user:           req.user,
+            config:         require('../config/app-config').APP_CONFIGS,
+            fromDate,
+            toDate,
+            incomeGroups:   [...incomeGroupMap.values()],
+            expenseGroups:  [...expenseGroupMap.values()],
+            totalIncome,
+            totalExpenses,
+            netPL:          totalIncome - totalExpenses
+        });
+    } catch (err) {
+        console.error('P&L error:', err);
+        req.flash('error', 'Failed to load P&L: ' + err.message);
+        res.redirect('/gl/day-book');
+    }
+});
+
+// ── Balance Sheet ─────────────────────────────────────────────────────────────
+// GET /gl/balance-sheet?as_of_date=
+
+router.get('/balance-sheet', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const today    = new Date().toISOString().substring(0, 10);
+    const asOfDate = req.query.as_of_date || today;
+
+    try {
+        // Asset and liability balances cumulative up to asOfDate
+        const rows = await db.sequelize.query(`
+            SELECT
+                g.group_name,
+                g.group_nature,
+                l.ledger_id,
+                l.ledger_name,
+                COALESCE(b.total_dr, 0) AS total_dr,
+                COALESCE(b.total_cr, 0) AS total_cr
+            FROM gl_ledgers l
+            JOIN gl_ledger_groups g ON g.group_id = l.group_id
+            LEFT JOIN (
+                SELECT jl.ledger_id,
+                       SUM(jl.dr_amount) AS total_dr,
+                       SUM(jl.cr_amount) AS total_cr
+                FROM gl_journal_lines jl
+                JOIN gl_journal_headers jh ON jh.voucher_id = jl.voucher_id
+                WHERE jh.location_code = :locationCode
+                  AND jh.voucher_date  <= :asOfDate
+                GROUP BY jl.ledger_id
+            ) b ON b.ledger_id = l.ledger_id
+            WHERE l.location_code = :locationCode
+              AND l.active_flag   = 'Y'
+              AND g.group_nature  IN ('ASSETS', 'LIABILITIES')
+              AND (b.total_dr IS NOT NULL OR b.total_cr IS NOT NULL)
+            ORDER BY g.group_nature, g.group_name, l.ledger_name
+        `, { replacements: { locationCode, asOfDate }, type: db.Sequelize.QueryTypes.SELECT });
+
+        // Net P&L from inception to asOfDate — rolled into equity on liabilities side
+        const plRows = await db.sequelize.query(`
+            SELECT
+                COALESCE(SUM(CASE WHEN g.group_nature = 'INCOME'   THEN jl.cr_amount - jl.dr_amount ELSE 0 END), 0) AS total_income,
+                COALESCE(SUM(CASE WHEN g.group_nature = 'EXPENSES' THEN jl.dr_amount - jl.cr_amount ELSE 0 END), 0) AS total_expenses
+            FROM gl_journal_lines jl
+            JOIN gl_journal_headers jh ON jh.voucher_id = jl.voucher_id
+            JOIN gl_ledgers l          ON l.ledger_id   = jl.ledger_id
+            JOIN gl_ledger_groups g    ON g.group_id    = l.group_id
+            WHERE jh.location_code = :locationCode
+              AND jh.voucher_date  <= :asOfDate
+              AND g.group_nature   IN ('INCOME', 'EXPENSES')
+        `, { replacements: { locationCode, asOfDate }, type: db.Sequelize.QueryTypes.SELECT });
+
+        const netPL = parseFloat(plRows[0].total_income) - parseFloat(plRows[0].total_expenses);
+
+        const assetGroupMap     = new Map();
+        const liabilityGroupMap = new Map();
+        let totalAssets = 0, totalLiabilities = 0;
+
+        for (const row of rows) {
+            const dr  = parseFloat(row.total_dr);
+            const cr  = parseFloat(row.total_cr);
+
+            if (row.group_nature === 'ASSETS') {
+                const net = dr - cr;
+                if (!assetGroupMap.has(row.group_name))
+                    assetGroupMap.set(row.group_name, { group_name: row.group_name, rows: [], subtotal: 0 });
+                const g = assetGroupMap.get(row.group_name);
+                g.rows.push({ ledger_id: row.ledger_id, ledger_name: row.ledger_name, amount: net });
+                g.subtotal   += net;
+                totalAssets  += net;
+            } else {
+                const net = cr - dr;
+                if (!liabilityGroupMap.has(row.group_name))
+                    liabilityGroupMap.set(row.group_name, { group_name: row.group_name, rows: [], subtotal: 0 });
+                const g = liabilityGroupMap.get(row.group_name);
+                g.rows.push({ ledger_id: row.ledger_id, ledger_name: row.ledger_name, amount: net });
+                g.subtotal        += net;
+                totalLiabilities  += net;
+            }
+        }
+
+        const totalLiabilitiesAndPL = totalLiabilities + netPL;
+
+        res.render('gl-balance-sheet', {
+            title:                  'Balance Sheet',
+            user:                   req.user,
+            config:                 require('../config/app-config').APP_CONFIGS,
+            asOfDate,
+            assetGroups:            [...assetGroupMap.values()],
+            liabilityGroups:        [...liabilityGroupMap.values()],
+            totalAssets,
+            totalLiabilities,
+            netPL,
+            totalLiabilitiesAndPL,
+            isBalanced:             Math.abs(totalAssets - totalLiabilitiesAndPL) < 0.01
+        });
+    } catch (err) {
+        console.error('Balance Sheet error:', err);
+        req.flash('error', 'Failed to load Balance Sheet: ' + err.message);
+        res.redirect('/gl/day-book');
+    }
+});
+
+// ── Manual Journal ────────────────────────────────────────────────────────────
+
+const MANUAL_JOURNAL_TYPES = ['JOURNAL', 'PAYMENT', 'RECEIPT', 'CONTRA'];
+const VOUCHER_PREFIXES_MAP  = { JOURNAL:'JNL', PAYMENT:'PMT', RECEIPT:'RCT', CONTRA:'CNT' };
+
+async function getFyId(locationCode, date) {
+    const rows = await db.sequelize.query(`
+        SELECT fy_id FROM gl_financial_years
+        WHERE location_code = :locationCode
+          AND :date BETWEEN start_date AND end_date
+        LIMIT 1
+    `, { replacements: { locationCode, date }, type: db.Sequelize.QueryTypes.SELECT });
+    return rows[0] ? rows[0].fy_id : null;
+}
+
+async function nextVoucherNo(locationCode, fyId, vType) {
+    const prefix  = VOUCHER_PREFIXES_MAP[vType] || 'JNL';
+    const seqRows = await db.sequelize.query(`
+        SELECT COALESCE(MAX(
+            CAST(SUBSTRING(voucher_no, LOCATE('-', voucher_no) + 1) AS UNSIGNED)
+        ), 0) + 1 AS next_no
+        FROM gl_journal_headers
+        WHERE location_code = :locationCode
+          AND fy_id         = :fyId
+          AND voucher_type  = :vType
+          AND voucher_no IS NOT NULL
+    `, { replacements: { locationCode, fyId, vType }, type: db.Sequelize.QueryTypes.SELECT });
+    return `${prefix}-${String(seqRows[0].next_no).padStart(4, '0')}`;
+}
+
+// GET /gl/journal — list
+router.get('/journal', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const today    = new Date().toISOString().substring(0, 10);
+    const fromDate = req.query.from_date || today.substring(0, 8) + '01';
+    const toDate   = req.query.to_date   || today;
+
+    try {
+        const journals = await db.sequelize.query(`
+            SELECT
+                h.voucher_id,
+                DATE_FORMAT(h.voucher_date, '%d-%b-%Y') AS voucher_date,
+                h.voucher_no,
+                h.voucher_type,
+                h.narration,
+                h.is_reversal,
+                h.posted_by,
+                SUM(l.dr_amount) AS total_amount
+            FROM gl_journal_headers h
+            JOIN gl_journal_lines l ON l.voucher_id = h.voucher_id
+            WHERE h.location_code = :locationCode
+              AND h.source_type   = 'MANUAL_JOURNAL'
+              AND h.voucher_date  BETWEEN :fromDate AND :toDate
+            GROUP BY h.voucher_id
+            ORDER BY h.voucher_date DESC, h.voucher_id DESC
+            LIMIT 200
+        `, { replacements: { locationCode, fromDate, toDate }, type: db.Sequelize.QueryTypes.SELECT });
+
+        res.render('gl-journal-list', {
+            title:    'Manual Journals',
+            user:     req.user,
+            config:   require('../config/app-config').APP_CONFIGS,
+            fromDate,
+            toDate,
+            journals,
+            messages: req.flash()
+        });
+    } catch (err) {
+        console.error('Journal list error:', err);
+        req.flash('error', err.message);
+        res.redirect('/gl/day-book');
+    }
+});
+
+// GET /gl/journal/new — blank form
+router.get('/journal/new', [isLoginEnsured, security.isAdmin()], function(req, res) {
+    const today = new Date().toISOString().substring(0, 10);
+    res.render('gl-journal-form', {
+        title:        'New Manual Journal',
+        user:         req.user,
+        config:       require('../config/app-config').APP_CONFIGS,
+        voucher:      null,
+        lines:        [],
+        readOnly:     false,
+        voucherDate:  today,
+        MANUAL_JOURNAL_TYPES,
+        messages:     req.flash()
+    });
+});
+
+// GET /gl/journal/:id — view
+router.get('/journal/:id', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const voucherId    = parseInt(req.params.id);
+
+    try {
+        const [hRows, lines] = await Promise.all([
+            db.sequelize.query(`
+                SELECT h.*,
+                       DATE_FORMAT(h.voucher_date, '%d-%b-%Y')    AS fmt_date,
+                       DATE_FORMAT(h.voucher_date, '%Y-%m-%d')    AS raw_date,
+                       rv.voucher_no                              AS reversal_of_no
+                FROM gl_journal_headers h
+                LEFT JOIN gl_journal_headers rv ON rv.voucher_id = h.reversal_of_voucher_id
+                WHERE h.voucher_id    = :voucherId
+                  AND h.location_code = :locationCode
+            `, { replacements: { voucherId, locationCode }, type: db.Sequelize.QueryTypes.SELECT }),
+            db.sequelize.query(`
+                SELECT l.line_no, l.ledger_id, gl.ledger_name, l.dr_amount, l.cr_amount, l.narration
+                FROM gl_journal_lines l
+                JOIN gl_ledgers gl ON gl.ledger_id = l.ledger_id
+                WHERE l.voucher_id = :voucherId
+                ORDER BY l.line_no
+            `, { replacements: { voucherId }, type: db.Sequelize.QueryTypes.SELECT })
+        ]);
+
+        if (!hRows.length) {
+            req.flash('error', 'Journal not found');
+            return res.redirect('/gl/journal');
+        }
+
+        res.render('gl-journal-form', {
+            title:        `Journal ${hRows[0].voucher_no}`,
+            user:         req.user,
+            config:       require('../config/app-config').APP_CONFIGS,
+            voucher:      hRows[0],
+            lines,
+            readOnly:     true,
+            voucherDate:  hRows[0].raw_date,
+            MANUAL_JOURNAL_TYPES,
+            messages:     req.flash()
+        });
+    } catch (err) {
+        console.error('Journal view error:', err);
+        req.flash('error', err.message);
+        res.redirect('/gl/journal');
+    }
+});
+
+// POST /gl/api/journal — save new journal
+router.post('/api/journal', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const postedBy     = req.user.username || String(req.user.Person_id);
+    const { voucher_type, voucher_date, narration, lines } = req.body;
+
+    try {
+        if (!voucher_date) throw new Error('Voucher date is required');
+        if (!Array.isArray(lines) || lines.length < 2) throw new Error('At least 2 journal lines are required');
+
+        const totalDr = lines.reduce((s, l) => s + parseFloat(l.dr_amount || 0), 0);
+        const totalCr = lines.reduce((s, l) => s + parseFloat(l.cr_amount || 0), 0);
+        if (Math.abs(totalDr - totalCr) > 0.005)
+            throw new Error(`Journal does not balance: DR ${totalDr.toFixed(2)} vs CR ${totalCr.toFixed(2)}`);
+
+        const vType = MANUAL_JOURNAL_TYPES.includes(voucher_type) ? voucher_type : 'JOURNAL';
+        const fyId  = await getFyId(locationCode, voucher_date);
+        if (!fyId) throw new Error(`No financial year found for date ${voucher_date}`);
+
+        const voucherNo = await nextVoucherNo(locationCode, fyId, vType);
+
+        const [voucherId] = await db.sequelize.query(`
+            INSERT INTO gl_journal_headers
+                (location_code, fy_id, voucher_type, voucher_date, voucher_no,
+                 narration, source_type, source_id, is_reversal, is_exported, posted_by, created_by)
+            VALUES
+                (:locationCode, :fyId, :vType, :voucher_date, :voucherNo,
+                 :narration, 'MANUAL_JOURNAL', NULL, 'N', 'N', :postedBy, :postedBy)
+        `, {
+            replacements: { locationCode, fyId, vType, voucher_date, voucherNo, narration: narration || '', postedBy },
+            type: db.Sequelize.QueryTypes.INSERT
+        });
+
+        for (let i = 0; i < lines.length; i++) {
+            const { ledger_id, dr_amount, cr_amount, narration: ln } = lines[i];
+            await db.sequelize.query(`
+                INSERT INTO gl_journal_lines
+                    (voucher_id, line_no, ledger_id, dr_amount, cr_amount, narration, created_by)
+                VALUES (:voucherId, :lineNo, :ledgerId, :drAmount, :crAmount, :lineNarration, :postedBy)
+            `, {
+                replacements: {
+                    voucherId, lineNo: i + 1, ledgerId: parseInt(ledger_id),
+                    drAmount: parseFloat(dr_amount || 0), crAmount: parseFloat(cr_amount || 0),
+                    lineNarration: ln || null, postedBy
+                },
+                type: db.Sequelize.QueryTypes.INSERT
+            });
+        }
+
+        res.json({ success: true, voucher_id: voucherId, voucher_no: voucherNo });
+    } catch (err) {
+        console.error('Journal save error:', err);
+        res.status(400).json({ success: false, error: err.message });
+    }
+});
+
+// POST /gl/api/journal/:id/reverse — create reversal voucher
+router.post('/api/journal/:id/reverse', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const postedBy     = req.user.username || String(req.user.Person_id);
+    const voucherId    = parseInt(req.params.id);
+
+    try {
+        const [hRows, lines] = await Promise.all([
+            db.sequelize.query(`SELECT * FROM gl_journal_headers WHERE voucher_id = :voucherId AND location_code = :locationCode`,
+                { replacements: { voucherId, locationCode }, type: db.Sequelize.QueryTypes.SELECT }),
+            db.sequelize.query(`SELECT * FROM gl_journal_lines WHERE voucher_id = :voucherId ORDER BY line_no`,
+                { replacements: { voucherId }, type: db.Sequelize.QueryTypes.SELECT })
+        ]);
+
+        if (!hRows.length) throw new Error('Journal not found');
+        const orig = hRows[0];
+
+        const today  = new Date().toISOString().substring(0, 10);
+        const fyId   = await getFyId(locationCode, today);
+        if (!fyId) throw new Error(`No financial year found for today (${today})`);
+
+        const voucherNo = await nextVoucherNo(locationCode, fyId, orig.voucher_type);
+
+        const [reversalId] = await db.sequelize.query(`
+            INSERT INTO gl_journal_headers
+                (location_code, fy_id, voucher_type, voucher_date, voucher_no,
+                 narration, source_type, source_id, is_reversal, reversal_of_voucher_id,
+                 is_exported, posted_by, created_by)
+            VALUES
+                (:locationCode, :fyId, :vType, :today, :voucherNo,
+                 :narration, 'MANUAL_JOURNAL', NULL, 'Y', :origId,
+                 'N', :postedBy, :postedBy)
+        `, {
+            replacements: {
+                locationCode, fyId, vType: orig.voucher_type, today, voucherNo,
+                narration: `REVERSAL of ${orig.voucher_no} — ${orig.narration || ''}`,
+                origId: voucherId, postedBy
+            },
+            type: db.Sequelize.QueryTypes.INSERT
+        });
+
+        for (let i = 0; i < lines.length; i++) {
+            const l = lines[i];
+            await db.sequelize.query(`
+                INSERT INTO gl_journal_lines
+                    (voucher_id, line_no, ledger_id, dr_amount, cr_amount, narration, created_by)
+                VALUES (:reversalId, :lineNo, :ledgerId, :drAmount, :crAmount, :lineNarration, :postedBy)
+            `, {
+                replacements: {
+                    reversalId, lineNo: i + 1, ledgerId: l.ledger_id,
+                    drAmount: parseFloat(l.cr_amount || 0),
+                    crAmount: parseFloat(l.dr_amount || 0),
+                    lineNarration: l.narration, postedBy
+                },
+                type: db.Sequelize.QueryTypes.INSERT
+            });
+        }
+
+        res.json({ success: true, voucher_id: reversalId, voucher_no: voucherNo });
+    } catch (err) {
+        console.error('Journal reversal error:', err);
+        res.status(400).json({ success: false, error: err.message });
+    }
+});
+
+// ── GL Control ────────────────────────────────────────────────────────────────
+// GET /gl/control — admin dashboard: events monitor + create accounting + generate events
+
+router.get('/control', [isLoginEnsured, security.isAdmin()], function(req, res) {
+    const today = new Date().toISOString().substring(0, 10);
+    const fromDate = today.substring(0, 8) + '01';
+    res.render('gl-control', {
+        title:    'GL Control',
+        user:     req.user,
+        config:   require('../config/app-config').APP_CONFIGS,
+        fromDate,
+        toDate:   today,
+        messages: req.flash()
+    });
+});
+
+// GET /gl/api/event-summary?from_date=&to_date=
+router.get('/api/event-summary', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const { from_date, to_date } = req.query;
+
+    try {
+        const [summary, byType] = await Promise.all([
+            db.sequelize.query(`
+                SELECT
+                    COUNT(*) AS total,
+                    SUM(event_status = 'UNPROCESSED') AS unprocessed,
+                    SUM(event_status = 'PROCESSED')   AS processed,
+                    SUM(event_status = 'ERROR')        AS errors
+                FROM gl_accounting_events
+                WHERE location_code = :locationCode
+                  AND (:from_date IS NULL OR event_date >= :from_date)
+                  AND (:to_date   IS NULL OR event_date <= :to_date)
+            `, {
+                replacements: { locationCode, from_date: from_date || null, to_date: to_date || null },
+                type: db.Sequelize.QueryTypes.SELECT
+            }),
+            db.sequelize.query(`
+                SELECT source_type,
+                       COUNT(*) AS total,
+                       SUM(event_status = 'UNPROCESSED') AS unprocessed,
+                       SUM(event_status = 'PROCESSED')   AS processed,
+                       SUM(event_status = 'ERROR')        AS errors
+                FROM gl_accounting_events
+                WHERE location_code = :locationCode
+                  AND (:from_date IS NULL OR event_date >= :from_date)
+                  AND (:to_date   IS NULL OR event_date <= :to_date)
+                GROUP BY source_type
+                ORDER BY source_type
+            `, {
+                replacements: { locationCode, from_date: from_date || null, to_date: to_date || null },
+                type: db.Sequelize.QueryTypes.SELECT
+            })
+        ]);
+
+        res.json({ ...summary[0], byType });
+    } catch (err) {
+        console.error('Event summary error:', err);
+        res.status(500).json({ error: err.message });
+    }
+});
+
+// POST /gl/api/retry-event/:id — reset a single ERROR event back to UNPROCESSED
+router.post('/api/retry-event/:id', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const eventId = parseInt(req.params.id);
+
+    try {
+        const [, meta] = await db.sequelize.query(`
+            UPDATE gl_accounting_events
+            SET event_status  = 'UNPROCESSED',
+                error_message = NULL,
+                processed_at  = NULL,
+                processed_by  = NULL
+            WHERE event_id      = :eventId
+              AND location_code = :locationCode
+              AND event_status  = 'ERROR'
+        `, { replacements: { eventId, locationCode }, type: db.Sequelize.QueryTypes.UPDATE });
+
+        if (!meta?.affectedRows) {
+            return res.status(404).json({ success: false, error: 'Event not found or not in ERROR status' });
+        }
+        res.json({ success: true });
+    } catch (err) {
+        console.error('Retry event error:', err);
+        res.status(500).json({ success: false, error: err.message });
+    }
+});
+
+// POST /gl/api/generate-events — backfill missing events for date range
+router.post('/api/generate-events', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const createdBy    = req.user.username || String(req.user.Person_id);
+    const { from_date, to_date } = req.body;
+
+    if (!from_date || !to_date) {
+        return res.status(400).json({ error: 'from_date and to_date are required' });
+    }
+
+    try {
+        const result = await createAccountingService.generateMissingEvents(locationCode, from_date, to_date, createdBy);
+        res.json({ success: true, ...result });
+    } catch (err) {
+        console.error('Generate events error:', err);
+        res.status(500).json({ success: false, error: err.message });
     }
 });
 

--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -826,6 +826,175 @@ router.post('/api/journal/:id/reverse', [isLoginEnsured, security.isAdmin()], as
     }
 });
 
+// ── Ledger Groups ─────────────────────────────────────────────────────────────
+// GET /gl/ledger-groups
+
+router.get('/ledger-groups', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    try {
+        const groups = await db.sequelize.query(`
+            SELECT g.group_id, g.group_name, g.group_nature,
+                   COUNT(l.ledger_id) AS ledger_count
+            FROM gl_ledger_groups g
+            LEFT JOIN gl_ledgers l ON l.group_id = g.group_id AND l.active_flag = 'Y'
+            WHERE g.location_code = :locationCode
+            GROUP BY g.group_id
+            ORDER BY FIELD(g.group_nature,'ASSETS','LIABILITIES','INCOME','EXPENSES'), g.group_name
+        `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT });
+
+        res.render('gl-ledger-groups', {
+            title:    'Ledger Groups',
+            user:     req.user,
+            config:   require('../config/app-config').APP_CONFIGS,
+            groups,
+            messages: req.flash()
+        });
+    } catch (err) {
+        console.error('Ledger groups error:', err);
+        req.flash('error', err.message);
+        res.redirect('/gl/day-book');
+    }
+});
+
+router.post('/api/ledger-groups', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const { group_name, group_nature } = req.body;
+    const NATURES = ['ASSETS', 'LIABILITIES', 'INCOME', 'EXPENSES'];
+    if (!group_name || !NATURES.includes(group_nature))
+        return res.status(400).json({ success: false, error: 'group_name and valid group_nature are required' });
+    try {
+        const [[exists]] = await db.sequelize.query(
+            `SELECT group_id FROM gl_ledger_groups WHERE location_code=:locationCode AND group_name=:group_name LIMIT 1`,
+            { replacements: { locationCode, group_name }, type: db.Sequelize.QueryTypes.SELECT }
+        );
+        if (exists) return res.status(400).json({ success: false, error: 'A group with this name already exists' });
+
+        const [groupId] = await db.sequelize.query(`
+            INSERT INTO gl_ledger_groups (location_code, group_name, group_nature, created_by, updated_by)
+            VALUES (:locationCode, :group_name, :group_nature, :user, :user)
+        `, { replacements: { locationCode, group_name, group_nature, user: req.user.username }, type: db.Sequelize.QueryTypes.INSERT });
+        res.json({ success: true, group_id: groupId });
+    } catch (err) {
+        res.status(500).json({ success: false, error: err.message });
+    }
+});
+
+router.put('/api/ledger-groups/:id', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const groupId = parseInt(req.params.id);
+    const { group_name, group_nature } = req.body;
+    const NATURES = ['ASSETS', 'LIABILITIES', 'INCOME', 'EXPENSES'];
+    if (!group_name || !NATURES.includes(group_nature))
+        return res.status(400).json({ success: false, error: 'group_name and valid group_nature are required' });
+    try {
+        await db.sequelize.query(`
+            UPDATE gl_ledger_groups SET group_name=:group_name, group_nature=:group_nature, updated_by=:user
+            WHERE group_id=:groupId AND location_code=:locationCode
+        `, { replacements: { groupId, locationCode, group_name, group_nature, user: req.user.username }, type: db.Sequelize.QueryTypes.UPDATE });
+        res.json({ success: true });
+    } catch (err) {
+        res.status(500).json({ success: false, error: err.message });
+    }
+});
+
+router.delete('/api/ledger-groups/:id', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const groupId = parseInt(req.params.id);
+    try {
+        const [rows] = await db.sequelize.query(
+            `SELECT COUNT(*) AS cnt FROM gl_ledgers WHERE group_id=:groupId`,
+            { replacements: { groupId }, type: db.Sequelize.QueryTypes.SELECT }
+        );
+        if (rows.cnt > 0)
+            return res.status(400).json({ success: false, error: `Cannot delete — ${rows.cnt} ledger(s) assigned to this group` });
+        await db.sequelize.query(
+            `DELETE FROM gl_ledger_groups WHERE group_id=:groupId AND location_code=:locationCode`,
+            { replacements: { groupId, locationCode }, type: db.Sequelize.QueryTypes.DELETE }
+        );
+        res.json({ success: true });
+    } catch (err) {
+        res.status(500).json({ success: false, error: err.message });
+    }
+});
+
+// ── Ledgers ───────────────────────────────────────────────────────────────────
+// GET /gl/ledgers
+
+router.get('/ledgers', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    try {
+        const [ledgers, groups] = await Promise.all([
+            db.sequelize.query(`
+                SELECT l.ledger_id, l.ledger_name, l.active_flag,
+                       g.group_id, g.group_name, g.group_nature
+                FROM gl_ledgers l
+                JOIN gl_ledger_groups g ON g.group_id = l.group_id
+                WHERE l.location_code = :locationCode
+                ORDER BY FIELD(g.group_nature,'ASSETS','LIABILITIES','INCOME','EXPENSES'), g.group_name, l.ledger_name
+            `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT }),
+            db.sequelize.query(`
+                SELECT group_id, group_name, group_nature
+                FROM gl_ledger_groups
+                WHERE location_code = :locationCode
+                ORDER BY FIELD(group_nature,'ASSETS','LIABILITIES','INCOME','EXPENSES'), group_name
+            `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT })
+        ]);
+
+        res.render('gl-ledgers', {
+            title:    'Ledgers',
+            user:     req.user,
+            config:   require('../config/app-config').APP_CONFIGS,
+            ledgers,
+            groups,
+            messages: req.flash()
+        });
+    } catch (err) {
+        console.error('Ledgers error:', err);
+        req.flash('error', err.message);
+        res.redirect('/gl/day-book');
+    }
+});
+
+router.post('/api/ledger', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const { ledger_name, group_id } = req.body;
+    if (!ledger_name || !group_id) return res.status(400).json({ success: false, error: 'ledger_name and group_id are required' });
+    try {
+        const [exists] = await db.sequelize.query(
+            `SELECT ledger_id FROM gl_ledgers WHERE location_code=:locationCode AND ledger_name=:ledger_name LIMIT 1`,
+            { replacements: { locationCode, ledger_name }, type: db.Sequelize.QueryTypes.SELECT }
+        );
+        if (exists) return res.status(400).json({ success: false, error: 'A ledger with this name already exists' });
+
+        const [ledgerId] = await db.sequelize.query(`
+            INSERT INTO gl_ledgers (location_code, ledger_name, group_id, active_flag, created_by, updated_by)
+            VALUES (:locationCode, :ledger_name, :group_id, 'Y', :user, :user)
+        `, { replacements: { locationCode, ledger_name, group_id: parseInt(group_id), user: req.user.username }, type: db.Sequelize.QueryTypes.INSERT });
+        res.json({ success: true, ledger_id: ledgerId });
+    } catch (err) {
+        res.status(500).json({ success: false, error: err.message });
+    }
+});
+
+router.put('/api/ledger/:id', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const ledgerId = parseInt(req.params.id);
+    const { ledger_name, group_id, active_flag } = req.body;
+    if (!ledger_name || !group_id) return res.status(400).json({ success: false, error: 'ledger_name and group_id are required' });
+    try {
+        await db.sequelize.query(`
+            UPDATE gl_ledgers SET ledger_name=:ledger_name, group_id=:group_id, active_flag=:active_flag, updated_by=:user
+            WHERE ledger_id=:ledgerId AND location_code=:locationCode
+        `, {
+            replacements: { ledgerId, locationCode, ledger_name, group_id: parseInt(group_id), active_flag: active_flag === 'Y' ? 'Y' : 'N', user: req.user.username },
+            type: db.Sequelize.QueryTypes.UPDATE
+        });
+        res.json({ success: true });
+    } catch (err) {
+        res.status(500).json({ success: false, error: err.message });
+    }
+});
+
 // ── GL Control ────────────────────────────────────────────────────────────────
 // GET /gl/control — admin dashboard: events monitor + create accounting + generate events
 

--- a/routes/products-routes.js
+++ b/routes/products-routes.js
@@ -237,26 +237,30 @@ router.put('/api/:id', [isLoginEnsured, security.isAdmin()], async function (req
 
 // ── Product Ledger Map ────────────────────────────────────────────────────────
 
-// Map types shown in the configure modal — add new types here as needed
-const PRODUCT_MAP_TYPES = [
-    { type: 'SALES',       label: 'Sales',       group: 'sales' },
-    { type: 'PURCHASE',    label: 'Purchase',     group: 'purchase' },
-    { type: 'OUTPUT_CGST', label: 'Output CGST',  group: 'tax' },
-    { type: 'OUTPUT_SGST', label: 'Output SGST',  group: 'tax' },
-    { type: 'INPUT_CGST',  label: 'Input CGST',   group: 'tax' },
-    { type: 'INPUT_SGST',  label: 'Input SGST',   group: 'tax' },
-];
+// Maps the attribute1 group key (from m_lookup) → actual GL ledger group name.
+// Update this only if a new ledger category is added to m_lookup.
+const GROUP_LEDGER_NAMES = {
+    sales:    'Sales Accounts',
+    purchase: 'Purchase Accounts',
+    tax:      'Duties & Taxes'
+};
 
 router.get('/ledger-map', [isLoginEnsured, security.isAdmin()], async (req, res) => {
     const locationCode = req.user.location_code;
     try {
-        const [products, rawMappings, salesLedgers, purchaseLedgers, taxLedgers] = await Promise.all([
+        const [products, rawMappings, mapTypes] = await Promise.all([
             ProductLedgerMapDao.getProducts(locationCode),
             ProductLedgerMapDao.getAllMappingsRaw(locationCode),
-            getLedgersByGroup(locationCode, 'Sales Accounts'),
-            getLedgersByGroup(locationCode, 'Purchase Accounts'),
-            getLedgersByGroup(locationCode, 'Duties & Taxes')
+            ProductLedgerMapDao.getMapTypes()
         ]);
+
+        // Fetch ledger lists for each distinct group used by the current map types
+        const neededGroups = [...new Set(mapTypes.map(m => m.group))];
+        const ledgerArrays = await Promise.all(
+            neededGroups.map(g => getLedgersByGroup(locationCode, GROUP_LEDGER_NAMES[g] || g))
+        );
+        const ledgers = {};
+        neededGroups.forEach((g, i) => { ledgers[g] = ledgerArrays[i]; });
 
         // Build { productId: { MAP_TYPE: ledgerId } } lookup for the modal
         const mappingLookup = {};
@@ -271,12 +275,8 @@ router.get('/ledger-map', [isLoginEnsured, security.isAdmin()], async (req, res)
             config: config.APP_CONFIGS,
             products,
             mappingLookup,
-            mapTypes: PRODUCT_MAP_TYPES,
-            ledgers: {
-                sales:    salesLedgers,
-                purchase: purchaseLedgers,
-                tax:      taxLedgers
-            }
+            mapTypes,
+            ledgers
         });
     } catch (err) {
         console.error('Error loading product ledger map:', err);

--- a/routes/products-routes.js
+++ b/routes/products-routes.js
@@ -8,6 +8,7 @@ const ProductDao = require('../dao/product-dao');
 const dbMapping = require("../db/ui-db-field-mapping")
 const config = require('../config/app-config');
 const locationConfigDao = require('../dao/location-config-dao');
+const { getLedgersByGroup } = require('./gl-routes');
 
 const PRODUCT_NAME_EDITABLE_SETTING = 'PRODUCT_NAME_EDITABLE';
 
@@ -22,10 +23,12 @@ router.get('/', [isLoginEnsured, security.isAdmin()], async function (req, res, 
     const locationCode = req.user.location_code;
     let products = [];
     try {
-        const [data, editableSetting, pumpLinkedNames] = await Promise.all([
+        const [data, editableSetting, pumpLinkedNames, salesLedgers, purchaseLedgers] = await Promise.all([
             ProductDao.findProducts(locationCode),
             locationConfigDao.getSetting(locationCode, PRODUCT_NAME_EDITABLE_SETTING),
-            ProductDao.findPumpLinkedProductNames(locationCode)
+            ProductDao.findPumpLinkedProductNames(locationCode),
+            getLedgersByGroup(locationCode, 'Sales Accounts'),
+            getLedgersByGroup(locationCode, 'Purchase Accounts')
         ]);
         const canEditProductName = isTruthySetting(editableSetting);
         const pumpLinkedSet = new Set(pumpLinkedNames);
@@ -39,6 +42,7 @@ router.get('/', [isLoginEnsured, security.isAdmin()], async function (req, res, 
                 qty: product.qty,
                 price: product.price,
                 ledger_name: product.ledger_name,
+                purchase_ledger_name: product.purchase_ledger_name,
                 cgst_percent: product.cgst_percent,
                 sgst_percent: product.sgst_percent,
                 sku_name: product.sku_name,
@@ -50,12 +54,14 @@ router.get('/', [isLoginEnsured, security.isAdmin()], async function (req, res, 
             });
         });
 
-        res.render('products', { 
-            title: 'Products', 
-            user: req.user, 
-            products: products, 
+        res.render('products', {
+            title: 'Products',
+            user: req.user,
+            products: products,
             config: config.APP_CONFIGS,
             canEditProductName: canEditProductName,
+            salesLedgers: salesLedgers,
+            purchaseLedgers: purchaseLedgers,
             messages: req.flash()
         });
     } catch (error) {
@@ -78,6 +84,7 @@ router.get('/api/data', [isLoginEnsured, security.isAdmin()], function (req, res
                 qty: product.qty,
                 price: product.price,
                 ledger_name: product.ledger_name,
+                purchase_ledger_name: product.purchase_ledger_name,
                 cgst_percent: product.cgst_percent,
                 sgst_percent: product.sgst_percent,
                 sku_name: product.sku_name,
@@ -115,6 +122,7 @@ router.post('/api', [isLoginEnsured, security.isAdmin()], function (req, res, ne
                 m_product_unit_0: req.body.unit,
                 m_product_price_0: req.body.price,
                 m_product_ledger_name_0: req.body.ledger_name,
+                m_product_purchase_ledger_name_0: req.body.purchase_ledger_name,
                 m_product_cgst_0: req.body.cgst_percent || 0,
                 m_product_sgst_0: req.body.sgst_percent || 0,
                 m_product_sku_name_0: req.body.sku_name || '',
@@ -199,6 +207,7 @@ router.put('/api/:id', [isLoginEnsured, security.isAdmin()], async function (req
             price: req.body.m_product_price,
             unit: req.body.m_product_unit,
             ledger_name: req.body.m_product_ledger_name,
+            purchase_ledger_name: req.body.m_product_purchase_ledger_name,
             cgst_percent: req.body.m_product_cgst,
             sgst_percent: req.body.m_product_sgst,
             is_tank_product: req.body.m_product_is_tank_product,

--- a/routes/products-routes.js
+++ b/routes/products-routes.js
@@ -237,23 +237,46 @@ router.put('/api/:id', [isLoginEnsured, security.isAdmin()], async function (req
 
 // ── Product Ledger Map ────────────────────────────────────────────────────────
 
+// Map types shown in the configure modal — add new types here as needed
+const PRODUCT_MAP_TYPES = [
+    { type: 'SALES',       label: 'Sales',       group: 'sales' },
+    { type: 'PURCHASE',    label: 'Purchase',     group: 'purchase' },
+    { type: 'OUTPUT_CGST', label: 'Output CGST',  group: 'tax' },
+    { type: 'OUTPUT_SGST', label: 'Output SGST',  group: 'tax' },
+    { type: 'INPUT_CGST',  label: 'Input CGST',   group: 'tax' },
+    { type: 'INPUT_SGST',  label: 'Input SGST',   group: 'tax' },
+];
+
 router.get('/ledger-map', [isLoginEnsured, security.isAdmin()], async (req, res) => {
     const locationCode = req.user.location_code;
     try {
-        const [products, salesLedgers, purchaseLedgers, taxLedgers] = await Promise.all([
-            ProductLedgerMapDao.getAllMappings(locationCode),
+        const [products, rawMappings, salesLedgers, purchaseLedgers, taxLedgers] = await Promise.all([
+            ProductLedgerMapDao.getProducts(locationCode),
+            ProductLedgerMapDao.getAllMappingsRaw(locationCode),
             getLedgersByGroup(locationCode, 'Sales Accounts'),
             getLedgersByGroup(locationCode, 'Purchase Accounts'),
             getLedgersByGroup(locationCode, 'Duties & Taxes')
         ]);
+
+        // Build { productId: { MAP_TYPE: ledgerId } } lookup for the modal
+        const mappingLookup = {};
+        rawMappings.forEach(m => {
+            if (!mappingLookup[m.product_id]) mappingLookup[m.product_id] = {};
+            mappingLookup[m.product_id][m.map_type] = m.ledger_id;
+        });
+
         res.render('product-ledger-map', {
             title: 'Product GL Ledger Map',
             user: req.user,
             config: config.APP_CONFIGS,
             products,
-            salesLedgers,
-            purchaseLedgers,
-            taxLedgers
+            mappingLookup,
+            mapTypes: PRODUCT_MAP_TYPES,
+            ledgers: {
+                sales:    salesLedgers,
+                purchase: purchaseLedgers,
+                tax:      taxLedgers
+            }
         });
     } catch (err) {
         console.error('Error loading product ledger map:', err);

--- a/routes/products-routes.js
+++ b/routes/products-routes.js
@@ -5,6 +5,7 @@ const login = require('connect-ensure-login');
 const isLoginEnsured = login.ensureLoggedIn({});
 const security = require("../utils/app-security");
 const ProductDao = require('../dao/product-dao');
+const ProductLedgerMapDao = require('../dao/product-ledger-map-dao');
 const dbMapping = require("../db/ui-db-field-mapping")
 const config = require('../config/app-config');
 const locationConfigDao = require('../dao/location-config-dao');
@@ -231,6 +232,51 @@ router.put('/api/:id', [isLoginEnsured, security.isAdmin()], async function (req
             success: false,
             error: 'Failed to update product: ' + error.message
         });
+    }
+});
+
+// ── Product Ledger Map ────────────────────────────────────────────────────────
+
+router.get('/ledger-map', [isLoginEnsured, security.isAdmin()], async (req, res) => {
+    const locationCode = req.user.location_code;
+    try {
+        const [products, salesLedgers, purchaseLedgers, taxLedgers] = await Promise.all([
+            ProductLedgerMapDao.getAllMappings(locationCode),
+            getLedgersByGroup(locationCode, 'Sales Accounts'),
+            getLedgersByGroup(locationCode, 'Purchase Accounts'),
+            getLedgersByGroup(locationCode, 'Duties & Taxes')
+        ]);
+        res.render('product-ledger-map', {
+            title: 'Product GL Ledger Map',
+            user: req.user,
+            config: config.APP_CONFIGS,
+            products,
+            salesLedgers,
+            purchaseLedgers,
+            taxLedgers
+        });
+    } catch (err) {
+        console.error('Error loading product ledger map:', err);
+        req.flash('error', 'Failed to load product ledger map: ' + err.message);
+        res.redirect('/products');
+    }
+});
+
+router.put('/api/ledger-maps/:productId/:mapType', [isLoginEnsured, security.isAdmin()], async (req, res) => {
+    const { productId, mapType } = req.params;
+    const { ledger_id } = req.body;
+    const locationCode = req.user.location_code;
+    const updatedBy = req.user.username || req.user.Person_id;
+    try {
+        if (!ledger_id) {
+            await ProductLedgerMapDao.deleteMapping(locationCode, productId, mapType);
+        } else {
+            await ProductLedgerMapDao.upsertMapping(locationCode, productId, mapType, ledger_id, updatedBy);
+        }
+        res.json({ success: true });
+    } catch (err) {
+        console.error('Error saving product ledger map:', err);
+        res.status(500).json({ success: false, error: err.message });
     }
 });
 

--- a/services/create-accounting-service.js
+++ b/services/create-accounting-service.js
@@ -37,7 +37,9 @@ const BOWSER_BOUND_TYPES = new Set(['BOWSER_CREDIT_SALE', 'BOWSER_CASH_SALE', 'B
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
-async function processEvents(locationCode, fromDate, toDate, processedBy) {
+async function processEvents(locationCode, fromDate, toDate, processedBy, logger) {
+    const log = logger || { info: () => {}, debug: () => {}, error: () => {} };
+
     const [events, openShiftDates, openBowserDates] = await Promise.all([
         db.sequelize.query(`
             SELECT * FROM gl_accounting_events
@@ -50,6 +52,8 @@ async function processEvents(locationCode, fromDate, toDate, processedBy) {
         getOpenBowserDates(locationCode, fromDate, toDate)
     ]);
 
+    log.info(`Create Accounting started: ${locationCode} ${fromDate} → ${toDate}, ${events.length} unprocessed events`);
+
     const summary = { processed: 0, errors: 0, skipped: 0, blocked: 0, blockedDates: [], details: [] };
 
     for (const event of events) {
@@ -60,6 +64,7 @@ async function processEvents(locationCode, fromDate, toDate, processedBy) {
         if (SHIFT_BOUND_TYPES.has(event.source_type) && openShiftDates.has(eventDate)) {
             summary.blocked++;
             if (!summary.blockedDates.includes(eventDate)) summary.blockedDates.push(eventDate);
+            log.debug(`BLOCKED event_id=${event.event_id} ${event.source_type}#${event.source_id} — shift on ${eventDate} is DRAFT`);
             summary.details.push({ event_id: event.event_id, status: 'BLOCKED', reason: `Shift on ${eventDate} is still DRAFT` });
             continue;
         }
@@ -67,6 +72,7 @@ async function processEvents(locationCode, fromDate, toDate, processedBy) {
         if (BOWSER_BOUND_TYPES.has(event.source_type) && openBowserDates.has(eventDate)) {
             summary.blocked++;
             if (!summary.blockedDates.includes(eventDate)) summary.blockedDates.push(eventDate);
+            log.debug(`BLOCKED event_id=${event.event_id} ${event.source_type}#${event.source_id} — bowser on ${eventDate} is DRAFT`);
             summary.details.push({ event_id: event.event_id, status: 'BLOCKED', reason: `Bowser closing on ${eventDate} is still DRAFT` });
             continue;
         }
@@ -74,19 +80,26 @@ async function processEvents(locationCode, fromDate, toDate, processedBy) {
         try {
             const result = await processEvent(event, processedBy);
             summary.processed += result.voucherCount;
+            log.debug(`PROCESSED event_id=${event.event_id} ${event.source_type}#${event.source_id} → ${result.voucherCount} voucher(s)`);
             summary.details.push({ event_id: event.event_id, status: 'PROCESSED', vouchers: result.voucherCount });
         } catch (err) {
             await markEventError(event.event_id, err.message);
             summary.errors++;
+            log.error(`ERROR event_id=${event.event_id} ${event.source_type}#${event.source_id}: ${err.message}`);
             summary.details.push({ event_id: event.event_id, status: 'ERROR', message: err.message });
         }
     }
 
+    log.info(`Create Accounting done — processed=${summary.processed} blocked=${summary.blocked} errors=${summary.errors} skipped=${summary.skipped}`);
+    if (summary.blockedDates.length) log.info(`Blocked dates (DRAFT shifts): ${summary.blockedDates.join(', ')}`);
+
     return summary;
 }
 
-async function reprocessEvents(locationCode, fromDate, toDate, processedBy) {
-    await db.sequelize.query(`
+async function reprocessEvents(locationCode, fromDate, toDate, processedBy, logger) {
+    const log = logger || { info: () => {}, debug: () => {}, error: () => {} };
+
+    const [, meta] = await db.sequelize.query(`
         UPDATE gl_accounting_events
         SET event_status  = 'UNPROCESSED',
             event_type    = 'UPDATE',
@@ -102,7 +115,9 @@ async function reprocessEvents(locationCode, fromDate, toDate, processedBy) {
         type: QueryTypes.UPDATE
     });
 
-    return await processEvents(locationCode, fromDate, toDate, processedBy);
+    log.info(`Reprocess: reset ${meta?.affectedRows || 0} events to UNPROCESSED for ${fromDate} → ${toDate}`);
+
+    return await processEvents(locationCode, fromDate, toDate, processedBy, log);
 }
 
 module.exports = { processEvents, reprocessEvents, generateMissingEvents };
@@ -111,9 +126,12 @@ module.exports = { processEvents, reprocessEvents, generateMissingEvents };
 // Backfill tool: scan each source table for records with no event and INSERT them.
 // Safe to run multiple times — NOT EXISTS guard prevents duplicates.
 
-async function generateMissingEvents(locationCode, fromDate, toDate, createdBy) {
+async function generateMissingEvents(locationCode, fromDate, toDate, createdBy, logger) {
+    const log = logger || { info: () => {}, debug: () => {}, error: () => {} };
     const counts = {};
     let total = 0;
+
+    log.info(`Generate Events started: ${locationCode} ${fromDate} → ${toDate}`);
 
     const run = async (sourceType, sql) => {
         const [, meta] = await db.sequelize.query(sql, {
@@ -123,6 +141,7 @@ async function generateMissingEvents(locationCode, fromDate, toDate, createdBy) 
         const n = meta?.affectedRows || 0;
         counts[sourceType] = n;
         total += n;
+        log.debug(`${sourceType}: inserted ${n} missing event(s)`);
     };
 
     await run('CREDIT_SALE', `
@@ -274,6 +293,9 @@ async function generateMissingEvents(locationCode, fromDate, toDate, createdBy) 
               WHERE e.source_type = 'TANK_INVOICE' AND e.source_id = ti.id
           )
     `);
+
+    log.info(`Generate Events done — total inserted=${total}` +
+        (total > 0 ? (' (' + Object.entries(counts).filter(([,v])=>v>0).map(([k,v])=>`${k}:${v}`).join(' ') + ')') : ''));
 
     return { counts, total };
 }

--- a/services/create-accounting-service.js
+++ b/services/create-accounting-service.js
@@ -536,7 +536,7 @@ async function processDayBillEvent(event, processedBy) {
                 p.product_name,
                 dbi.quantity,
                 dbi.total_amount,
-                dbi.base_amount,
+                dbi.taxable_amount,
                 dbi.cgst_amount,
                 dbi.sgst_amount
             FROM t_day_bill_items dbi
@@ -564,7 +564,7 @@ async function processDayBillEvent(event, processedBy) {
             if (!salesLedgerId) throw new Error(`Sales ledger not configured for product ${item.product_name} (id:${item.product_id})`);
 
             const itemTotal   = parseFloat(item.total_amount);
-            const itemBase    = parseFloat(item.base_amount  || itemTotal);
+            const itemBase    = parseFloat(item.taxable_amount || itemTotal);
             const itemCgst    = parseFloat(item.cgst_amount  || 0);
             const itemSgst    = parseFloat(item.sgst_amount  || 0);
             const itemNarration = `${parseFloat(item.quantity).toFixed(3)} ${item.product_name} | ₹${itemTotal.toFixed(2)} | ${headerNarration}`;
@@ -910,7 +910,7 @@ async function processLubesInvoiceEvent(event, processedBy) {
             h.lubes_hdr_id,
             h.closing_status,
             h.invoice_date,
-            h.invoice_no,
+            h.invoice_number,
             s.supplier_name,
             h.supplier_id
         FROM t_lubes_inv_hdr h
@@ -946,7 +946,7 @@ async function processLubesInvoiceEvent(event, processedBy) {
     const supplierLedgerId = await resolveLedger(location_code, 'SUPPLIER', hdr.supplier_id);
     if (!supplierLedgerId) throw new Error(`Supplier GL ledger not found for ${hdr.supplier_name} (supplier_id:${hdr.supplier_id})`);
 
-    const narration = `Lubes Invoice ${hdr.invoice_no || lubesHdrId} | ${hdr.supplier_name} | ${event_date}`;
+    const narration = `Lubes Invoice ${hdr.invoice_number || lubesHdrId} | ${hdr.supplier_name} | ${event_date}`;
     const journalLines = [];
     let totalCr = 0;
 
@@ -1007,7 +1007,7 @@ async function processTankInvoiceEvent(event, processedBy) {
     const hdrs = await db.sequelize.query(`
         SELECT
             ti.id,
-            ti.invoice_no,
+            ti.invoice_number,
             ti.invoice_date,
             ti.supplier_id,
             s.supplier_name
@@ -1022,7 +1022,7 @@ async function processTankInvoiceEvent(event, processedBy) {
     const supplierLedgerId = await resolveLedger(location_code, 'SUPPLIER', hdr.supplier_id);
     if (!supplierLedgerId) throw new Error(`Supplier GL ledger not found for ${hdr.supplier_name} (supplier_id:${hdr.supplier_id})`);
 
-    const narration = `Tank Invoice ${hdr.invoice_no || invoiceId} | ${hdr.supplier_name} | ${event_date}`;
+    const narration = `Tank Invoice ${hdr.invoice_number || invoiceId} | ${hdr.supplier_name} | ${event_date}`;
     const journalLines = [];
     let totalCr = 0;
 

--- a/services/create-accounting-service.js
+++ b/services/create-accounting-service.js
@@ -1,0 +1,834 @@
+// services/create-accounting-service.js
+// GL accounting engine — processes gl_accounting_events → gl_journal_headers + gl_journal_lines
+//
+// Event types handled:
+//   CREDIT_SALE  (source_id = tcredit_id)   — Customer DR / Sales CR + Output CGST CR + Output SGST CR
+//   CASH_SALE    (source_id = cashsales_id)  — Cash DR / Sales CR + Output CGST CR + Output SGST CR
+//   DAY_BILL     (source_id = day_bill_id)   — Cash/Digital DR / Sales CR + GST CRs per product line
+//   BANK_TXN     (source_id = t_bank_id)     — bank statement / oil-company SOA line
+//
+// Raised automatically by DB triggers on t_credits, t_cashsales, t_day_bill,
+// t_bank_transaction, and t_bank_transaction_splits.
+// UPDATE events reverse existing vouchers and regenerate fresh ones.
+// DELETE events reverse only.
+
+const db = require('../db/db-connection');
+const { QueryTypes } = require('sequelize');
+
+const VOUCHER_PREFIXES = {
+    SALES:    'SAL',
+    PURCHASE: 'PUR',
+    PAYMENT:  'PMT',
+    RECEIPT:  'RCT',
+    JOURNAL:  'JNL',
+    CONTRA:   'CNT'
+};
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+async function processEvents(locationCode, fromDate, toDate, processedBy) {
+    const events = await db.sequelize.query(`
+        SELECT * FROM gl_accounting_events
+        WHERE location_code = :locationCode
+          AND event_date BETWEEN :fromDate AND :toDate
+          AND event_status = 'UNPROCESSED'
+        ORDER BY event_date, event_id
+    `, {
+        replacements: { locationCode, fromDate, toDate },
+        type: QueryTypes.SELECT
+    });
+
+    const summary = { processed: 0, errors: 0, skipped: 0, details: [] };
+
+    for (const event of events) {
+        try {
+            const result = await processEvent(event, processedBy);
+            summary.processed += result.voucherCount;
+            summary.details.push({ event_id: event.event_id, status: 'PROCESSED', vouchers: result.voucherCount });
+        } catch (err) {
+            await markEventError(event.event_id, err.message);
+            summary.errors++;
+            summary.details.push({ event_id: event.event_id, status: 'ERROR', message: err.message });
+        }
+    }
+
+    return summary;
+}
+
+async function reprocessEvents(locationCode, fromDate, toDate, processedBy) {
+    await db.sequelize.query(`
+        UPDATE gl_accounting_events
+        SET event_status  = 'UNPROCESSED',
+            event_type    = 'UPDATE',
+            voucher_id    = NULL,
+            error_message = NULL,
+            processed_at  = NULL,
+            processed_by  = NULL
+        WHERE location_code = :locationCode
+          AND event_date BETWEEN :fromDate AND :toDate
+          AND event_status IN ('PROCESSED', 'ERROR')
+    `, {
+        replacements: { locationCode, fromDate, toDate },
+        type: QueryTypes.UPDATE
+    });
+
+    return await processEvents(locationCode, fromDate, toDate, processedBy);
+}
+
+module.exports = { processEvents, reprocessEvents };
+
+// ─── Event Dispatcher ─────────────────────────────────────────────────────────
+
+async function processEvent(event, processedBy) {
+    if (event.event_type === 'UPDATE' || event.event_type === 'DELETE') {
+        await reverseExistingVouchers(event.location_code, event.source_type, event.source_id, processedBy);
+    }
+
+    if (event.event_type === 'DELETE') {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    switch (event.source_type) {
+        case 'CREDIT_SALE':   return await processCreditSaleEvent(event, processedBy);
+        case 'CASH_SALE':     return await processCashSaleEvent(event, processedBy);
+        case 'DAY_BILL':      return await processDayBillEvent(event, processedBy);
+        case 'BANK_TXN':      return await processBankTxnEvent(event, processedBy);
+        default:
+            throw new Error(`Unhandled source_type: ${event.source_type}`);
+    }
+}
+
+// ─── CREDIT_SALE Handler ──────────────────────────────────────────────────────
+// Customer DR (total) → Sales CR (base) + Output CGST CR + Output SGST CR
+
+async function processCreditSaleEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: tcreditId, event_date } = event;
+
+    const rows = await db.sequelize.query(`
+        SELECT
+            tc.tcredit_id,
+            tc.product_id,
+            p.product_name,
+            tc.creditlist_id,
+            cl.Company_Name AS customer_name,
+            tc.qty,
+            tc.amount,
+            tc.base_amount,
+            tc.cgst_amount,
+            tc.sgst_amount,
+            tc.bill_no
+        FROM t_credits tc
+        JOIN m_product p       ON p.product_id     = tc.product_id
+        JOIN m_credit_list cl  ON cl.creditlist_id  = tc.creditlist_id
+        WHERE tc.tcredit_id = :tcreditId
+    `, {
+        replacements: { tcreditId },
+        type: QueryTypes.SELECT
+    });
+
+    if (!rows.length) throw new Error(`Credit entry not found: tcredit_id=${tcreditId}`);
+    const row = rows[0];
+
+    const salesLedgerId = await resolveProductLedger(location_code, row.product_id, 'SALES');
+    if (!salesLedgerId) throw new Error(`Sales ledger not configured for product ${row.product_name} (id:${row.product_id})`);
+
+    const customerLedgerId = await resolveLedger(location_code, 'CREDIT', row.creditlist_id);
+    if (!customerLedgerId) throw new Error(`GL ledger not found for customer ${row.customer_name} (creditlist_id:${row.creditlist_id})`);
+
+    const totalAmount = parseFloat(row.amount);
+    const baseAmount  = parseFloat(row.base_amount  || totalAmount);
+    const cgstAmount  = parseFloat(row.cgst_amount  || 0);
+    const sgstAmount  = parseFloat(row.sgst_amount  || 0);
+    const qty         = parseFloat(row.qty).toFixed(3);
+    const narration   = `${qty} ${row.product_name} | ₹${totalAmount.toFixed(2)} | ${row.customer_name} | Bill: ${row.bill_no}`;
+
+    const lines = [
+        { ledger_id: customerLedgerId, dr_amount: totalAmount, cr_amount: 0,           narration },
+        { ledger_id: salesLedgerId,    dr_amount: 0,           cr_amount: baseAmount,  narration }
+    ];
+
+    if (cgstAmount > 0) {
+        const cgstLedgerId = await resolveProductLedger(location_code, row.product_id, 'OUTPUT_CGST');
+        if (!cgstLedgerId) throw new Error(`OUTPUT_CGST ledger not mapped for product ${row.product_name} at ${location_code}`);
+        lines.push({ ledger_id: cgstLedgerId, dr_amount: 0, cr_amount: cgstAmount, narration });
+    }
+    if (sgstAmount > 0) {
+        const sgstLedgerId = await resolveProductLedger(location_code, row.product_id, 'OUTPUT_SGST');
+        if (!sgstLedgerId) throw new Error(`OUTPUT_SGST ledger not mapped for product ${row.product_name} at ${location_code}`);
+        lines.push({ ledger_id: sgstLedgerId, dr_amount: 0, cr_amount: sgstAmount, narration });
+    }
+
+    const vid = await createVoucher({
+        locationCode: location_code,
+        fyId:         fy_id,
+        voucherType:  'SALES',
+        voucherDate:  event_date,
+        sourceType:   'CREDIT_SALE',
+        sourceId:     tcreditId,
+        narration,
+        lines,
+        postedBy: processedBy
+    });
+
+    await markEventProcessed(event.event_id, vid, processedBy);
+    return { voucherCount: 1 };
+}
+
+// ─── CASH_SALE Handler ────────────────────────────────────────────────────────
+// Cash DR (total) → Sales CR (base) + Output CGST CR + Output SGST CR
+
+async function processCashSaleEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: cashsalesId, event_date } = event;
+
+    const rows = await db.sequelize.query(`
+        SELECT
+            cs.cashsales_id,
+            cs.product_id,
+            p.product_name,
+            cs.qty,
+            cs.amount,
+            cs.base_amount,
+            cs.cgst_amount,
+            cs.sgst_amount,
+            cs.bill_no
+        FROM t_cashsales cs
+        JOIN m_product p ON p.product_id = cs.product_id
+        WHERE cs.cashsales_id = :cashsalesId
+    `, {
+        replacements: { cashsalesId },
+        type: QueryTypes.SELECT
+    });
+
+    if (!rows.length) throw new Error(`Cash sale not found: cashsales_id=${cashsalesId}`);
+    const row = rows[0];
+
+    if (parseFloat(row.amount) <= 0) {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const salesLedgerId = await resolveProductLedger(location_code, row.product_id, 'SALES');
+    if (!salesLedgerId) throw new Error(`Sales ledger not configured for product ${row.product_name} (id:${row.product_id})`);
+
+    const cashLedgerId = await resolveCashLedger(location_code);
+    if (!cashLedgerId) throw new Error(`Cash-in-Hand ledger not found for location ${location_code}`);
+
+    const totalAmount = parseFloat(row.amount);
+    const baseAmount  = parseFloat(row.base_amount  || totalAmount);
+    const cgstAmount  = parseFloat(row.cgst_amount  || 0);
+    const sgstAmount  = parseFloat(row.sgst_amount  || 0);
+    const qty         = parseFloat(row.qty).toFixed(3);
+    const narration   = `${qty} ${row.product_name} | ₹${totalAmount.toFixed(2)} | Bill: ${row.bill_no}`;
+
+    const lines = [
+        { ledger_id: cashLedgerId,  dr_amount: totalAmount, cr_amount: 0,          narration },
+        { ledger_id: salesLedgerId, dr_amount: 0,           cr_amount: baseAmount, narration }
+    ];
+
+    if (cgstAmount > 0) {
+        const cgstLedgerId = await resolveProductLedger(location_code, row.product_id, 'OUTPUT_CGST');
+        if (!cgstLedgerId) throw new Error(`OUTPUT_CGST ledger not mapped for product ${row.product_name} at ${location_code}`);
+        lines.push({ ledger_id: cgstLedgerId, dr_amount: 0, cr_amount: cgstAmount, narration });
+    }
+    if (sgstAmount > 0) {
+        const sgstLedgerId = await resolveProductLedger(location_code, row.product_id, 'OUTPUT_SGST');
+        if (!sgstLedgerId) throw new Error(`OUTPUT_SGST ledger not mapped for product ${row.product_name} at ${location_code}`);
+        lines.push({ ledger_id: sgstLedgerId, dr_amount: 0, cr_amount: sgstAmount, narration });
+    }
+
+    const vid = await createVoucher({
+        locationCode: location_code,
+        fyId:         fy_id,
+        voucherType:  'SALES',
+        voucherDate:  event_date,
+        sourceType:   'CASH_SALE',
+        sourceId:     cashsalesId,
+        narration,
+        lines,
+        postedBy: processedBy
+    });
+
+    await markEventProcessed(event.event_id, vid, processedBy);
+    return { voucherCount: 1 };
+}
+
+// ─── DAY_BILL Handler ─────────────────────────────────────────────────────────
+// One voucher per day bill header:
+//   CASH header   → Cash DR          → Product Sales CR (per product line)
+//   DIGITAL header → Vendor (creditlist card_flag=Y) DR → Product Sales CR (per product line)
+
+async function processDayBillEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: dayBillId, event_date } = event;
+    const voucherIds = [];
+
+    // Fetch all headers for this day bill
+    const headers = await db.sequelize.query(`
+        SELECT
+            dbh.header_id,
+            dbh.bill_type,
+            dbh.vendor_id,
+            dbh.total_amount,
+            CASE WHEN dbh.bill_type = 'DIGITAL' THEN cl.Company_Name ELSE 'CASH' END AS party_name
+        FROM t_day_bill_header dbh
+        LEFT JOIN m_credit_list cl ON cl.creditlist_id = dbh.vendor_id
+        WHERE dbh.day_bill_id = :dayBillId
+        ORDER BY dbh.bill_type, dbh.header_id
+    `, {
+        replacements: { dayBillId },
+        type: QueryTypes.SELECT
+    });
+
+    if (!headers.length) {
+        // Day bill exists but has no headers yet (regeneration in progress) — skip silently
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const cashLedgerId = await resolveCashLedger(location_code);
+    if (!cashLedgerId) throw new Error(`Cash-in-Hand ledger not found for location ${location_code}`);
+
+    for (const header of headers) {
+        if (parseFloat(header.total_amount) <= 0) continue;
+
+        // Resolve the debit ledger
+        let drLedgerId;
+        if (header.bill_type === 'CASH') {
+            drLedgerId = cashLedgerId;
+        } else {
+            // Digital vendor — creditlist with card_flag=Y
+            drLedgerId = await resolveLedger(location_code, 'CREDIT', header.vendor_id);
+            if (!drLedgerId) throw new Error(`GL ledger not found for digital vendor ${header.party_name} (creditlist_id:${header.vendor_id})`);
+        }
+
+        // Fetch line items for this header
+        const items = await db.sequelize.query(`
+            SELECT
+                dbi.product_id,
+                p.product_name,
+                dbi.quantity,
+                dbi.total_amount,
+                dbi.base_amount,
+                dbi.cgst_amount,
+                dbi.sgst_amount
+            FROM t_day_bill_items dbi
+            JOIN m_product p ON p.product_id = dbi.product_id
+            WHERE dbi.header_id = :headerId
+              AND dbi.total_amount > 0
+        `, {
+            replacements: { headerId: header.header_id },
+            type: QueryTypes.SELECT
+        });
+
+        if (!items.length) continue;
+
+        // Build journal lines — one DR line (payment method) + Sales/GST CR lines per product
+        const lines = [];
+        const totalAmount = parseFloat(header.total_amount);
+        const headerNarration = `Day Bill ${header.bill_type}${header.bill_type === 'DIGITAL' ? ' — ' + header.party_name : ''} | ₹${totalAmount.toFixed(2)} | ${event_date}`;
+
+        // Debit: payment method (Cash or Digital vendor) for total
+        lines.push({ ledger_id: drLedgerId, dr_amount: totalAmount, cr_amount: 0, narration: headerNarration });
+
+        // Credit: Sales (base) + Output CGST + Output SGST per product
+        for (const item of items) {
+            const salesLedgerId = await resolveProductLedger(location_code, item.product_id, 'SALES');
+            if (!salesLedgerId) throw new Error(`Sales ledger not configured for product ${item.product_name} (id:${item.product_id})`);
+
+            const itemTotal   = parseFloat(item.total_amount);
+            const itemBase    = parseFloat(item.base_amount  || itemTotal);
+            const itemCgst    = parseFloat(item.cgst_amount  || 0);
+            const itemSgst    = parseFloat(item.sgst_amount  || 0);
+            const itemNarration = `${parseFloat(item.quantity).toFixed(3)} ${item.product_name} | ₹${itemTotal.toFixed(2)} | ${headerNarration}`;
+
+            lines.push({ ledger_id: salesLedgerId, dr_amount: 0, cr_amount: itemBase, narration: itemNarration });
+
+            if (itemCgst > 0) {
+                const cgstLedgerId = await resolveProductLedger(location_code, item.product_id, 'OUTPUT_CGST');
+                if (!cgstLedgerId) throw new Error(`OUTPUT_CGST ledger not mapped for product ${item.product_name} at ${location_code}`);
+                lines.push({ ledger_id: cgstLedgerId, dr_amount: 0, cr_amount: itemCgst, narration: itemNarration });
+            }
+            if (itemSgst > 0) {
+                const sgstLedgerId = await resolveProductLedger(location_code, item.product_id, 'OUTPUT_SGST');
+                if (!sgstLedgerId) throw new Error(`OUTPUT_SGST ledger not mapped for product ${item.product_name} at ${location_code}`);
+                lines.push({ ledger_id: sgstLedgerId, dr_amount: 0, cr_amount: itemSgst, narration: itemNarration });
+            }
+        }
+
+        const vid = await createVoucher({
+            locationCode: location_code,
+            fyId:         fy_id,
+            voucherType:  'SALES',
+            voucherDate:  event_date,
+            sourceType:   'DAY_BILL',
+            sourceId:     dayBillId,
+            narration:    headerNarration,
+            lines,
+            postedBy:     processedBy
+        });
+        voucherIds.push(vid);
+    }
+
+    await markEventProcessed(event.event_id, voucherIds[voucherIds.length - 1] || null, processedBy);
+    return { voucherCount: voucherIds.length };
+}
+
+// ─── BANK_TXN Handler ────────────────────────────────────────────────────────
+// One voucher per classified bank transaction (real bank or oil company SOA line).
+//
+// Skip conditions:
+//   • accounting_type IS NULL          — not yet classified; mark PROCESSED 0 vouchers
+//   • amount = 0                       — nothing to journal
+//   • is_oil_company='Y' + external_source='Bank' — SOA payment receipt line;
+//                                        the real bank statement row already journals it
+//   • is_oil_company='N' + external_source='Bank' + credit_amount>0
+//                                      — receiving side of a contra; the paying bank's
+//                                        debit row journals the transfer
+//   • external_source='Static' + ledger in 'Purchase Accounts' group
+//                                      — purchase invoice handler covers this
+//
+// Direction logic:
+//   Real bank:       credit_amount>0 → Bank DR, counterpart CR
+//                    debit_amount>0  → counterpart DR, Bank CR
+//   Oil company SOA: credit_amount>0 → Sundry Creditor CR (charge, we owe more), counterpart DR
+//                    debit_amount>0  → Sundry Creditor DR (rebate, we owe less), counterpart CR
+
+const ACCOUNTING_TYPE_VOUCHER_MAP = {
+    'Payment':  'PAYMENT',
+    'Receipt':  'RECEIPT',
+    'Contra':   'CONTRA',
+    'Journal':  'JOURNAL',
+    'Purchase': 'PURCHASE',
+};
+
+async function processBankTxnEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: tBankId, event_date } = event;
+
+    const rows = await db.sequelize.query(`
+        SELECT
+            tbt.t_bank_id,
+            tbt.bank_id,
+            tbt.trans_date,
+            tbt.credit_amount,
+            tbt.debit_amount,
+            tbt.accounting_type,
+            tbt.ledger_name,
+            tbt.external_id,
+            tbt.external_source,
+            tbt.is_split,
+            tbt.remarks,
+            mb.is_oil_company,
+            mb.supplier_id,
+            mb.bank_name,
+            mb.location_code AS bank_location
+        FROM t_bank_transaction tbt
+        JOIN m_bank mb ON mb.bank_id = tbt.bank_id
+        WHERE tbt.t_bank_id = :tBankId
+    `, { replacements: { tBankId }, type: QueryTypes.SELECT });
+
+    if (!rows.length) throw new Error(`Bank transaction not found: t_bank_id=${tBankId}`);
+    const txn = rows[0];
+
+    // Skip: transaction not yet classified
+    if (!txn.accounting_type) {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const creditAmt = parseFloat(txn.credit_amount || 0);
+    const debitAmt  = parseFloat(txn.debit_amount  || 0);
+    const txnAmount = creditAmt > 0 ? creditAmt : debitAmt;
+
+    if (txnAmount <= 0) {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const isOilCo = txn.is_oil_company === 'Y';
+
+    // Skip: all external_source='Bank' lines on oil-company SOA (our payment receipt lines —
+    // the real bank statement already journals the payment)
+    if (isOilCo && txn.external_source === 'Bank') {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    // Skip: receiving side of a contra between real banks
+    if (!isOilCo && txn.external_source === 'Bank' && creditAmt > 0) {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const voucherType = ACCOUNTING_TYPE_VOUCHER_MAP[txn.accounting_type];
+    if (!voucherType) throw new Error(`Unknown accounting_type: '${txn.accounting_type}' on t_bank_id=${tBankId}`);
+
+    // Resolve the bank's own GL ledger
+    let bankLedgerId;
+    if (isOilCo) {
+        if (!txn.supplier_id) throw new Error(`Oil company bank '${txn.bank_name}' (bank_id:${txn.bank_id}) has no supplier_id linked — update m_bank.supplier_id`);
+        bankLedgerId = await resolveLedger(location_code, 'SUPPLIER', txn.supplier_id);
+        if (!bankLedgerId) throw new Error(`SUPPLIER GL ledger not found for bank '${txn.bank_name}' (supplier_id:${txn.supplier_id})`);
+    } else {
+        bankLedgerId = await resolveLedger(location_code, 'BANK', txn.bank_id);
+        if (!bankLedgerId) throw new Error(`BANK GL ledger not found for bank '${txn.bank_name}' (bank_id:${txn.bank_id})`);
+    }
+
+    // For real bank: credit_amount → bank is DR; debit_amount → bank is CR
+    // For oil company SOA: credit_amount → bank (Sundry Creditor) is CR; debit_amount → bank (SC) is DR
+    // The "bankSide" determines where the bank ledger goes in the journal lines.
+    const bankIsDr = isOilCo ? debitAmt > 0 : creditAmt > 0;
+
+    const narration = txn.remarks
+        ? txn.remarks
+        : `${txn.accounting_type} | ${txn.bank_name} | ₹${txnAmount.toFixed(2)} | ${event_date}`;
+
+    let lines;
+
+    if (txn.is_split === 'Y') {
+        lines = await buildSplitLines(tBankId, bankLedgerId, bankIsDr, txnAmount, narration, location_code);
+    } else {
+        const counterLedgerId = await resolveCounterpartLedger(txn, location_code, event.event_id, processedBy);
+        if (counterLedgerId === null) {
+            // resolveCounterpartLedger already called markEventProcessed for skip cases
+            return { voucherCount: 0 };
+        }
+        lines = buildTwoLineJournal(bankLedgerId, counterLedgerId, bankIsDr, txnAmount, narration);
+    }
+
+    const vid = await createVoucher({
+        locationCode: location_code,
+        fyId:         fy_id,
+        voucherType,
+        voucherDate:  event_date,
+        sourceType:   'BANK_TXN',
+        sourceId:     tBankId,
+        narration,
+        lines,
+        postedBy:     processedBy
+    });
+
+    await markEventProcessed(event.event_id, vid, processedBy);
+    return { voucherCount: 1 };
+}
+
+// Returns counterpart ledger_id, or null if the event was already marked PROCESSED (skip).
+// Throws on unresolvable ledger.
+async function resolveCounterpartLedger(txn, locationCode, eventId, processedBy) {
+    const { external_source, external_id, ledger_name } = txn;
+
+    if (external_source === 'Static') {
+        const info = await resolveLedgerByName(locationCode, ledger_name);
+        if (!info) throw new Error(`Static GL ledger '${ledger_name}' not found for location ${locationCode}`);
+        if (info.group_name === 'Purchase Accounts') {
+            // Purchase invoices are journaled by the PURCHASE_INVOICE handler — skip here
+            await markEventProcessed(eventId, null, processedBy);
+            return null;
+        }
+        return info.ledger_id;
+    }
+
+    if (external_source === 'Credit') {
+        const id = await resolveLedger(locationCode, 'CREDIT', external_id);
+        if (!id) throw new Error(`CREDIT GL ledger not found for creditlist_id=${external_id}`);
+        return id;
+    }
+
+    if (external_source === 'Supplier') {
+        const id = await resolveLedger(locationCode, 'SUPPLIER', external_id);
+        if (!id) throw new Error(`SUPPLIER GL ledger not found for supplier_id=${external_id}`);
+        return id;
+    }
+
+    if (external_source === 'Bank') {
+        // Debit-side of a real-bank contra (credit side was already skipped above)
+        const id = await resolveLedger(locationCode, 'BANK', external_id);
+        if (!id) throw new Error(`BANK GL ledger not found for contra bank_id=${external_id}`);
+        return id;
+    }
+
+    throw new Error(`Cannot resolve counterpart ledger: external_source='${external_source}', external_id=${external_id}, ledger_name='${ledger_name}'`);
+}
+
+async function buildSplitLines(tBankId, bankLedgerId, bankIsDr, txnAmount, narration, locationCode) {
+    const splits = await db.sequelize.query(`
+        SELECT split_id, amount, ledger_name, external_id, external_source, remarks
+        FROM t_bank_transaction_splits
+        WHERE t_bank_id = :tBankId
+        ORDER BY split_id
+    `, { replacements: { tBankId }, type: QueryTypes.SELECT });
+
+    if (!splits.length) throw new Error(`Split transaction t_bank_id=${tBankId} has no split rows`);
+
+    const lines = [];
+    // Bank line covers the total
+    lines.push(bankIsDr
+        ? { ledger_id: bankLedgerId, dr_amount: txnAmount, cr_amount: 0,         narration }
+        : { ledger_id: bankLedgerId, dr_amount: 0,         cr_amount: txnAmount, narration }
+    );
+
+    for (const split of splits) {
+        const splitAmt = parseFloat(split.amount);
+        const splitNarration = split.remarks || narration;
+        const counterLedgerId = await resolveSplitCounterLedger(split, locationCode);
+        lines.push(bankIsDr
+            ? { ledger_id: counterLedgerId, dr_amount: 0,        cr_amount: splitAmt, narration: splitNarration }
+            : { ledger_id: counterLedgerId, dr_amount: splitAmt, cr_amount: 0,        narration: splitNarration }
+        );
+    }
+
+    return lines;
+}
+
+async function resolveSplitCounterLedger(split, locationCode) {
+    const { external_source, external_id, ledger_name, split_id } = split;
+    const errCtx = `split_id=${split_id}`;
+
+    if (external_source === 'Static') {
+        const info = await resolveLedgerByName(locationCode, ledger_name);
+        if (!info) throw new Error(`Static GL ledger '${ledger_name}' not found for ${errCtx}`);
+        return info.ledger_id;
+    }
+    if (external_source === 'Credit') {
+        const id = await resolveLedger(locationCode, 'CREDIT', external_id);
+        if (!id) throw new Error(`CREDIT GL ledger not found for creditlist_id=${external_id} (${errCtx})`);
+        return id;
+    }
+    if (external_source === 'Supplier') {
+        const id = await resolveLedger(locationCode, 'SUPPLIER', external_id);
+        if (!id) throw new Error(`SUPPLIER GL ledger not found for supplier_id=${external_id} (${errCtx})`);
+        return id;
+    }
+    if (external_source === 'Bank') {
+        const id = await resolveLedger(locationCode, 'BANK', external_id);
+        if (!id) throw new Error(`BANK GL ledger not found for bank_id=${external_id} (${errCtx})`);
+        return id;
+    }
+    throw new Error(`Cannot resolve split ledger: source='${external_source}', id=${external_id} (${errCtx})`);
+}
+
+function buildTwoLineJournal(bankLedgerId, counterLedgerId, bankIsDr, amount, narration) {
+    if (bankIsDr) {
+        return [
+            { ledger_id: bankLedgerId,    dr_amount: amount, cr_amount: 0,      narration },
+            { ledger_id: counterLedgerId, dr_amount: 0,      cr_amount: amount, narration }
+        ];
+    } else {
+        return [
+            { ledger_id: counterLedgerId, dr_amount: amount, cr_amount: 0,      narration },
+            { ledger_id: bankLedgerId,    dr_amount: 0,      cr_amount: amount, narration }
+        ];
+    }
+}
+
+// ─── Voucher Utilities ────────────────────────────────────────────────────────
+
+async function createVoucher({ locationCode, fyId, voucherType, voucherDate, sourceType, sourceId, narration, lines, postedBy }) {
+    const totalDr = lines.reduce((s, l) => s + (l.dr_amount || 0), 0);
+    const totalCr = lines.reduce((s, l) => s + (l.cr_amount || 0), 0);
+    if (Math.abs(totalDr - totalCr) > 0.005) {
+        throw new Error(`Voucher does not balance: DR ${totalDr.toFixed(2)} vs CR ${totalCr.toFixed(2)}`);
+    }
+
+    const voucherNo = await generateVoucherNo(locationCode, fyId, voucherType);
+
+    const [voucherId] = await db.sequelize.query(`
+        INSERT INTO gl_journal_headers
+            (location_code, fy_id, voucher_type, voucher_date, voucher_no,
+             narration, source_type, source_id, is_reversal, is_exported,
+             posted_by, created_by)
+        VALUES
+            (:locationCode, :fyId, :voucherType, :voucherDate, :voucherNo,
+             :narration, :sourceType, :sourceId, 'N', 'N',
+             :postedBy, :postedBy)
+    `, {
+        replacements: { locationCode, fyId, voucherType, voucherDate, voucherNo, narration, sourceType, sourceId, postedBy },
+        type: QueryTypes.INSERT
+    });
+
+    for (let i = 0; i < lines.length; i++) {
+        const { ledger_id, dr_amount = 0, cr_amount = 0, narration: lineNarration = null } = lines[i];
+        await db.sequelize.query(`
+            INSERT INTO gl_journal_lines
+                (voucher_id, line_no, ledger_id, dr_amount, cr_amount, narration, created_by)
+            VALUES
+                (:voucherId, :lineNo, :ledgerId, :drAmount, :crAmount, :lineNarration, :postedBy)
+        `, {
+            replacements: { voucherId, lineNo: i + 1, ledgerId: ledger_id, drAmount: dr_amount, crAmount: cr_amount, lineNarration, postedBy },
+            type: QueryTypes.INSERT
+        });
+    }
+
+    return voucherId;
+}
+
+async function reverseExistingVouchers(locationCode, sourceType, sourceId, reversedBy) {
+    const existing = await db.sequelize.query(`
+        SELECT voucher_id, voucher_type, voucher_date, fy_id, narration
+        FROM gl_journal_headers
+        WHERE location_code = :locationCode
+          AND source_type   = :sourceType
+          AND source_id     = :sourceId
+          AND is_reversal   = 'N'
+    `, {
+        replacements: { locationCode, sourceType, sourceId },
+        type: QueryTypes.SELECT
+    });
+
+    for (const v of existing) {
+        const lines = await db.sequelize.query(`
+            SELECT ledger_id, cr_amount AS dr_amount, dr_amount AS cr_amount
+            FROM gl_journal_lines
+            WHERE voucher_id = :voucherId
+        `, {
+            replacements: { voucherId: v.voucher_id },
+            type: QueryTypes.SELECT
+        });
+
+        const voucherNo = await generateVoucherNo(locationCode, v.fy_id, v.voucher_type);
+
+        const [reversalId] = await db.sequelize.query(`
+            INSERT INTO gl_journal_headers
+                (location_code, fy_id, voucher_type, voucher_date, voucher_no,
+                 narration, source_type, source_id, is_reversal, reversal_of_voucher_id,
+                 is_exported, posted_by, created_by)
+            VALUES
+                (:locationCode, :fyId, :voucherType, NOW(), :voucherNo,
+                 :narration, :sourceType, :sourceId, 'Y', :originalId,
+                 'N', :reversedBy, :reversedBy)
+        `, {
+            replacements: {
+                locationCode,
+                fyId:        v.fy_id,
+                voucherType: v.voucher_type,
+                voucherNo,
+                narration:   `REVERSAL of ${v.voucher_type} — ${v.narration || ''}`,
+                sourceType,
+                sourceId,
+                originalId:  v.voucher_id,
+                reversedBy
+            },
+            type: QueryTypes.INSERT
+        });
+
+        for (let i = 0; i < lines.length; i++) {
+            const { ledger_id, dr_amount, cr_amount } = lines[i];
+            await db.sequelize.query(`
+                INSERT INTO gl_journal_lines
+                    (voucher_id, line_no, ledger_id, dr_amount, cr_amount, created_by)
+                VALUES (:reversalId, :lineNo, :ledgerId, :drAmount, :crAmount, :reversedBy)
+            `, {
+                replacements: { reversalId, lineNo: i + 1, ledgerId: ledger_id, drAmount: dr_amount, crAmount: cr_amount, reversedBy },
+                type: QueryTypes.INSERT
+            });
+        }
+    }
+}
+
+async function generateVoucherNo(locationCode, fyId, voucherType) {
+    const prefix = VOUCHER_PREFIXES[voucherType] || 'JNL';
+    const result = await db.sequelize.query(`
+        SELECT COALESCE(MAX(
+            CAST(SUBSTRING(voucher_no, LOCATE('-', voucher_no) + 1) AS UNSIGNED)
+        ), 0) + 1 AS next_no
+        FROM gl_journal_headers
+        WHERE location_code = :locationCode
+          AND fy_id         = :fyId
+          AND voucher_type  = :voucherType
+          AND voucher_no IS NOT NULL
+    `, {
+        replacements: { locationCode, fyId, voucherType },
+        type: QueryTypes.SELECT
+    });
+    const nextNo = result[0].next_no;
+    return `${prefix}-${String(nextNo).padStart(4, '0')}`;
+}
+
+// ─── Ledger Resolvers ─────────────────────────────────────────────────────────
+
+async function resolveLedger(locationCode, sourceType, sourceId) {
+    const rows = await db.sequelize.query(`
+        SELECT ledger_id FROM gl_ledgers
+        WHERE location_code = :locationCode
+          AND source_type   = :sourceType
+          AND source_id     = :sourceId
+        LIMIT 1
+    `, {
+        replacements: { locationCode, sourceType, sourceId },
+        type: QueryTypes.SELECT
+    });
+    return rows[0] ? rows[0].ledger_id : null;
+}
+
+async function resolveProductLedger(locationCode, productId, mapType) {
+    const rows = await db.sequelize.query(`
+        SELECT ledger_id FROM gl_product_ledger_map
+        WHERE location_code = :locationCode
+          AND product_id    = :productId
+          AND map_type      = :mapType
+        LIMIT 1
+    `, {
+        replacements: { locationCode, productId, mapType },
+        type: QueryTypes.SELECT
+    });
+    return rows[0] ? rows[0].ledger_id : null;
+}
+
+async function resolveLedgerByName(locationCode, ledgerName) {
+    const rows = await db.sequelize.query(`
+        SELECT l.ledger_id, g.group_name
+        FROM gl_ledgers l
+        JOIN gl_ledger_groups g ON g.group_id = l.group_id
+        WHERE l.location_code = :locationCode
+          AND l.ledger_name   = :ledgerName
+          AND l.active_flag   = 'Y'
+        LIMIT 1
+    `, {
+        replacements: { locationCode, ledgerName },
+        type: QueryTypes.SELECT
+    });
+    return rows[0] || null;
+}
+
+async function resolveCashLedger(locationCode) {
+    const rows = await db.sequelize.query(`
+        SELECT l.ledger_id FROM gl_ledgers l
+        JOIN gl_ledger_groups g ON g.group_id = l.group_id
+        WHERE l.location_code = :locationCode
+          AND g.group_name    = 'Cash-in-Hand'
+          AND l.active_flag   = 'Y'
+        LIMIT 1
+    `, {
+        replacements: { locationCode },
+        type: QueryTypes.SELECT
+    });
+    return rows[0] ? rows[0].ledger_id : null;
+}
+
+// ─── Event Status Helpers ─────────────────────────────────────────────────────
+
+async function markEventProcessed(eventId, voucherId, processedBy) {
+    await db.sequelize.query(`
+        UPDATE gl_accounting_events
+        SET event_status  = 'PROCESSED',
+            voucher_id    = :voucherId,
+            processed_at  = NOW(),
+            processed_by  = :processedBy
+        WHERE event_id = :eventId
+    `, {
+        replacements: { eventId, voucherId, processedBy },
+        type: QueryTypes.UPDATE
+    });
+}
+
+async function markEventError(eventId, errorMessage) {
+    await db.sequelize.query(`
+        UPDATE gl_accounting_events
+        SET event_status  = 'ERROR',
+            error_message = :errorMessage,
+            processed_at  = NOW()
+        WHERE event_id = :eventId
+    `, {
+        replacements: { eventId, errorMessage: String(errorMessage).substring(0, 1000) },
+        type: QueryTypes.UPDATE
+    });
+}

--- a/services/create-accounting-service.js
+++ b/services/create-accounting-service.js
@@ -2,13 +2,17 @@
 // GL accounting engine — processes gl_accounting_events → gl_journal_headers + gl_journal_lines
 //
 // Event types handled:
-//   CREDIT_SALE  (source_id = tcredit_id)   — Customer DR / Sales CR + Output CGST CR + Output SGST CR
-//   CASH_SALE    (source_id = cashsales_id)  — Cash DR / Sales CR + Output CGST CR + Output SGST CR
-//   DAY_BILL     (source_id = day_bill_id)   — Cash/Digital DR / Sales CR + GST CRs per product line
-//   BANK_TXN     (source_id = t_bank_id)     — bank statement / oil-company SOA line
+//   CREDIT_SALE         (source_id = tcredit_id)       — Customer DR / Sales CR + Output CGST/SGST CR
+//   CASH_SALE           (source_id = cashsales_id)     — Cash DR / Sales CR + Output CGST/SGST CR
+//   DAY_BILL            (source_id = day_bill_id)      — Cash/Digital DR / Sales CR + GST CRs per line
+//   BANK_TXN            (source_id = t_bank_id)        — bank statement / oil-company SOA line
+//   BOWSER_CREDIT_SALE  (source_id = credit_id)        — Customer DR / Sales CR (no GST, HSD 0%)
+//   BOWSER_CASH_SALE    (source_id = cashsale_id)      — Cash DR / Sales CR
+//   BOWSER_DIGITAL_SALE (source_id = digital_id)       — Vendor DR / Sales CR
+//   LUBES_INVOICE       (source_id = lubes_hdr_id)     — Purchase DR + Input CGST/SGST DR / Supplier CR
+//   TANK_INVOICE        (source_id = t_tank_invoice.id)— Purchase DR + Charges DR / Supplier CR
 //
-// Raised automatically by DB triggers on t_credits, t_cashsales, t_day_bill,
-// t_bank_transaction, and t_bank_transaction_splits.
+// Raised automatically by DB triggers on source tables.
 // UPDATE events reverse existing vouchers and regenerate fresh ones.
 // DELETE events reverse only.
 
@@ -24,23 +28,49 @@ const VOUCHER_PREFIXES = {
     CONTRA:   'CNT'
 };
 
+// Source types that belong to a shift — blocked if t_closing is still DRAFT.
+// BANK_TXN / PURCHASE_INVOICE / MANUAL_JOURNAL are not shift-bound and always process.
+const SHIFT_BOUND_TYPES  = new Set(['CREDIT_SALE', 'CASH_SALE', 'DAY_BILL']);
+
+// Source types that belong to a bowser closing — blocked if t_bowser_closing is still DRAFT.
+const BOWSER_BOUND_TYPES = new Set(['BOWSER_CREDIT_SALE', 'BOWSER_CASH_SALE', 'BOWSER_DIGITAL_SALE']);
+
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 async function processEvents(locationCode, fromDate, toDate, processedBy) {
-    const events = await db.sequelize.query(`
-        SELECT * FROM gl_accounting_events
-        WHERE location_code = :locationCode
-          AND event_date BETWEEN :fromDate AND :toDate
-          AND event_status = 'UNPROCESSED'
-        ORDER BY event_date, event_id
-    `, {
-        replacements: { locationCode, fromDate, toDate },
-        type: QueryTypes.SELECT
-    });
+    const [events, openShiftDates, openBowserDates] = await Promise.all([
+        db.sequelize.query(`
+            SELECT * FROM gl_accounting_events
+            WHERE location_code = :locationCode
+              AND event_date BETWEEN :fromDate AND :toDate
+              AND event_status = 'UNPROCESSED'
+            ORDER BY event_date, event_id
+        `, { replacements: { locationCode, fromDate, toDate }, type: QueryTypes.SELECT }),
+        getOpenShiftDates(locationCode, fromDate, toDate),
+        getOpenBowserDates(locationCode, fromDate, toDate)
+    ]);
 
-    const summary = { processed: 0, errors: 0, skipped: 0, details: [] };
+    const summary = { processed: 0, errors: 0, skipped: 0, blocked: 0, blockedDates: [], details: [] };
 
     for (const event of events) {
+        const eventDate = typeof event.event_date === 'string'
+            ? event.event_date.substring(0, 10)
+            : event.event_date.toISOString().substring(0, 10);
+
+        if (SHIFT_BOUND_TYPES.has(event.source_type) && openShiftDates.has(eventDate)) {
+            summary.blocked++;
+            if (!summary.blockedDates.includes(eventDate)) summary.blockedDates.push(eventDate);
+            summary.details.push({ event_id: event.event_id, status: 'BLOCKED', reason: `Shift on ${eventDate} is still DRAFT` });
+            continue;
+        }
+
+        if (BOWSER_BOUND_TYPES.has(event.source_type) && openBowserDates.has(eventDate)) {
+            summary.blocked++;
+            if (!summary.blockedDates.includes(eventDate)) summary.blockedDates.push(eventDate);
+            summary.details.push({ event_id: event.event_id, status: 'BLOCKED', reason: `Bowser closing on ${eventDate} is still DRAFT` });
+            continue;
+        }
+
         try {
             const result = await processEvent(event, processedBy);
             summary.processed += result.voucherCount;
@@ -75,7 +105,178 @@ async function reprocessEvents(locationCode, fromDate, toDate, processedBy) {
     return await processEvents(locationCode, fromDate, toDate, processedBy);
 }
 
-module.exports = { processEvents, reprocessEvents };
+module.exports = { processEvents, reprocessEvents, generateMissingEvents };
+
+// ─── Generate Missing Events ──────────────────────────────────────────────────
+// Backfill tool: scan each source table for records with no event and INSERT them.
+// Safe to run multiple times — NOT EXISTS guard prevents duplicates.
+
+async function generateMissingEvents(locationCode, fromDate, toDate, createdBy) {
+    const counts = {};
+    let total = 0;
+
+    const run = async (sourceType, sql) => {
+        const [, meta] = await db.sequelize.query(sql, {
+            replacements: { locationCode, fromDate, toDate, createdBy },
+            type: QueryTypes.INSERT
+        });
+        const n = meta?.affectedRows || 0;
+        counts[sourceType] = n;
+        total += n;
+    };
+
+    await run('CREDIT_SALE', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT cl.location_code, fy.fy_id, 'CREDIT_SALE', tc.tcredit_id, 'CREATE',
+               DATE(cl.closing_date), 'UNPROCESSED', :createdBy
+        FROM t_credits tc
+        JOIN t_closing cl ON cl.closing_id = tc.closing_id
+        JOIN gl_financial_years fy ON fy.location_code = cl.location_code
+            AND DATE(cl.closing_date) BETWEEN fy.start_date AND fy.end_date
+        WHERE cl.location_code = :locationCode
+          AND DATE(cl.closing_date) BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'CREDIT_SALE' AND e.source_id = tc.tcredit_id
+          )
+    `);
+
+    await run('CASH_SALE', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT cl.location_code, fy.fy_id, 'CASH_SALE', cs.cashsales_id, 'CREATE',
+               DATE(cl.closing_date), 'UNPROCESSED', :createdBy
+        FROM t_cashsales cs
+        JOIN t_closing cl ON cl.closing_id = cs.closing_id
+        JOIN gl_financial_years fy ON fy.location_code = cl.location_code
+            AND DATE(cl.closing_date) BETWEEN fy.start_date AND fy.end_date
+        WHERE cl.location_code = :locationCode
+          AND DATE(cl.closing_date) BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'CASH_SALE' AND e.source_id = cs.cashsales_id
+          )
+    `);
+
+    await run('DAY_BILL', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT db.location_code, fy.fy_id, 'DAY_BILL', db.day_bill_id, 'CREATE',
+               db.bill_date, 'UNPROCESSED', :createdBy
+        FROM t_day_bill db
+        JOIN gl_financial_years fy ON fy.location_code = db.location_code
+            AND db.bill_date BETWEEN fy.start_date AND fy.end_date
+        WHERE db.location_code = :locationCode
+          AND db.bill_date BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'DAY_BILL' AND e.source_id = db.day_bill_id
+          )
+    `);
+
+    await run('BANK_TXN', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT mb.location_code, fy.fy_id, 'BANK_TXN', tbt.t_bank_id, 'CREATE',
+               DATE(tbt.trans_date), 'UNPROCESSED', :createdBy
+        FROM t_bank_transaction tbt
+        JOIN m_bank mb ON mb.bank_id = tbt.bank_id
+        JOIN gl_financial_years fy ON fy.location_code = mb.location_code
+            AND DATE(tbt.trans_date) BETWEEN fy.start_date AND fy.end_date
+        WHERE mb.location_code = :locationCode
+          AND DATE(tbt.trans_date) BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'BANK_TXN' AND e.source_id = tbt.t_bank_id
+          )
+    `);
+
+    await run('BOWSER_CREDIT_SALE', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT tbc.location_code, fy.fy_id, 'BOWSER_CREDIT_SALE', bc.credit_id, 'CREATE',
+               DATE(tbc.closing_date), 'UNPROCESSED', :createdBy
+        FROM t_bowser_credits bc
+        JOIN t_bowser_closing tbc ON tbc.bowser_closing_id = bc.bowser_closing_id
+        JOIN gl_financial_years fy ON fy.location_code = tbc.location_code
+            AND DATE(tbc.closing_date) BETWEEN fy.start_date AND fy.end_date
+        WHERE tbc.location_code = :locationCode
+          AND DATE(tbc.closing_date) BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'BOWSER_CREDIT_SALE' AND e.source_id = bc.credit_id
+          )
+    `);
+
+    await run('BOWSER_CASH_SALE', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT tbc.location_code, fy.fy_id, 'BOWSER_CASH_SALE', bcs.cashsale_id, 'CREATE',
+               DATE(tbc.closing_date), 'UNPROCESSED', :createdBy
+        FROM t_bowser_cashsales bcs
+        JOIN t_bowser_closing tbc ON tbc.bowser_closing_id = bcs.bowser_closing_id
+        JOIN gl_financial_years fy ON fy.location_code = tbc.location_code
+            AND DATE(tbc.closing_date) BETWEEN fy.start_date AND fy.end_date
+        WHERE tbc.location_code = :locationCode
+          AND DATE(tbc.closing_date) BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'BOWSER_CASH_SALE' AND e.source_id = bcs.cashsale_id
+          )
+    `);
+
+    await run('BOWSER_DIGITAL_SALE', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT tbc.location_code, fy.fy_id, 'BOWSER_DIGITAL_SALE', bds.digital_id, 'CREATE',
+               DATE(tbc.closing_date), 'UNPROCESSED', :createdBy
+        FROM t_bowser_digital_sales bds
+        JOIN t_bowser_closing tbc ON tbc.bowser_closing_id = bds.bowser_closing_id
+        JOIN gl_financial_years fy ON fy.location_code = tbc.location_code
+            AND DATE(tbc.closing_date) BETWEEN fy.start_date AND fy.end_date
+        WHERE tbc.location_code = :locationCode
+          AND DATE(tbc.closing_date) BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'BOWSER_DIGITAL_SALE' AND e.source_id = bds.digital_id
+          )
+    `);
+
+    await run('LUBES_INVOICE', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT lh.location_code, fy.fy_id, 'LUBES_INVOICE', lh.lubes_hdr_id, 'CREATE',
+               lh.invoice_date, 'UNPROCESSED', :createdBy
+        FROM t_lubes_inv_hdr lh
+        JOIN gl_financial_years fy ON fy.location_code = lh.location_code
+            AND lh.invoice_date BETWEEN fy.start_date AND fy.end_date
+        WHERE lh.location_code = :locationCode
+          AND lh.invoice_date BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'LUBES_INVOICE' AND e.source_id = lh.lubes_hdr_id
+          )
+    `);
+
+    await run('TANK_INVOICE', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT ti.location_id, fy.fy_id, 'TANK_INVOICE', ti.id, 'CREATE',
+               ti.invoice_date, 'UNPROCESSED', :createdBy
+        FROM t_tank_invoice ti
+        JOIN gl_financial_years fy ON fy.location_code = ti.location_id
+            AND ti.invoice_date BETWEEN fy.start_date AND fy.end_date
+        WHERE ti.location_id = :locationCode
+          AND ti.invoice_date BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'TANK_INVOICE' AND e.source_id = ti.id
+          )
+    `);
+
+    return { counts, total };
+}
 
 // ─── Event Dispatcher ─────────────────────────────────────────────────────────
 
@@ -90,10 +291,15 @@ async function processEvent(event, processedBy) {
     }
 
     switch (event.source_type) {
-        case 'CREDIT_SALE':   return await processCreditSaleEvent(event, processedBy);
-        case 'CASH_SALE':     return await processCashSaleEvent(event, processedBy);
-        case 'DAY_BILL':      return await processDayBillEvent(event, processedBy);
-        case 'BANK_TXN':      return await processBankTxnEvent(event, processedBy);
+        case 'CREDIT_SALE':         return await processCreditSaleEvent(event, processedBy);
+        case 'CASH_SALE':           return await processCashSaleEvent(event, processedBy);
+        case 'DAY_BILL':            return await processDayBillEvent(event, processedBy);
+        case 'BANK_TXN':            return await processBankTxnEvent(event, processedBy);
+        case 'BOWSER_CREDIT_SALE':  return await processBowserCreditSaleEvent(event, processedBy);
+        case 'BOWSER_CASH_SALE':    return await processBowserCashSaleEvent(event, processedBy);
+        case 'BOWSER_DIGITAL_SALE': return await processBowserDigitalSaleEvent(event, processedBy);
+        case 'LUBES_INVOICE':       return await processLubesInvoiceEvent(event, processedBy);
+        case 'TANK_INVOICE':        return await processTankInvoiceEvent(event, processedBy);
         default:
             throw new Error(`Unhandled source_type: ${event.source_type}`);
     }
@@ -375,9 +581,10 @@ async function processDayBillEvent(event, processedBy) {
 
 // ─── BANK_TXN Handler ────────────────────────────────────────────────────────
 // One voucher per classified bank transaction (real bank or oil company SOA line).
+// Voucher type derived from context: PAYMENT / RECEIPT / CONTRA / JOURNAL (oil co SOA).
 //
 // Skip conditions:
-//   • accounting_type IS NULL          — not yet classified; mark PROCESSED 0 vouchers
+//   • ledger_name IS NULL              — not yet classified; mark PROCESSED 0 vouchers
 //   • amount = 0                       — nothing to journal
 //   • is_oil_company='Y' + external_source='Bank' — SOA payment receipt line;
 //                                        the real bank statement row already journals it
@@ -393,14 +600,6 @@ async function processDayBillEvent(event, processedBy) {
 //   Oil company SOA: credit_amount>0 → Sundry Creditor CR (charge, we owe more), counterpart DR
 //                    debit_amount>0  → Sundry Creditor DR (rebate, we owe less), counterpart CR
 
-const ACCOUNTING_TYPE_VOUCHER_MAP = {
-    'Payment':  'PAYMENT',
-    'Receipt':  'RECEIPT',
-    'Contra':   'CONTRA',
-    'Journal':  'JOURNAL',
-    'Purchase': 'PURCHASE',
-};
-
 async function processBankTxnEvent(event, processedBy) {
     const { location_code, fy_id, source_id: tBankId, event_date } = event;
 
@@ -411,7 +610,6 @@ async function processBankTxnEvent(event, processedBy) {
             tbt.trans_date,
             tbt.credit_amount,
             tbt.debit_amount,
-            tbt.accounting_type,
             tbt.ledger_name,
             tbt.external_id,
             tbt.external_source,
@@ -429,8 +627,8 @@ async function processBankTxnEvent(event, processedBy) {
     if (!rows.length) throw new Error(`Bank transaction not found: t_bank_id=${tBankId}`);
     const txn = rows[0];
 
-    // Skip: transaction not yet classified
-    if (!txn.accounting_type) {
+    // Skip: transaction not yet classified (no ledger assigned)
+    if (!txn.ledger_name) {
         await markEventProcessed(event.event_id, null, processedBy);
         return { voucherCount: 0 };
     }
@@ -459,9 +657,6 @@ async function processBankTxnEvent(event, processedBy) {
         return { voucherCount: 0 };
     }
 
-    const voucherType = ACCOUNTING_TYPE_VOUCHER_MAP[txn.accounting_type];
-    if (!voucherType) throw new Error(`Unknown accounting_type: '${txn.accounting_type}' on t_bank_id=${tBankId}`);
-
     // Resolve the bank's own GL ledger
     let bankLedgerId;
     if (isOilCo) {
@@ -480,7 +675,7 @@ async function processBankTxnEvent(event, processedBy) {
 
     const narration = txn.remarks
         ? txn.remarks
-        : `${txn.accounting_type} | ${txn.bank_name} | ₹${txnAmount.toFixed(2)} | ${event_date}`;
+        : `${txn.bank_name} | ${txn.ledger_name} | ₹${txnAmount.toFixed(2)} | ${event_date}`;
 
     let lines;
 
@@ -494,6 +689,8 @@ async function processBankTxnEvent(event, processedBy) {
         }
         lines = buildTwoLineJournal(bankLedgerId, counterLedgerId, bankIsDr, txnAmount, narration);
     }
+
+    const voucherType = deriveBankVoucherType(txn, bankIsDr);
 
     const vid = await createVoucher({
         locationCode: location_code,
@@ -509,6 +706,385 @@ async function processBankTxnEvent(event, processedBy) {
 
     await markEventProcessed(event.event_id, vid, processedBy);
     return { voucherCount: 1 };
+}
+
+// ─── BOWSER_CREDIT_SALE Handler ───────────────────────────────────────────────
+// Customer DR → HSD Sales CR
+// No GST split — HSD is 0% GST.
+
+async function processBowserCreditSaleEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: creditId, event_date } = event;
+
+    const rows = await db.sequelize.query(`
+        SELECT
+            bc.credit_id,
+            bc.product_id,
+            p.product_name,
+            bc.creditlist_id,
+            cl.Company_Name AS customer_name,
+            bc.quantity,
+            bc.amount,
+            bc.bill_no
+        FROM t_bowser_credits bc
+        JOIN m_product    p  ON p.product_id    = bc.product_id
+        JOIN m_credit_list cl ON cl.creditlist_id = bc.creditlist_id
+        WHERE bc.credit_id = :creditId
+    `, { replacements: { creditId }, type: QueryTypes.SELECT });
+
+    if (!rows.length) throw new Error(`Bowser credit sale not found: credit_id=${creditId}`);
+    const row = rows[0];
+
+    const salesLedgerId = await resolveProductLedger(location_code, row.product_id, 'SALES');
+    if (!salesLedgerId) throw new Error(`Sales ledger not configured for product ${row.product_name} (id:${row.product_id})`);
+
+    const customerLedgerId = await resolveLedger(location_code, 'CREDIT', row.creditlist_id);
+    if (!customerLedgerId) throw new Error(`GL ledger not found for customer ${row.customer_name} (creditlist_id:${row.creditlist_id})`);
+
+    const amount = parseFloat(row.amount);
+    const qty    = parseFloat(row.quantity).toFixed(3);
+    const narration = `${qty} ${row.product_name} | ₹${amount.toFixed(2)} | ${row.customer_name} | Bill: ${row.bill_no || '-'}`;
+
+    const vid = await createVoucher({
+        locationCode: location_code,
+        fyId:         fy_id,
+        voucherType:  'SALES',
+        voucherDate:  event_date,
+        sourceType:   'BOWSER_CREDIT_SALE',
+        sourceId:     creditId,
+        narration,
+        lines: [
+            { ledger_id: customerLedgerId, dr_amount: amount, cr_amount: 0,      narration },
+            { ledger_id: salesLedgerId,    dr_amount: 0,      cr_amount: amount, narration }
+        ],
+        postedBy: processedBy
+    });
+
+    await markEventProcessed(event.event_id, vid, processedBy);
+    return { voucherCount: 1 };
+}
+
+// ─── BOWSER_CASH_SALE Handler ─────────────────────────────────────────────────
+// Cash DR → HSD Sales CR
+
+async function processBowserCashSaleEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: cashsaleId, event_date } = event;
+
+    const rows = await db.sequelize.query(`
+        SELECT
+            bcs.cashsale_id,
+            bcs.product_id,
+            p.product_name,
+            bcs.amount
+        FROM t_bowser_cashsales bcs
+        JOIN m_product p ON p.product_id = bcs.product_id
+        WHERE bcs.cashsale_id = :cashsaleId
+    `, { replacements: { cashsaleId }, type: QueryTypes.SELECT });
+
+    if (!rows.length) throw new Error(`Bowser cash sale not found: cashsale_id=${cashsaleId}`);
+    const row = rows[0];
+
+    if (parseFloat(row.amount) <= 0) {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const salesLedgerId = await resolveProductLedger(location_code, row.product_id, 'SALES');
+    if (!salesLedgerId) throw new Error(`Sales ledger not configured for product ${row.product_name} (id:${row.product_id})`);
+
+    const cashLedgerId = await resolveCashLedger(location_code);
+    if (!cashLedgerId) throw new Error(`Cash-in-Hand ledger not found for location ${location_code}`);
+
+    const amount    = parseFloat(row.amount);
+    const narration = `${row.product_name} Cash Sale | ₹${amount.toFixed(2)} | ${event_date}`;
+
+    const vid = await createVoucher({
+        locationCode: location_code,
+        fyId:         fy_id,
+        voucherType:  'SALES',
+        voucherDate:  event_date,
+        sourceType:   'BOWSER_CASH_SALE',
+        sourceId:     cashsaleId,
+        narration,
+        lines: [
+            { ledger_id: cashLedgerId,  dr_amount: amount, cr_amount: 0,      narration },
+            { ledger_id: salesLedgerId, dr_amount: 0,      cr_amount: amount, narration }
+        ],
+        postedBy: processedBy
+    });
+
+    await markEventProcessed(event.event_id, vid, processedBy);
+    return { voucherCount: 1 };
+}
+
+// ─── BOWSER_DIGITAL_SALE Handler ──────────────────────────────────────────────
+// Digital vendor DR → HSD Sales CR
+// Product resolved from m_bowser (via t_bowser_closing) since t_bowser_digital_sales
+// has no product_id column.
+
+async function processBowserDigitalSaleEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: digitalId, event_date } = event;
+
+    const rows = await db.sequelize.query(`
+        SELECT
+            bds.digital_id,
+            bds.digital_vendor_id,
+            bds.amount,
+            mb.product_id,
+            p.product_name,
+            cl.Company_Name AS vendor_name
+        FROM t_bowser_digital_sales bds
+        JOIN t_bowser_closing tbc ON tbc.bowser_closing_id = bds.bowser_closing_id
+        JOIN m_bowser         mb  ON mb.bowser_id          = tbc.bowser_id
+        JOIN m_product        p   ON p.product_id          = mb.product_id
+        JOIN m_credit_list    cl  ON cl.creditlist_id      = bds.digital_vendor_id
+        WHERE bds.digital_id = :digitalId
+    `, { replacements: { digitalId }, type: QueryTypes.SELECT });
+
+    if (!rows.length) throw new Error(`Bowser digital sale not found: digital_id=${digitalId}`);
+    const row = rows[0];
+
+    if (parseFloat(row.amount) <= 0) {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const salesLedgerId = await resolveProductLedger(location_code, row.product_id, 'SALES');
+    if (!salesLedgerId) throw new Error(`Sales ledger not configured for product ${row.product_name} (id:${row.product_id})`);
+
+    const vendorLedgerId = await resolveLedger(location_code, 'CREDIT', row.digital_vendor_id);
+    if (!vendorLedgerId) throw new Error(`GL ledger not found for digital vendor ${row.vendor_name} (creditlist_id:${row.digital_vendor_id})`);
+
+    const amount    = parseFloat(row.amount);
+    const narration = `${row.product_name} Digital Sale | ₹${amount.toFixed(2)} | ${row.vendor_name} | ${event_date}`;
+
+    const vid = await createVoucher({
+        locationCode: location_code,
+        fyId:         fy_id,
+        voucherType:  'SALES',
+        voucherDate:  event_date,
+        sourceType:   'BOWSER_DIGITAL_SALE',
+        sourceId:     digitalId,
+        narration,
+        lines: [
+            { ledger_id: vendorLedgerId, dr_amount: amount, cr_amount: 0,      narration },
+            { ledger_id: salesLedgerId,  dr_amount: 0,      cr_amount: amount, narration }
+        ],
+        postedBy: processedBy
+    });
+
+    await markEventProcessed(event.event_id, vid, processedBy);
+    return { voucherCount: 1 };
+}
+
+// ─── LUBES_INVOICE Handler ────────────────────────────────────────────────────
+// Supplier CR (sum of all line amounts) → Purchase DR + Input CGST DR + Input SGST DR per line.
+// Skips silently if invoice is still DRAFT — UPDATE trigger fires again when it transitions to CLOSED.
+
+async function processLubesInvoiceEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: lubesHdrId, event_date } = event;
+
+    const hdrs = await db.sequelize.query(`
+        SELECT
+            h.lubes_hdr_id,
+            h.closing_status,
+            h.invoice_date,
+            h.invoice_no,
+            s.supplier_name,
+            h.supplier_id
+        FROM t_lubes_inv_hdr h
+        JOIN m_supplier s ON s.supplier_id = h.supplier_id
+        WHERE h.lubes_hdr_id = :lubesHdrId
+    `, { replacements: { lubesHdrId }, type: QueryTypes.SELECT });
+
+    if (!hdrs.length) throw new Error(`Lubes invoice not found: lubes_hdr_id=${lubesHdrId}`);
+    const hdr = hdrs[0];
+
+    // DRAFT gate — engine will re-run when UPDATE trigger fires on DRAFT→CLOSED transition
+    if (hdr.closing_status === 'DRAFT') {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const lines_rows = await db.sequelize.query(`
+        SELECT
+            l.line_id,
+            l.product_id,
+            p.product_name,
+            l.taxable_value,
+            l.cgst_amount,
+            l.sgst_amount
+        FROM t_lubes_inv_lines l
+        JOIN m_product p ON p.product_id = l.product_id
+        WHERE l.lubes_hdr_id = :lubesHdrId
+          AND l.taxable_value > 0
+    `, { replacements: { lubesHdrId }, type: QueryTypes.SELECT });
+
+    if (!lines_rows.length) throw new Error(`No lines found for lubes invoice lubes_hdr_id=${lubesHdrId}`);
+
+    const supplierLedgerId = await resolveLedger(location_code, 'SUPPLIER', hdr.supplier_id);
+    if (!supplierLedgerId) throw new Error(`Supplier GL ledger not found for ${hdr.supplier_name} (supplier_id:${hdr.supplier_id})`);
+
+    const narration = `Lubes Invoice ${hdr.invoice_no || lubesHdrId} | ${hdr.supplier_name} | ${event_date}`;
+    const journalLines = [];
+    let totalCr = 0;
+
+    for (const ln of lines_rows) {
+        const taxable = parseFloat(ln.taxable_value);
+        const cgst    = parseFloat(ln.cgst_amount || 0);
+        const sgst    = parseFloat(ln.sgst_amount || 0);
+        totalCr      += taxable + cgst + sgst;
+
+        const purchaseLedgerId = await resolveProductLedger(location_code, ln.product_id, 'PURCHASE');
+        if (!purchaseLedgerId) throw new Error(`PURCHASE ledger not configured for product ${ln.product_name} (id:${ln.product_id})`);
+
+        const lineNarration = `${ln.product_name} | ₹${taxable.toFixed(2)} + GST | ${narration}`;
+        journalLines.push({ ledger_id: purchaseLedgerId, dr_amount: taxable, cr_amount: 0, narration: lineNarration });
+
+        if (cgst > 0) {
+            const cgstLedgerId = await resolveProductLedger(location_code, ln.product_id, 'INPUT_CGST');
+            if (!cgstLedgerId) throw new Error(`INPUT_CGST ledger not mapped for product ${ln.product_name} — configure it at /products/ledger-map`);
+            journalLines.push({ ledger_id: cgstLedgerId, dr_amount: cgst, cr_amount: 0, narration: lineNarration });
+        }
+        if (sgst > 0) {
+            const sgstLedgerId = await resolveProductLedger(location_code, ln.product_id, 'INPUT_SGST');
+            if (!sgstLedgerId) throw new Error(`INPUT_SGST ledger not mapped for product ${ln.product_name} — configure it at /products/ledger-map`);
+            journalLines.push({ ledger_id: sgstLedgerId, dr_amount: sgst, cr_amount: 0, narration: lineNarration });
+        }
+    }
+
+    // Supplier CR — sum of all line amounts (guarantees balance regardless of header rounding)
+    journalLines.push({ ledger_id: supplierLedgerId, dr_amount: 0, cr_amount: totalCr, narration });
+
+    const vid = await createVoucher({
+        locationCode: location_code,
+        fyId:         fy_id,
+        voucherType:  'PURCHASE',
+        voucherDate:  event_date,
+        sourceType:   'LUBES_INVOICE',
+        sourceId:     lubesHdrId,
+        narration,
+        lines:        journalLines,
+        postedBy:     processedBy
+    });
+
+    await markEventProcessed(event.event_id, vid, processedBy);
+    return { voucherCount: 1 };
+}
+
+// ─── TANK_INVOICE Handler ─────────────────────────────────────────────────────
+// Supplier CR (sum of product lines + charges) →
+//   Per t_tank_invoice_dtl: DR Product Purchase (total_line_amount)
+//   Per t_tank_invoice_charges: DR charge ledger by name (resolveLedgerByName)
+//
+// charge_type is free text in t_tank_invoice_charges — admin must create a GL ledger
+// with the exact same name, otherwise the engine throws a descriptive error.
+
+async function processTankInvoiceEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: invoiceId, event_date } = event;
+
+    const hdrs = await db.sequelize.query(`
+        SELECT
+            ti.id,
+            ti.invoice_no,
+            ti.invoice_date,
+            ti.supplier_id,
+            s.supplier_name
+        FROM t_tank_invoice ti
+        JOIN m_supplier s ON s.supplier_id = ti.supplier_id
+        WHERE ti.id = :invoiceId
+    `, { replacements: { invoiceId }, type: QueryTypes.SELECT });
+
+    if (!hdrs.length) throw new Error(`Tank invoice not found: id=${invoiceId}`);
+    const hdr = hdrs[0];
+
+    const supplierLedgerId = await resolveLedger(location_code, 'SUPPLIER', hdr.supplier_id);
+    if (!supplierLedgerId) throw new Error(`Supplier GL ledger not found for ${hdr.supplier_name} (supplier_id:${hdr.supplier_id})`);
+
+    const narration = `Tank Invoice ${hdr.invoice_no || invoiceId} | ${hdr.supplier_name} | ${event_date}`;
+    const journalLines = [];
+    let totalCr = 0;
+
+    // Product purchase lines
+    const dtlRows = await db.sequelize.query(`
+        SELECT
+            d.dtl_id,
+            d.product_id,
+            p.product_name,
+            d.total_line_amount
+        FROM t_tank_invoice_dtl d
+        JOIN m_product p ON p.product_id = d.product_id
+        WHERE d.invoice_id = :invoiceId
+          AND d.total_line_amount > 0
+    `, { replacements: { invoiceId }, type: QueryTypes.SELECT });
+
+    for (const dtl of dtlRows) {
+        const lineAmt = parseFloat(dtl.total_line_amount);
+        totalCr      += lineAmt;
+
+        const purchaseLedgerId = await resolveProductLedger(location_code, dtl.product_id, 'PURCHASE');
+        if (!purchaseLedgerId) throw new Error(`PURCHASE ledger not configured for product ${dtl.product_name} (id:${dtl.product_id})`);
+
+        journalLines.push({
+            ledger_id:  purchaseLedgerId,
+            dr_amount:  lineAmt,
+            cr_amount:  0,
+            narration:  `${dtl.product_name} | ₹${lineAmt.toFixed(2)} | ${narration}`
+        });
+    }
+
+    // Charge lines (free-text charge_type → GL ledger by name)
+    const chargeRows = await db.sequelize.query(`
+        SELECT charge_type, amount
+        FROM t_tank_invoice_charges
+        WHERE invoice_id = :invoiceId
+          AND amount > 0
+    `, { replacements: { invoiceId }, type: QueryTypes.SELECT });
+
+    for (const ch of chargeRows) {
+        const chargeAmt = parseFloat(ch.amount);
+        totalCr        += chargeAmt;
+
+        const info = await resolveLedgerByName(location_code, ch.charge_type);
+        if (!info) throw new Error(`GL ledger '${ch.charge_type}' not found for location ${location_code} — create a ledger with this exact name to map the charge`);
+
+        journalLines.push({
+            ledger_id:  info.ledger_id,
+            dr_amount:  chargeAmt,
+            cr_amount:  0,
+            narration:  `${ch.charge_type} | ₹${chargeAmt.toFixed(2)} | ${narration}`
+        });
+    }
+
+    if (!journalLines.length) throw new Error(`Tank invoice id=${invoiceId} has no product lines or charges to journal`);
+
+    // Supplier CR — sum of all DR lines (guarantees balance regardless of header rounding)
+    journalLines.push({ ledger_id: supplierLedgerId, dr_amount: 0, cr_amount: totalCr, narration });
+
+    const vid = await createVoucher({
+        locationCode: location_code,
+        fyId:         fy_id,
+        voucherType:  'PURCHASE',
+        voucherDate:  event_date,
+        sourceType:   'TANK_INVOICE',
+        sourceId:     invoiceId,
+        narration,
+        lines:        journalLines,
+        postedBy:     processedBy
+    });
+
+    await markEventProcessed(event.event_id, vid, processedBy);
+    return { voucherCount: 1 };
+}
+
+// Derives the Tally voucher type from bank transaction context.
+//   CONTRA  — inter-bank transfer (external_source='Bank', debit/paying side)
+//   PAYMENT — money leaves the bank (bank is CR side)
+//   RECEIPT — money enters the bank (bank is DR side)
+//   JOURNAL — oil company SOA entries (supplier account adjustments)
+function deriveBankVoucherType(txn, bankIsDr) {
+    if (txn.is_oil_company === 'Y') return 'JOURNAL';
+    if (txn.external_source === 'Bank') return 'CONTRA';
+    return bankIsDr ? 'RECEIPT' : 'PAYMENT';
 }
 
 // Returns counterpart ledger_id, or null if the event was already marked PROCESSED (skip).
@@ -802,6 +1378,39 @@ async function resolveCashLedger(locationCode) {
         type: QueryTypes.SELECT
     });
     return rows[0] ? rows[0].ledger_id : null;
+}
+
+// ─── Shift Gate ───────────────────────────────────────────────────────────────
+// Returns a Set of 'YYYY-MM-DD' dates within the range where t_closing rows
+// are still in DRAFT status.  Shift-bound event types (CREDIT_SALE, CASH_SALE,
+// DAY_BILL) are skipped for these dates — left UNPROCESSED until the shift closes.
+
+async function getOpenShiftDates(locationCode, fromDate, toDate) {
+    const rows = await db.sequelize.query(`
+        SELECT DISTINCT DATE_FORMAT(closing_date, '%Y-%m-%d') AS blocked_date
+        FROM t_closing
+        WHERE location_code  = :locationCode
+          AND closing_date   BETWEEN :fromDate AND :toDate
+          AND closing_status = 'DRAFT'
+    `, {
+        replacements: { locationCode, fromDate, toDate },
+        type: QueryTypes.SELECT
+    });
+    return new Set(rows.map(r => r.blocked_date));
+}
+
+async function getOpenBowserDates(locationCode, fromDate, toDate) {
+    const rows = await db.sequelize.query(`
+        SELECT DISTINCT DATE_FORMAT(closing_date, '%Y-%m-%d') AS blocked_date
+        FROM t_bowser_closing
+        WHERE location_code = :locationCode
+          AND closing_date  BETWEEN :fromDate AND :toDate
+          AND status        = 'DRAFT'
+    `, {
+        replacements: { locationCode, fromDate, toDate },
+        type: QueryTypes.SELECT
+    });
+    return new Set(rows.map(r => r.blocked_date));
 }
 
 // ─── Event Status Helpers ─────────────────────────────────────────────────────

--- a/services/gl-batch-logger.js
+++ b/services/gl-batch-logger.js
@@ -1,0 +1,27 @@
+// services/gl-batch-logger.js
+// Lightweight in-memory logger for GL batch runs.
+// GL_LOG_LEVEL controls verbosity: DEBUG (all) | INFO (summaries+errors) | ERROR (errors only)
+
+const LEVEL_RANK = { DEBUG: 0, INFO: 1, ERROR: 2 };
+
+class GlBatchLogger {
+    constructor(minLevel) {
+        this._minLevel = LEVEL_RANK[minLevel] ?? LEVEL_RANK.INFO;
+        this._lines    = [];
+    }
+
+    log(level, msg) {
+        if ((LEVEL_RANK[level] ?? 0) >= this._minLevel) {
+            const ts = new Date().toISOString().replace('T', ' ').substring(0, 19);
+            this._lines.push(`[${ts}] [${level}] ${msg}`);
+        }
+    }
+
+    debug(msg) { this.log('DEBUG', msg); }
+    info(msg)  { this.log('INFO',  msg); }
+    error(msg) { this.log('ERROR', msg); }
+
+    getText() { return this._lines.join('\n'); }
+}
+
+module.exports = GlBatchLogger;

--- a/services/gl-batch-service.js
+++ b/services/gl-batch-service.js
@@ -1,0 +1,110 @@
+// services/gl-batch-service.js
+// Oracle-style concurrent request wrapper for GL batch operations.
+// Lifecycle: PENDING → RUNNING → COMPLETED | ERROR
+// Log verbosity controlled by GL_LOG_LEVEL in m_location_config.
+
+const db                    = require('../db/db-connection');
+const { QueryTypes }        = require('sequelize');
+const GlBatchLogger         = require('./gl-batch-logger');
+const { getLocationConfigValue } = require('../utils/location-config');
+
+async function submitRequest(requestType, locationCode, fromDate, toDate, params, submittedBy) {
+    const [requestId] = await db.sequelize.query(`
+        INSERT INTO gl_batch_requests
+            (request_type, location_code, from_date, to_date, params, status, submitted_by)
+        VALUES (:requestType, :locationCode, :fromDate, :toDate, :params, 'PENDING', :submittedBy)
+    `, {
+        replacements: {
+            requestType, locationCode,
+            fromDate, toDate,
+            params: params ? JSON.stringify(params) : null,
+            submittedBy
+        },
+        type: QueryTypes.INSERT
+    });
+    return requestId;
+}
+
+async function runRequest(requestId, locationCode, fn) {
+    const logLevel = await getLocationConfigValue(locationCode, 'GL_LOG_LEVEL', 'INFO');
+    const logger   = new GlBatchLogger(logLevel);
+
+    await db.sequelize.query(`
+        UPDATE gl_batch_requests SET status='RUNNING', started_at=NOW() WHERE request_id=:requestId
+    `, { replacements: { requestId }, type: QueryTypes.UPDATE });
+
+    let resultSummary = null;
+    try {
+        resultSummary = await fn(logger);
+
+        await db.sequelize.query(`
+            UPDATE gl_batch_requests
+            SET status='COMPLETED', completed_at=NOW(),
+                result_summary=:summary, log_text=:log
+            WHERE request_id=:requestId
+        `, {
+            replacements: {
+                requestId,
+                summary: JSON.stringify(resultSummary),
+                log: logger.getText()
+            },
+            type: QueryTypes.UPDATE
+        });
+
+        return { success: true, summary: resultSummary };
+    } catch (err) {
+        logger.error('Fatal: ' + err.message);
+
+        await db.sequelize.query(`
+            UPDATE gl_batch_requests
+            SET status='ERROR', completed_at=NOW(),
+                result_summary=:summary, log_text=:log
+            WHERE request_id=:requestId
+        `, {
+            replacements: {
+                requestId,
+                summary: JSON.stringify({ error: err.message }),
+                log: logger.getText()
+            },
+            type: QueryTypes.UPDATE
+        });
+
+        throw err;
+    }
+}
+
+async function recoverStaleRequests(locationCode) {
+    await db.sequelize.query(`
+        UPDATE gl_batch_requests
+        SET status       = 'ERROR',
+            completed_at = NOW(),
+            log_text     = CONCAT(COALESCE(log_text,''), '\n[RECOVERED] Server restarted during processing — run did not complete.')
+        WHERE location_code = :locationCode
+          AND status        = 'RUNNING'
+    `, { replacements: { locationCode }, type: QueryTypes.UPDATE });
+}
+
+async function getRecentRequests(locationCode, limit) {
+    return db.sequelize.query(`
+        SELECT request_id, request_type, from_date, to_date, status,
+               submitted_by, submitted_at, started_at, completed_at,
+               result_summary
+        FROM gl_batch_requests
+        WHERE location_code = :locationCode
+        ORDER BY submitted_at DESC
+        LIMIT :limit
+    `, { replacements: { locationCode, limit: limit || 20 }, type: QueryTypes.SELECT });
+}
+
+async function getRequestLog(requestId, locationCode) {
+    const rows = await db.sequelize.query(`
+        SELECT request_id, request_type, from_date, to_date, status,
+               submitted_by, submitted_at, started_at, completed_at,
+               result_summary, log_text
+        FROM gl_batch_requests
+        WHERE request_id = :requestId AND location_code = :locationCode
+    `, { replacements: { requestId, locationCode }, type: QueryTypes.SELECT });
+    return rows[0] || null;
+}
+
+module.exports = { submitRequest, runRequest, recoverStaleRequests, getRecentRequests, getRequestLog };

--- a/views/dev-db-refresh.pug
+++ b/views/dev-db-refresh.pug
@@ -1,0 +1,175 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Dev DB Refresh Control
+            span.badge.badge-warning.ml-2(style="font-size:0.85rem") DEV ONLY
+
+        //- Last Refresh Info
+        .card.mb-3
+            .card-body.py-2
+                .row.align-items-center
+                    .col-auto
+                        .small.text-muted Last Refresh
+                        if lastRefresh
+                            .font-weight-bold= new Date(lastRefresh.restored_at).toLocaleString('en-IN')
+                        else
+                            .text-muted.small Unknown
+                    .col-auto
+                        .small.text-muted Backup Taken At (Prod)
+                        if lastRefresh
+                            .font-weight-bold= new Date(lastRefresh.backup_taken_at).toLocaleString('en-IN')
+                        else
+                            span.text-muted.small —
+                    .col-auto
+                        .small.text-muted Backup File
+                        if lastRefresh
+                            .small.text-monospace= lastRefresh.backup_filename
+                        else
+                            span.text-muted.small —
+                    .col-auto.ml-auto
+                        .small.text-muted Cron Schedule
+                        .small Every 4 hours
+
+        //- Controls
+        .card.mb-3
+            .card-body.py-2
+                .row.align-items-center
+
+                    .col-auto
+                        .small.text-muted.mb-1 Auto-Refresh Status
+                        if isRunning
+                            span.badge.badge-primary(style="font-size:0.9rem")
+                                i.bi.bi-arrow-repeat.mr-1
+                                | RUNNING
+                        else if isPaused
+                            span.badge.badge-warning(style="font-size:0.9rem")
+                                i.bi.bi-pause-fill.mr-1
+                                | PAUSED
+                        else
+                            span.badge.badge-success(style="font-size:0.9rem")
+                                i.bi.bi-play-fill.mr-1
+                                | ACTIVE (every 4h)
+
+                    .col-auto
+                        if isPaused
+                            button.btn.btn-success.btn-sm#btnResume(type="button")
+                                i.bi.bi-play-fill.mr-1
+                                | Resume Auto-Refresh
+                        else
+                            button.btn.btn-warning.btn-sm#btnPause(type="button")
+                                i.bi.bi-pause-fill.mr-1
+                                | Pause Auto-Refresh
+
+                    .col-auto
+                        button.btn.btn-danger.btn-sm#btnRefreshNow(type="button" disabled=isRunning)
+                            i.bi.bi-arrow-clockwise.mr-1
+                            | Refresh Now (from S3)
+
+                    .col-auto.ml-auto
+                        button.btn.btn-outline-secondary.btn-sm#btnRefreshStatus(type="button")
+                            i.bi.bi-arrow-repeat.mr-1
+                            | Refresh Status
+
+        .alert.alert-warning.py-2.small.mb-3
+            i.bi.bi-exclamation-triangle-fill.mr-1
+            | &ldquo;Refresh Now&rdquo; drops and recreates the dev DB from the latest prod S3 backup.
+            | The app will lose DB connection for 1&ndash;2 minutes while the import runs.
+            | All unsaved test data will be lost.
+
+        //- Log Tail
+        .card
+            .card-header.py-2.d-flex.justify-content-between.align-items-center
+                span.small.font-weight-bold Refresh Log (last 30 lines)
+                span.small.text-muted#logStatus
+                    if isRunning
+                        | Auto-refreshing…
+            .card-body.p-0
+                pre.small.mb-0(style="max-height:350px;overflow-y:auto;padding:10px;background:#f8f9fa;border-radius:0 0 4px 4px;white-space:pre-wrap" id="logBox")= logTail || '(no log yet)'
+
+    script.
+        let pollTimer = null;
+
+        function setStatus(isPaused, isRunning) {
+            const badge = document.querySelector('.badge[class*="badge-"]');
+            const btnPause   = document.getElementById('btnPause');
+            const btnResume  = document.getElementById('btnResume');
+            const btnNow     = document.getElementById('btnRefreshNow');
+
+            if (isRunning) {
+                if (badge) { badge.className = 'badge badge-primary'; badge.innerHTML = '<i class="bi bi-arrow-repeat mr-1"></i> RUNNING'; }
+                if (btnNow) btnNow.disabled = true;
+            } else if (isPaused) {
+                if (badge) { badge.className = 'badge badge-warning'; badge.innerHTML = '<i class="bi bi-pause-fill mr-1"></i> PAUSED'; }
+                if (btnNow) btnNow.disabled = false;
+            } else {
+                if (badge) { badge.className = 'badge badge-success'; badge.innerHTML = '<i class="bi bi-play-fill mr-1"></i> ACTIVE (every 4h)'; }
+                if (btnNow) btnNow.disabled = false;
+            }
+        }
+
+        async function pollStatus() {
+            const data = await fetch('/dev-db-refresh/status').then(r => r.json());
+            setStatus(data.isPaused, data.isRunning);
+
+            if (data.logTail) document.getElementById('logBox').textContent = data.logTail;
+            document.getElementById('logStatus').textContent = data.isRunning ? 'Auto-refreshing…' : '';
+
+            // Show pause/resume button correctly
+            const btnPause  = document.getElementById('btnPause');
+            const btnResume = document.getElementById('btnResume');
+            if (btnPause)  btnPause.style.display  = data.isPaused ? 'none' : '';
+            if (btnResume) btnResume.style.display  = data.isPaused ? '' : 'none';
+
+            if (data.isRunning) {
+                pollTimer = setTimeout(pollStatus, 3000);
+            } else {
+                clearTimeout(pollTimer);
+                pollTimer = null;
+            }
+        }
+
+        const btnPause = document.getElementById('btnPause');
+        if (btnPause) {
+            btnPause.addEventListener('click', async function() {
+                this.disabled = true;
+                await fetch('/dev-db-refresh/pause', { method: 'POST' });
+                pollStatus();
+                this.disabled = false;
+            });
+        }
+
+        const btnResume = document.getElementById('btnResume');
+        if (btnResume) {
+            btnResume.addEventListener('click', async function() {
+                this.disabled = true;
+                await fetch('/dev-db-refresh/resume', { method: 'POST' });
+                pollStatus();
+                this.disabled = false;
+            });
+        }
+
+        document.getElementById('btnRefreshNow').addEventListener('click', async function() {
+            if (!confirm('This will drop and recreate the dev DB from the latest prod S3 backup.\nAll current test data will be lost.\n\nProceed?')) return;
+            this.disabled = true;
+            this.textContent = 'Starting…';
+            const data = await fetch('/dev-db-refresh/run-now', { method: 'POST' }).then(r => r.json());
+            if (data.success) {
+                document.getElementById('logStatus').textContent = 'Auto-refreshing…';
+                pollTimer = setTimeout(pollStatus, 3000);
+            } else {
+                alert('Error: ' + data.error);
+                this.disabled = false;
+                this.innerHTML = '<i class="bi bi-arrow-clockwise mr-1"></i> Refresh Now (from S3)';
+            }
+        });
+
+        document.getElementById('btnRefreshStatus').addEventListener('click', pollStatus);
+
+        // Auto-poll if already running on page load
+        if (#{isRunning ? 'true' : 'false'}) {
+            pollTimer = setTimeout(pollStatus, 3000);
+        }

--- a/views/gl-balance-sheet.pug
+++ b/views/gl-balance-sheet.pug
@@ -1,0 +1,90 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Balance Sheet
+            a.btn.btn-sm.btn-outline-secondary(href="/gl/profit-loss") &larr; P&amp;L
+
+        form.row.align-items-end.mb-3(method="GET" action="/gl/balance-sheet")
+            .col-auto
+                label.small.mb-1 As of Date
+                input.form-control.form-control-sm(type="date" name="as_of_date" value=asOfDate)
+            .col-auto.align-self-end
+                button.btn.btn-primary.btn-sm(type="submit") View
+
+        - const fmt = (n) => Math.abs(n).toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+
+        if isBalanced
+            .alert.alert-success.py-2.mb-2
+                i.bi.bi-check-circle-fill.mr-1
+                | Balance Sheet balances &mdash; Assets = Liabilities + P&amp;L = ₹#{fmt(totalAssets)}
+        else
+            .alert.alert-danger.py-2.mb-2
+                i.bi.bi-exclamation-triangle-fill.mr-1
+                | Out of balance &mdash; Assets ₹#{fmt(totalAssets)} vs Liabilities + P&amp;L ₹#{fmt(totalLiabilitiesAndPL)} (diff ₹#{Math.abs(totalAssets - totalLiabilitiesAndPL).toLocaleString('en-IN',{minimumFractionDigits:2,maximumFractionDigits:2})})
+
+        .row
+            //- LEFT: Assets
+            .col-md-6
+                h6.border-bottom.pb-1 Assets
+                if !assetGroups.length
+                    p.text-muted.small No asset entries up to this date.
+                else
+                    table.table.table-sm.table-bordered#bsAssetTable
+                        tbody
+                            each g in assetGroups
+                                tr.group-header
+                                    td.font-weight-bold(colspan="2")= g.group_name
+                                each row in g.rows
+                                    tr
+                                        td.pl-4
+                                            a(href='/gl/ledger?ledger_id=' + row.ledger_id + '&from_date=' + asOfDate.substring(0,4) + '-04-01&to_date=' + asOfDate)= row.ledger_name
+                                        td.text-right.small= fmt(row.amount)
+                                tr.group-subtotal
+                                    td.text-right.font-weight-bold.text-muted.small #{g.group_name} Total
+                                    td.text-right.font-weight-bold.small= fmt(g.subtotal)
+                        tfoot
+                            tr.font-weight-bold.table-primary
+                                td Total Assets
+                                td.text-right= fmt(totalAssets)
+
+            //- RIGHT: Liabilities + P&L
+            .col-md-6
+                h6.border-bottom.pb-1 Liabilities &amp; Equity
+                table.table.table-sm.table-bordered#bsLiabTable
+                    tbody
+                        if liabilityGroups.length
+                            each g in liabilityGroups
+                                tr.group-header
+                                    td.font-weight-bold(colspan="2")= g.group_name
+                                each row in g.rows
+                                    tr
+                                        td.pl-4
+                                            a(href='/gl/ledger?ledger_id=' + row.ledger_id + '&from_date=' + asOfDate.substring(0,4) + '-04-01&to_date=' + asOfDate)= row.ledger_name
+                                        td.text-right.small= fmt(row.amount)
+                                tr.group-subtotal
+                                    td.text-right.font-weight-bold.text-muted.small #{g.group_name} Total
+                                    td.text-right.font-weight-bold.small= fmt(g.subtotal)
+                        //- P&L rolled in as retained surplus/deficit
+                        tr.group-header
+                            td.font-weight-bold(colspan="2") Retained Earnings
+                        tr(class=(netPL >= 0 ? '' : 'table-warning'))
+                            td.pl-4
+                                a(href='/gl/profit-loss?from_date=' + asOfDate.substring(0,4) + '-04-01&to_date=' + asOfDate)
+                                    = netPL >= 0 ? 'Net Profit (from inception)' : 'Net Loss (from inception)'
+                            td.text-right.small(class=(netPL >= 0 ? '' : 'text-danger'))= fmt(netPL)
+                        tr.group-subtotal
+                            td.text-right.font-weight-bold.text-muted.small Retained Earnings Total
+                            td.text-right.font-weight-bold.small= fmt(netPL)
+                    tfoot
+                        tr.font-weight-bold.table-primary
+                            td Total Liabilities &amp; Equity
+                            td.text-right= fmt(totalLiabilitiesAndPL)
+
+    style.
+        #bsAssetTable, #bsLiabTable { font-size: 0.82rem; }
+        .group-header td  { background-color: #e9ecef; }
+        .group-subtotal td { background-color: #f8f9fa; border-top: 2px solid #dee2e6 !important; }

--- a/views/gl-balance-sheet.pug
+++ b/views/gl-balance-sheet.pug
@@ -10,8 +10,16 @@ block content
 
         form.row.align-items-end.mb-3(method="GET" action="/gl/balance-sheet")
             .col-auto
+                label.small.mb-1 Quick Select
+                select.form-control.form-control-sm#glPeriodAsOf(onchange="glSetAsOf('glAsOf')")
+                    option(value="today") Today
+                    option(value="end_last_month") End of Last Month
+                    option(value="end_this_fy") End of This FY
+                    option(value="end_last_fy") End of Last FY
+                    option(value="custom" selected) Custom
+            .col-auto
                 label.small.mb-1 As of Date
-                input.form-control.form-control-sm(type="date" name="as_of_date" value=asOfDate)
+                input.form-control.form-control-sm#glAsOf(type="date" name="as_of_date" value=asOfDate)
             .col-auto.align-self-end
                 button.btn.btn-primary.btn-sm(type="submit") View
 

--- a/views/gl-balance-sheet.pug
+++ b/views/gl-balance-sheet.pug
@@ -11,7 +11,7 @@ block content
         form.row.align-items-end.mb-3(method="GET" action="/gl/balance-sheet")
             .col-auto
                 label.small.mb-1 Quick Select
-                select.form-control.form-control-sm#glPeriodAsOf(onchange="glSetAsOf('glAsOf')")
+                select.form-control.form-control-sm#glPeriodAsOf(onchange="glSetAsOf(this)" data-target="glAsOf")
                     option(value="today") Today
                     option(value="end_last_month") End of Last Month
                     option(value="end_this_fy") End of This FY

--- a/views/gl-control.pug
+++ b/views/gl-control.pug
@@ -84,10 +84,17 @@ block content
 
                 #eventsTableWrap(style="display:none")
                     .alert.alert-warning.py-2.small.mb-2(id="eventsLimitWarn" style="display:none")
+                    .d-flex.align-items-center.mb-2(id="bulkBar" style="display:none !important")
+                        span.small.mr-2#bulkCount 0 selected
+                        button.btn.btn-warning.btn-sm(type="button" id="btnBulkRetry")
+                            i.bi.bi-arrow-repeat.mr-1
+                            | Retry Selected
                     .table-responsive
                         table.table.table-sm.table-bordered.table-hover#eventsTable
                             thead.thead-dark
                                 tr
+                                    th(style="width:32px")
+                                        input(type="checkbox" id="chkSelectAll" title="Select all errors")
                                     th(style="width:60px") ID
                                     th(style="width:90px") Date
                                     th Source Type
@@ -223,12 +230,20 @@ block content
                 warn.style.display = 'none';
             }
 
+            document.getElementById('chkSelectAll').checked = false;
+            document.getElementById('bulkBar').style.display = 'none';
+
             rows.forEach(function(r) {
                 const tr = document.createElement('tr');
-                const retryBtn = r.event_status === 'ERROR'
+                const isError = r.event_status === 'ERROR';
+                const chk = isError
+                    ? `<input type="checkbox" class="chk-error-row" data-id="${r.event_id}">`
+                    : '';
+                const retryBtn = isError
                     ? `<button class="btn btn-outline-warning btn-sm btn-retry" data-id="${r.event_id}" title="Retry"><i class="bi bi-arrow-repeat"></i></button>`
                     : '';
                 tr.innerHTML = `
+                    <td class="text-center">${chk}</td>
                     <td class="small">${r.event_id}</td>
                     <td class="small">${r.event_date ? r.event_date.substring(0,10) : ''}</td>
                     <td class="small">${r.source_type}</td>
@@ -242,21 +257,77 @@ block content
             });
             document.getElementById('eventsTableWrap').style.display = '';
 
+            function updateBulkBar() {
+                const checked = tbody.querySelectorAll('.chk-error-row:checked');
+                const bar = document.getElementById('bulkBar');
+                if (checked.length > 0) {
+                    document.getElementById('bulkCount').textContent = checked.length + ' selected';
+                    bar.style.display = '';
+                } else {
+                    bar.style.display = 'none';
+                }
+            }
+
+            tbody.querySelectorAll('.chk-error-row').forEach(function(chk) {
+                chk.addEventListener('change', updateBulkBar);
+            });
+
+            document.getElementById('chkSelectAll').onchange = function() {
+                tbody.querySelectorAll('.chk-error-row').forEach(function(chk) {
+                    chk.checked = document.getElementById('chkSelectAll').checked;
+                });
+                updateBulkBar();
+            };
+
             tbody.querySelectorAll('.btn-retry').forEach(function(btn) {
                 btn.addEventListener('click', async function() {
                     const id = this.dataset.id;
                     this.disabled = true;
                     const data = await fetch('/gl/api/retry-event/' + id, { method: 'POST' }).then(r => r.json());
                     if (data.success) {
-                        this.closest('tr').querySelector('.badge').className = 'badge badge-warning';
-                        this.closest('tr').querySelector('.badge').textContent = 'UNPROCESSED';
+                        const tr = this.closest('tr');
+                        tr.querySelector('.badge').className = 'badge badge-warning';
+                        tr.querySelector('.badge').textContent = 'UNPROCESSED';
+                        const chk = tr.querySelector('.chk-error-row');
+                        if (chk) chk.remove();
                         this.remove();
+                        updateBulkBar();
                     } else {
                         alert('Error: ' + data.error);
                         this.disabled = false;
                     }
                 });
             });
+
+            document.getElementById('btnBulkRetry').onclick = async function() {
+                const checked = Array.from(tbody.querySelectorAll('.chk-error-row:checked'));
+                if (!checked.length) return;
+                const ids = checked.map(c => parseInt(c.dataset.id));
+                this.disabled = true;
+                this.textContent = 'Retrying…';
+                const data = await fetch('/gl/api/retry-events', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ event_ids: ids })
+                }).then(r => r.json());
+                this.disabled = false;
+                this.innerHTML = '<i class="bi bi-arrow-repeat mr-1"></i>Retry Selected';
+                if (data.success) {
+                    checked.forEach(function(chk) {
+                        const tr = chk.closest('tr');
+                        const badge = tr.querySelector('.badge');
+                        if (badge) { badge.className = 'badge badge-warning'; badge.textContent = 'UNPROCESSED'; }
+                        const retryBtn = tr.querySelector('.btn-retry');
+                        if (retryBtn) retryBtn.remove();
+                        chk.remove();
+                    });
+                    document.getElementById('chkSelectAll').checked = false;
+                    updateBulkBar();
+                    alert(data.updated + ' event(s) queued for reprocessing.');
+                } else {
+                    alert('Error: ' + data.error);
+                }
+            };
         }
 
         document.getElementById('btnLoadEvents').addEventListener('click', loadEvents);

--- a/views/gl-control.pug
+++ b/views/gl-control.pug
@@ -129,6 +129,12 @@ block content
                 #caResult(style="display:none")
                     .card.card-body.mt-2#caResultBody
 
+                hr.mt-3
+                h6.mt-3.mb-2 Recent Runs
+                    button.btn.btn-outline-secondary.btn-sm.ml-2(type="button" onclick="loadBatchRuns('ca')") Refresh
+                #caBatchRuns
+                    .text-muted.small Loading…
+
             //- ── Generate Events ─────────────────────────────────────────────
             #pane-generate.tab-pane.fade(role="tabpanel")
 
@@ -160,6 +166,12 @@ block content
 
                 #geResult(style="display:none")
                     .card.card-body.mt-2#geResultBody
+
+                hr.mt-3
+                h6.mt-3.mb-2 Recent Runs
+                    button.btn.btn-outline-secondary.btn-sm.ml-2(type="button" onclick="loadBatchRuns('ge')") Refresh
+                #geBatchRuns
+                    .text-muted.small Loading…
 
 
     script.
@@ -250,6 +262,68 @@ block content
         document.getElementById('btnLoadEvents').addEventListener('click', loadEvents);
         document.getElementById('btnRefreshSummary').addEventListener('click', loadSummary);
 
+        // ── Batch Runs (shown in Create Accounting and Generate Events tabs) ────
+
+        const BATCH_TYPE_MAP = {
+            ca: ['CREATE_ACCOUNTING', 'REPROCESS_ACCOUNTING'],
+            ge: ['GENERATE_EVENTS']
+        };
+
+        function batchRunsHtml(rows, types) {
+            const filtered = rows.filter(r => types.includes(r.request_type));
+            if (!filtered.length) return '<p class="text-muted small mb-0">No recent runs.</p>';
+            const statusColor = { PENDING:'secondary', RUNNING:'primary', COMPLETED:'success', ERROR:'danger' };
+            const resultText = (rs) => {
+                try {
+                    const s = typeof rs === 'string' ? JSON.parse(rs) : rs;
+                    if (!s) return '';
+                    if (s.total      !== undefined) return `${s.total} generated`;
+                    if (s.processed  !== undefined) return `proc=${s.processed} err=${s.errors||0}`;
+                    if (s.error) return `<span class="text-danger">${s.error}</span>`;
+                } catch(e) {}
+                return '';
+            };
+            const rows_html = filtered.map(r => `<tr>
+                <td class="small">${r.request_id}</td>
+                <td class="small">${r.request_type}</td>
+                <td class="small">${(r.from_date||'').toString().substring(0,10)}</td>
+                <td class="small">${(r.to_date||'').toString().substring(0,10)}</td>
+                <td class="small"><span class="badge badge-${statusColor[r.status]||'secondary'}">${r.status}</span></td>
+                <td class="small">${r.submitted_at ? new Date(r.submitted_at).toLocaleString('en-IN') : ''}</td>
+                <td class="small">${r.completed_at ? new Date(r.completed_at).toLocaleString('en-IN') : ''}</td>
+                <td class="small">${resultText(r.result_summary)}</td>
+                <td class="text-center"><button class="btn btn-outline-info btn-sm btn-view-log" data-id="${r.request_id}" title="View Log"><i class="bi bi-file-text"></i></button></td>
+            </tr>`).join('');
+            return `<div class="table-responsive"><table class="table table-sm table-bordered table-hover">
+                <thead class="thead-dark"><tr>
+                    <th style="width:50px">ID</th><th style="width:160px">Type</th>
+                    <th style="width:90px">From</th><th style="width:90px">To</th>
+                    <th style="width:90px">Status</th><th style="width:130px">Submitted</th>
+                    <th style="width:130px">Completed</th><th>Result</th>
+                    <th style="width:50px" class="text-center">Log</th>
+                </tr></thead><tbody>${rows_html}</tbody></table></div>`;
+        }
+
+        var _batchRunsCache = null;
+        async function loadBatchRuns(tab) {
+            const containerId = tab === 'ca' ? 'caBatchRuns' : 'geBatchRuns';
+            const el = document.getElementById(containerId);
+            el.innerHTML = '<p class="text-muted small">Loading…</p>';
+            const rows = await fetch('/gl/api/batch-requests').then(r => r.json());
+            _batchRunsCache = rows;
+            el.innerHTML = batchRunsHtml(rows, BATCH_TYPE_MAP[tab]);
+            el.querySelectorAll('.btn-view-log').forEach(function(btn) {
+                btn.addEventListener('click', async function() {
+                    const id = this.dataset.id;
+                    const data = await fetch('/gl/api/batch-requests/' + id + '/log').then(r => r.json());
+                    alert('[Run #' + data.request_id + ' — ' + data.request_type + ']\n\n' + (data.log_text || '(no log)'));
+                });
+            });
+        }
+
+        document.getElementById('tab-accounting').addEventListener('shown.bs.tab', function() { loadBatchRuns('ca'); });
+        document.getElementById('tab-generate').addEventListener('shown.bs.tab',  function() { loadBatchRuns('ge'); });
+
         // Auto-load summary on page open
         loadSummary();
 
@@ -300,6 +374,7 @@ block content
                     body.innerHTML = `<div class="text-danger"><i class="bi bi-exclamation-triangle mr-1"></i>${data.error}</div>`;
                 }
                 wrap.style.display = '';
+                loadBatchRuns('ca');
             } catch (e) {
                 alert('Network error: ' + e.message);
             } finally {
@@ -348,6 +423,7 @@ block content
                     body.innerHTML = `<div class="text-danger"><i class="bi bi-exclamation-triangle mr-1"></i>${data.error}</div>`;
                 }
                 wrap.style.display = '';
+                loadBatchRuns('ge');
             } catch (e) {
                 alert('Network error: ' + e.message);
             } finally {

--- a/views/gl-control.pug
+++ b/views/gl-control.pug
@@ -43,6 +43,22 @@ block content
                             option(value="UNPROCESSED") Unprocessed
                             option(value="PROCESSED") Processed
                             option(value="ERROR") Error
+                    .col-auto
+                        label.small.mb-1 Source Type
+                        select.form-control.form-control-sm#evSourceType
+                            option(value="") All
+                            option CREDIT_SALE
+                            option CASH_SALE
+                            option DAY_BILL
+                            option BANK_TXN
+                            option LUBES_INVOICE
+                            option TANK_INVOICE
+                            option BOWSER_CREDIT_SALE
+                            option BOWSER_CASH_SALE
+                            option BOWSER_DIGITAL_SALE
+                    .col-auto
+                        label.small.mb-1 Search
+                        input.form-control.form-control-sm(type="text" id="evSearch" placeholder="source ID / error…" style="width:160px")
                     .col-auto.align-self-end
                         button.btn.btn-primary.btn-sm(type="button" id="btnLoadEvents") View
                     .col-auto.align-self-end
@@ -67,6 +83,7 @@ block content
                             .h5.mb-0.text-danger#sumErrors —
 
                 #eventsTableWrap(style="display:none")
+                    .alert.alert-warning.py-2.small.mb-2(id="eventsLimitWarn" style="display:none")
                     .table-responsive
                         table.table.table-sm.table-bordered.table-hover#eventsTable
                             thead.thead-dark
@@ -144,57 +161,6 @@ block content
                 #geResult(style="display:none")
                     .card.card-body.mt-2#geResultBody
 
-        //- ── Recent Batch Runs ───────────────────────────────────────────
-        h6.mt-4.mb-2 Recent Batch Runs
-            button.btn.btn-outline-secondary.btn-sm.ml-2(type="button" id="btnRefreshRuns") Refresh
-        .table-responsive
-            table.table.table-sm.table-bordered.table-hover#runsTable
-                thead.thead-dark
-                    tr
-                        th(style="width:60px") ID
-                        th(style="width:140px") Type
-                        th(style="width:90px") From
-                        th(style="width:90px") To
-                        th(style="width:90px") Status
-                        th(style="width:130px") Submitted
-                        th(style="width:130px") Completed
-                        th Result
-                        th.text-center(style="width:50px") Log
-                tbody#runsBody
-                    - if (typeof recentRequests !== 'undefined')
-                        each r in recentRequests
-                            tr
-                                td.small= r.request_id
-                                td.small= r.request_type
-                                td.small= r.from_date ? r.from_date.toString().substring(0,10) : ''
-                                td.small= r.to_date ? r.to_date.toString().substring(0,10) : ''
-                                td.small
-                                    - const sc = {PENDING:'secondary',RUNNING:'primary',COMPLETED:'success',ERROR:'danger'}[r.status]||'secondary'
-                                    span.badge(class='badge-'+sc)= r.status
-                                td.small= r.submitted_at ? new Date(r.submitted_at).toLocaleString('en-IN') : ''
-                                td.small= r.completed_at ? new Date(r.completed_at).toLocaleString('en-IN') : ''
-                                td.small
-                                    - try { const s = typeof r.result_summary === 'string' ? JSON.parse(r.result_summary) : r.result_summary; if(s && s.total !== undefined) { }; var rs = s; } catch(e) { var rs = null; }
-                                    if rs && rs.total !== undefined
-                                        | #{rs.total} generated
-                                    else if rs && rs.processed !== undefined
-                                        | proc=#{rs.processed} err=#{rs.errors||0}
-                                    else if rs && rs.error
-                                        span.text-danger= rs.error
-                                td.text-center
-                                    button.btn.btn-outline-info.btn-sm.btn-view-log(type="button" data-id=r.request_id title="View Log")
-                                        i.bi.bi-file-text
-
-        //- Log Modal
-        #logModal.modal.fade(tabindex="-1" role="dialog")
-            .modal-dialog.modal-lg(role="document")
-                .modal-content
-                    .modal-header.py-2
-                        h6.modal-title#logModalLabel Batch Run Log
-                        button.close(type="button" data-dismiss="modal")
-                            span &times;
-                    .modal-body.p-2
-                        pre.small(style="max-height:400px;overflow-y:auto;white-space:pre-wrap;background:#f8f9fa;padding:8px;border-radius:4px" id="logModalBody") Loading…
 
     script.
         // ── Event Summary & List ──────────────────────────────────────────────
@@ -223,14 +189,28 @@ block content
 
         async function loadEvents() {
             await loadSummary();
-            const from   = document.getElementById('evFrom').value;
-            const to     = document.getElementById('evTo').value;
-            const status = document.getElementById('evStatus').value;
-            const qs     = new URLSearchParams({ from_date: from, to_date: to });
-            if (status) qs.set('status', status);
-            const rows = await fetch('/gl/api/accounting-events?' + qs).then(r => r.json());
+            const from       = document.getElementById('evFrom').value;
+            const to         = document.getElementById('evTo').value;
+            const status     = document.getElementById('evStatus').value;
+            const sourceType = document.getElementById('evSourceType').value;
+            const search     = document.getElementById('evSearch').value.trim();
+            const qs         = new URLSearchParams({ from_date: from, to_date: to });
+            if (status)     qs.set('status', status);
+            if (sourceType) qs.set('source_type', sourceType);
+            if (search)     qs.set('search', search);
+            const resp  = await fetch('/gl/api/accounting-events?' + qs).then(r => r.json());
+            const rows  = resp.rows;
             const tbody = document.getElementById('eventsBody');
             tbody.innerHTML = '';
+
+            const warn = document.getElementById('eventsLimitWarn');
+            if (resp.hasMore) {
+                warn.textContent = 'Showing 2,000 of more results — please narrow your date range, status, or source type filter.';
+                warn.style.display = '';
+            } else {
+                warn.style.display = 'none';
+            }
+
             rows.forEach(function(r) {
                 const tr = document.createElement('tr');
                 const retryBtn = r.event_status === 'ERROR'
@@ -376,61 +356,3 @@ block content
             }
         });
 
-        // ── Recent Batch Runs ─────────────────────────────────────────────────
-
-        function statusBadge(s) {
-            const map = { PENDING:'secondary', RUNNING:'primary', COMPLETED:'success', ERROR:'danger' };
-            return `<span class="badge badge-${map[s]||'secondary'}">${s}</span>`;
-        }
-
-        function resultSummaryText(rs) {
-            if (!rs) return '';
-            try {
-                const s = typeof rs === 'string' ? JSON.parse(rs) : rs;
-                if (s.total !== undefined) return `${s.total} generated`;
-                if (s.processed !== undefined) return `proc=${s.processed} err=${s.errors||0}`;
-                if (s.error) return `<span class="text-danger">${s.error}</span>`;
-            } catch(e) {}
-            return '';
-        }
-
-        async function loadRecentRuns() {
-            const rows = await fetch('/gl/api/batch-requests').then(r => r.json());
-            const tbody = document.getElementById('runsBody');
-            tbody.innerHTML = '';
-            rows.forEach(function(r) {
-                const tr = document.createElement('tr');
-                const sub = r.submitted_at ? new Date(r.submitted_at).toLocaleString('en-IN') : '';
-                const cmp = r.completed_at ? new Date(r.completed_at).toLocaleString('en-IN') : '';
-                tr.innerHTML = `
-                    <td class="small">${r.request_id}</td>
-                    <td class="small">${r.request_type}</td>
-                    <td class="small">${(r.from_date||'').toString().substring(0,10)}</td>
-                    <td class="small">${(r.to_date||'').toString().substring(0,10)}</td>
-                    <td class="small">${statusBadge(r.status)}</td>
-                    <td class="small">${sub}</td>
-                    <td class="small">${cmp}</td>
-                    <td class="small">${resultSummaryText(r.result_summary)}</td>
-                    <td class="text-center"><button class="btn btn-outline-info btn-sm btn-view-log" data-id="${r.request_id}" title="View Log"><i class="bi bi-file-text"></i></button></td>`;
-                tbody.appendChild(tr);
-            });
-            bindLogButtons();
-        }
-
-        function bindLogButtons() {
-            document.querySelectorAll('.btn-view-log').forEach(function(btn) {
-                btn.addEventListener('click', async function() {
-                    const id = this.dataset.id;
-                    document.getElementById('logModalBody').textContent = 'Loading…';
-                    $('#logModal').modal('show');
-                    const data = await fetch('/gl/api/batch-requests/' + id + '/log').then(r => r.json());
-                    document.getElementById('logModalLabel').textContent =
-                        `Run #${data.request_id} — ${data.request_type} (${data.status})`;
-                    document.getElementById('logModalBody').textContent =
-                        data.log_text || '(no log)';
-                });
-            });
-        }
-
-        document.getElementById('btnRefreshRuns').addEventListener('click', loadRecentRuns);
-        bindLogButtons();

--- a/views/gl-control.pug
+++ b/views/gl-control.pug
@@ -115,6 +115,7 @@ block content
             //- ── Generate Events ─────────────────────────────────────────────
             #pane-generate.tab-pane.fade(role="tabpanel")
 
+
                 p.text-muted.small.mb-3
                     | Scans all source tables for records with no event in the queue and inserts missing events.
                     | Safe to run multiple times — duplicate events are never created.
@@ -142,6 +143,58 @@ block content
 
                 #geResult(style="display:none")
                     .card.card-body.mt-2#geResultBody
+
+        //- ── Recent Batch Runs ───────────────────────────────────────────
+        h6.mt-4.mb-2 Recent Batch Runs
+            button.btn.btn-outline-secondary.btn-sm.ml-2(type="button" id="btnRefreshRuns") Refresh
+        .table-responsive
+            table.table.table-sm.table-bordered.table-hover#runsTable
+                thead.thead-dark
+                    tr
+                        th(style="width:60px") ID
+                        th(style="width:140px") Type
+                        th(style="width:90px") From
+                        th(style="width:90px") To
+                        th(style="width:90px") Status
+                        th(style="width:130px") Submitted
+                        th(style="width:130px") Completed
+                        th Result
+                        th.text-center(style="width:50px") Log
+                tbody#runsBody
+                    - if (typeof recentRequests !== 'undefined')
+                        each r in recentRequests
+                            tr
+                                td.small= r.request_id
+                                td.small= r.request_type
+                                td.small= r.from_date ? r.from_date.toString().substring(0,10) : ''
+                                td.small= r.to_date ? r.to_date.toString().substring(0,10) : ''
+                                td.small
+                                    - const sc = {PENDING:'secondary',RUNNING:'primary',COMPLETED:'success',ERROR:'danger'}[r.status]||'secondary'
+                                    span.badge(class='badge-'+sc)= r.status
+                                td.small= r.submitted_at ? new Date(r.submitted_at).toLocaleString('en-IN') : ''
+                                td.small= r.completed_at ? new Date(r.completed_at).toLocaleString('en-IN') : ''
+                                td.small
+                                    - try { const s = typeof r.result_summary === 'string' ? JSON.parse(r.result_summary) : r.result_summary; if(s && s.total !== undefined) { }; var rs = s; } catch(e) { var rs = null; }
+                                    if rs && rs.total !== undefined
+                                        | #{rs.total} generated
+                                    else if rs && rs.processed !== undefined
+                                        | proc=#{rs.processed} err=#{rs.errors||0}
+                                    else if rs && rs.error
+                                        span.text-danger= rs.error
+                                td.text-center
+                                    button.btn.btn-outline-info.btn-sm.btn-view-log(type="button" data-id=r.request_id title="View Log")
+                                        i.bi.bi-file-text
+
+        //- Log Modal
+        #logModal.modal.fade(tabindex="-1" role="dialog")
+            .modal-dialog.modal-lg(role="document")
+                .modal-content
+                    .modal-header.py-2
+                        h6.modal-title#logModalLabel Batch Run Log
+                        button.close(type="button" data-dismiss="modal")
+                            span &times;
+                    .modal-body.p-2
+                        pre.small(style="max-height:400px;overflow-y:auto;white-space:pre-wrap;background:#f8f9fa;padding:8px;border-radius:4px" id="logModalBody") Loading…
 
     script.
         // ── Event Summary & List ──────────────────────────────────────────────
@@ -322,3 +375,62 @@ block content
                 this.textContent = orig;
             }
         });
+
+        // ── Recent Batch Runs ─────────────────────────────────────────────────
+
+        function statusBadge(s) {
+            const map = { PENDING:'secondary', RUNNING:'primary', COMPLETED:'success', ERROR:'danger' };
+            return `<span class="badge badge-${map[s]||'secondary'}">${s}</span>`;
+        }
+
+        function resultSummaryText(rs) {
+            if (!rs) return '';
+            try {
+                const s = typeof rs === 'string' ? JSON.parse(rs) : rs;
+                if (s.total !== undefined) return `${s.total} generated`;
+                if (s.processed !== undefined) return `proc=${s.processed} err=${s.errors||0}`;
+                if (s.error) return `<span class="text-danger">${s.error}</span>`;
+            } catch(e) {}
+            return '';
+        }
+
+        async function loadRecentRuns() {
+            const rows = await fetch('/gl/api/batch-requests').then(r => r.json());
+            const tbody = document.getElementById('runsBody');
+            tbody.innerHTML = '';
+            rows.forEach(function(r) {
+                const tr = document.createElement('tr');
+                const sub = r.submitted_at ? new Date(r.submitted_at).toLocaleString('en-IN') : '';
+                const cmp = r.completed_at ? new Date(r.completed_at).toLocaleString('en-IN') : '';
+                tr.innerHTML = `
+                    <td class="small">${r.request_id}</td>
+                    <td class="small">${r.request_type}</td>
+                    <td class="small">${(r.from_date||'').toString().substring(0,10)}</td>
+                    <td class="small">${(r.to_date||'').toString().substring(0,10)}</td>
+                    <td class="small">${statusBadge(r.status)}</td>
+                    <td class="small">${sub}</td>
+                    <td class="small">${cmp}</td>
+                    <td class="small">${resultSummaryText(r.result_summary)}</td>
+                    <td class="text-center"><button class="btn btn-outline-info btn-sm btn-view-log" data-id="${r.request_id}" title="View Log"><i class="bi bi-file-text"></i></button></td>`;
+                tbody.appendChild(tr);
+            });
+            bindLogButtons();
+        }
+
+        function bindLogButtons() {
+            document.querySelectorAll('.btn-view-log').forEach(function(btn) {
+                btn.addEventListener('click', async function() {
+                    const id = this.dataset.id;
+                    document.getElementById('logModalBody').textContent = 'Loading…';
+                    $('#logModal').modal('show');
+                    const data = await fetch('/gl/api/batch-requests/' + id + '/log').then(r => r.json());
+                    document.getElementById('logModalLabel').textContent =
+                        `Run #${data.request_id} — ${data.request_type} (${data.status})`;
+                    document.getElementById('logModalBody').textContent =
+                        data.log_text || '(no log)';
+                });
+            });
+        }
+
+        document.getElementById('btnRefreshRuns').addEventListener('click', loadRecentRuns);
+        bindLogButtons();

--- a/views/gl-control.pug
+++ b/views/gl-control.pug
@@ -1,0 +1,300 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 GL Control
+            a.btn.btn-sm.btn-outline-secondary(href="/gl/day-book") Day Book &rarr;
+
+        ul.nav.nav-tabs.mb-3#controlTabs(role="tablist")
+            li.nav-item
+                a.nav-link.active(id="tab-events" data-toggle="tab" href="#pane-events" role="tab") Events Monitor
+            li.nav-item
+                a.nav-link(id="tab-accounting" data-toggle="tab" href="#pane-accounting" role="tab") Create Accounting
+            li.nav-item
+                a.nav-link(id="tab-generate" data-toggle="tab" href="#pane-generate" role="tab") Generate Events
+
+        .tab-content
+
+            //- ── Events Monitor ──────────────────────────────────────────────
+            #pane-events.tab-pane.fade.show.active(role="tabpanel")
+
+                form.row.align-items-end.mb-3#eventsFilterForm
+                    .col-auto
+                        label.small.mb-1 From Date
+                        input.form-control.form-control-sm(type="date" id="evFrom" value=fromDate)
+                    .col-auto
+                        label.small.mb-1 To Date
+                        input.form-control.form-control-sm(type="date" id="evTo" value=toDate)
+                    .col-auto
+                        label.small.mb-1 Status
+                        select.form-control.form-control-sm#evStatus
+                            option(value="") All
+                            option(value="UNPROCESSED") Unprocessed
+                            option(value="PROCESSED") Processed
+                            option(value="ERROR") Error
+                    .col-auto.align-self-end
+                        button.btn.btn-primary.btn-sm(type="button" id="btnLoadEvents") View
+                    .col-auto.align-self-end
+                        button.btn.btn-outline-secondary.btn-sm(type="button" id="btnRefreshSummary") Refresh Summary
+
+                .row.mb-3#summaryCards(style="display:none")
+                    .col-6.col-md-3
+                        .card.text-center.py-2
+                            .small.text-muted Total
+                            .h5.mb-0#sumTotal —
+                    .col-6.col-md-3
+                        .card.text-center.py-2.border-warning
+                            .small.text-warning Unprocessed
+                            .h5.mb-0.text-warning#sumUnprocessed —
+                    .col-6.col-md-3
+                        .card.text-center.py-2.border-success
+                            .small.text-success Processed
+                            .h5.mb-0.text-success#sumProcessed —
+                    .col-6.col-md-3
+                        .card.text-center.py-2.border-danger
+                            .small.text-danger Errors
+                            .h5.mb-0.text-danger#sumErrors —
+
+                #eventsTableWrap(style="display:none")
+                    .table-responsive
+                        table.table.table-sm.table-bordered.table-hover#eventsTable
+                            thead.thead-dark
+                                tr
+                                    th(style="width:60px") ID
+                                    th(style="width:90px") Date
+                                    th Source Type
+                                    th(style="width:80px") Source ID
+                                    th(style="width:70px") Ev. Type
+                                    th(style="width:90px") Status
+                                    th Processed By
+                                    th Error
+                                    th.text-center(style="width:60px")
+                            tbody#eventsBody
+
+            //- ── Create Accounting ───────────────────────────────────────────
+            #pane-accounting.tab-pane.fade(role="tabpanel")
+
+                p.text-muted.small.mb-3
+                    | Processes UNPROCESSED events in the queue and creates journal entries.
+                    | Blocked dates (DRAFT shifts/bowser closings) are skipped automatically.
+
+                .row.align-items-end.mb-3
+                    .col-auto
+                        label.small.mb-1 From Date
+                        input.form-control.form-control-sm(type="date" id="caFrom" value=fromDate)
+                    .col-auto
+                        label.small.mb-1 To Date
+                        input.form-control.form-control-sm(type="date" id="caTo" value=toDate)
+                    .col-auto.align-self-end
+                        button.btn.btn-success.btn-sm#btnRunAccounting Run Create Accounting
+                    .col-auto.align-self-end
+                        button.btn.btn-warning.btn-sm#btnReprocess Reprocess (force redo)
+
+                #caResult(style="display:none")
+                    .card.card-body.mt-2#caResultBody
+
+            //- ── Generate Events ─────────────────────────────────────────────
+            #pane-generate.tab-pane.fade(role="tabpanel")
+
+                p.text-muted.small.mb-3
+                    | Scans all source tables for records with no event in the queue and inserts missing events.
+                    | Safe to run multiple times — duplicate events are never created.
+                    br
+                    | Use this when: a trigger failed silently, records were imported directly into the DB,
+                    | or accounting was enabled after transactions already existed.
+
+                .row.align-items-end.mb-3
+                    .col-auto
+                        label.small.mb-1 From Date
+                        input.form-control.form-control-sm(type="date" id="geFrom" value=fromDate)
+                    .col-auto
+                        label.small.mb-1 To Date
+                        input.form-control.form-control-sm(type="date" id="geTo" value=toDate)
+                    .col-auto.align-self-end
+                        button.btn.btn-primary.btn-sm#btnGenerate Generate Missing Events
+
+                #geResult(style="display:none")
+                    .card.card-body.mt-2#geResultBody
+
+    script.
+        // ── Event Summary & List ──────────────────────────────────────────────
+
+        function badgeStatus(s) {
+            const map = { UNPROCESSED: 'warning', PROCESSED: 'success', ERROR: 'danger' };
+            return `<span class="badge badge-${map[s]||'secondary'}">${s}</span>`;
+        }
+
+        function badgeType(t) {
+            const map = { CREATE:'info', UPDATE:'warning', DELETE:'danger' };
+            return `<span class="badge badge-${map[t]||'secondary'}">${t}</span>`;
+        }
+
+        async function loadSummary() {
+            const from = document.getElementById('evFrom').value;
+            const to   = document.getElementById('evTo').value;
+            const qs   = new URLSearchParams({ from_date: from, to_date: to });
+            const data = await fetch('/gl/api/event-summary?' + qs).then(r => r.json());
+            document.getElementById('sumTotal').textContent       = data.total       || 0;
+            document.getElementById('sumUnprocessed').textContent = data.unprocessed || 0;
+            document.getElementById('sumProcessed').textContent   = data.processed   || 0;
+            document.getElementById('sumErrors').textContent      = data.errors      || 0;
+            document.getElementById('summaryCards').style.display = '';
+        }
+
+        async function loadEvents() {
+            await loadSummary();
+            const from   = document.getElementById('evFrom').value;
+            const to     = document.getElementById('evTo').value;
+            const status = document.getElementById('evStatus').value;
+            const qs     = new URLSearchParams({ from_date: from, to_date: to });
+            if (status) qs.set('status', status);
+            const rows = await fetch('/gl/api/accounting-events?' + qs).then(r => r.json());
+            const tbody = document.getElementById('eventsBody');
+            tbody.innerHTML = '';
+            rows.forEach(function(r) {
+                const tr = document.createElement('tr');
+                const retryBtn = r.event_status === 'ERROR'
+                    ? `<button class="btn btn-outline-warning btn-sm btn-retry" data-id="${r.event_id}" title="Retry"><i class="bi bi-arrow-repeat"></i></button>`
+                    : '';
+                tr.innerHTML = `
+                    <td class="small">${r.event_id}</td>
+                    <td class="small">${r.event_date ? r.event_date.substring(0,10) : ''}</td>
+                    <td class="small">${r.source_type}</td>
+                    <td class="small">${r.source_id}</td>
+                    <td class="small">${badgeType(r.event_type)}</td>
+                    <td class="small">${badgeStatus(r.event_status)}</td>
+                    <td class="small">${r.processed_by || ''}</td>
+                    <td class="small text-danger" style="max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${r.error_message||''}">${r.error_message||''}</td>
+                    <td class="text-center">${retryBtn}</td>`;
+                tbody.appendChild(tr);
+            });
+            document.getElementById('eventsTableWrap').style.display = '';
+
+            tbody.querySelectorAll('.btn-retry').forEach(function(btn) {
+                btn.addEventListener('click', async function() {
+                    const id = this.dataset.id;
+                    this.disabled = true;
+                    const data = await fetch('/gl/api/retry-event/' + id, { method: 'POST' }).then(r => r.json());
+                    if (data.success) {
+                        this.closest('tr').querySelector('.badge').className = 'badge badge-warning';
+                        this.closest('tr').querySelector('.badge').textContent = 'UNPROCESSED';
+                        this.remove();
+                    } else {
+                        alert('Error: ' + data.error);
+                        this.disabled = false;
+                    }
+                });
+            });
+        }
+
+        document.getElementById('btnLoadEvents').addEventListener('click', loadEvents);
+        document.getElementById('btnRefreshSummary').addEventListener('click', loadSummary);
+
+        // Auto-load summary on page open
+        loadSummary();
+
+        // ── Create Accounting ─────────────────────────────────────────────────
+
+        async function runAccounting(reprocess) {
+            const from = document.getElementById('caFrom').value;
+            const to   = document.getElementById('caTo').value;
+            if (!from || !to) { alert('Please select a date range.'); return; }
+            const btn = document.getElementById(reprocess ? 'btnReprocess' : 'btnRunAccounting');
+            btn.disabled = true;
+            const orig = btn.textContent;
+            btn.textContent = 'Running…';
+            try {
+                const resp = await fetch('/gl/api/create-accounting', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ from_date: from, to_date: to, reprocess })
+                });
+                const data = await resp.json();
+                const wrap = document.getElementById('caResult');
+                const body = document.getElementById('caResultBody');
+                if (data.success) {
+                    const s = data.summary;
+                    body.innerHTML = `
+                        <div class="text-success font-weight-bold mb-2"><i class="bi bi-check-circle-fill mr-1"></i>Done</div>
+                        <div class="row text-center">
+                            <div class="col">
+                                <div class="small text-muted">Vouchers Created</div>
+                                <div class="h5">${s.processed}</div>
+                            </div>
+                            <div class="col">
+                                <div class="small text-muted">Blocked</div>
+                                <div class="h5 text-warning">${s.blocked}</div>
+                            </div>
+                            <div class="col">
+                                <div class="small text-muted">Skipped</div>
+                                <div class="h5">${s.skipped}</div>
+                            </div>
+                            <div class="col">
+                                <div class="small text-danger">Errors</div>
+                                <div class="h5 text-danger">${s.errors}</div>
+                            </div>
+                        </div>
+                        ${s.blockedDates && s.blockedDates.length ? `<div class="small text-muted mt-1">Blocked dates (DRAFT): ${s.blockedDates.join(', ')}</div>` : ''}
+                        ${s.errors > 0 ? `<div class="small text-danger mt-1">Check Events Monitor tab for error details.</div>` : ''}`;
+                } else {
+                    body.innerHTML = `<div class="text-danger"><i class="bi bi-exclamation-triangle mr-1"></i>${data.error}</div>`;
+                }
+                wrap.style.display = '';
+            } catch (e) {
+                alert('Network error: ' + e.message);
+            } finally {
+                btn.disabled = false;
+                btn.textContent = orig;
+            }
+        }
+
+        document.getElementById('btnRunAccounting').addEventListener('click', () => runAccounting(false));
+        document.getElementById('btnReprocess').addEventListener('click', function() {
+            if (!confirm('Reprocess will reverse and re-create ALL existing vouchers in this range. Are you sure?')) return;
+            runAccounting(true);
+        });
+
+        // ── Generate Events ───────────────────────────────────────────────────
+
+        document.getElementById('btnGenerate').addEventListener('click', async function() {
+            const from = document.getElementById('geFrom').value;
+            const to   = document.getElementById('geTo').value;
+            if (!from || !to) { alert('Please select a date range.'); return; }
+            this.disabled = true;
+            const orig = this.textContent;
+            this.textContent = 'Running…';
+            try {
+                const resp = await fetch('/gl/api/generate-events', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ from_date: from, to_date: to })
+                });
+                const data = await resp.json();
+                const wrap = document.getElementById('geResult');
+                const body = document.getElementById('geResultBody');
+                if (data.success) {
+                    const counts = data.counts || {};
+                    const rows = Object.entries(counts).map(([k, v]) =>
+                        `<tr><td class="small">${k}</td><td class="small text-right">${v}</td></tr>`
+                    ).join('');
+                    body.innerHTML = `
+                        <div class="font-weight-bold mb-2 ${data.total > 0 ? 'text-success' : 'text-muted'}">
+                            <i class="bi bi-${data.total > 0 ? 'check-circle-fill' : 'info-circle'} mr-1"></i>
+                            ${data.total} event${data.total !== 1 ? 's' : ''} generated
+                        </div>
+                        ${data.total > 0 ? `<table class="table table-sm table-bordered w-auto"><thead class="thead-light"><tr><th>Source Type</th><th class="text-right">Generated</th></tr></thead><tbody>${rows}</tbody></table>` : ''}
+                        ${data.total > 0 ? `<div class="small text-muted">Run Create Accounting to process them.</div>` : '<div class="small text-muted">No missing events found — queue is up to date.</div>'}`;
+                } else {
+                    body.innerHTML = `<div class="text-danger"><i class="bi bi-exclamation-triangle mr-1"></i>${data.error}</div>`;
+                }
+                wrap.style.display = '';
+            } catch (e) {
+                alert('Network error: ' + e.message);
+            } finally {
+                this.disabled = false;
+                this.textContent = orig;
+            }
+        });

--- a/views/gl-control.pug
+++ b/views/gl-control.pug
@@ -24,7 +24,7 @@ block content
                 form.row.align-items-end.mb-3#eventsFilterForm
                     .col-auto
                         label.small.mb-1 Period
-                        select.form-control.form-control-sm(onchange="glSetPeriod('evFrom','evTo',this.id)" id="evPeriod")
+                        select.form-control.form-control-sm#evPeriod(onchange="glSetPeriod(this)" data-from="evFrom" data-to="evTo")
                             option(value="this_month") This Month
                             option(value="last_month") Last Month
                             option(value="this_fy") This Financial Year
@@ -92,7 +92,7 @@ block content
                 .row.align-items-end.mb-3
                     .col-auto
                         label.small.mb-1 Period
-                        select.form-control.form-control-sm(onchange="glSetPeriod('caFrom','caTo',this.id)" id="caPeriod")
+                        select.form-control.form-control-sm#caPeriod(onchange="glSetPeriod(this)" data-from="caFrom" data-to="caTo")
                             option(value="this_month") This Month
                             option(value="last_month") Last Month
                             option(value="this_fy") This Financial Year
@@ -125,7 +125,7 @@ block content
                 .row.align-items-end.mb-3
                     .col-auto
                         label.small.mb-1 Period
-                        select.form-control.form-control-sm(onchange="glSetPeriod('geFrom','geTo',this.id)" id="gePeriod")
+                        select.form-control.form-control-sm#gePeriod(onchange="glSetPeriod(this)" data-from="geFrom" data-to="geTo")
                             option(value="this_month") This Month
                             option(value="last_month") Last Month
                             option(value="this_fy") This Financial Year

--- a/views/gl-control.pug
+++ b/views/gl-control.pug
@@ -23,6 +23,14 @@ block content
 
                 form.row.align-items-end.mb-3#eventsFilterForm
                     .col-auto
+                        label.small.mb-1 Period
+                        select.form-control.form-control-sm(onchange="glSetPeriod('evFrom','evTo',this.id)" id="evPeriod")
+                            option(value="this_month") This Month
+                            option(value="last_month") Last Month
+                            option(value="this_fy") This Financial Year
+                            option(value="last_fy") Last Financial Year
+                            option(value="custom" selected) Custom
+                    .col-auto
                         label.small.mb-1 From Date
                         input.form-control.form-control-sm(type="date" id="evFrom" value=fromDate)
                     .col-auto
@@ -83,6 +91,14 @@ block content
 
                 .row.align-items-end.mb-3
                     .col-auto
+                        label.small.mb-1 Period
+                        select.form-control.form-control-sm(onchange="glSetPeriod('caFrom','caTo',this.id)" id="caPeriod")
+                            option(value="this_month") This Month
+                            option(value="last_month") Last Month
+                            option(value="this_fy") This Financial Year
+                            option(value="last_fy") Last Financial Year
+                            option(value="custom" selected) Custom
+                    .col-auto
                         label.small.mb-1 From Date
                         input.form-control.form-control-sm(type="date" id="caFrom" value=fromDate)
                     .col-auto
@@ -107,6 +123,14 @@ block content
                     | or accounting was enabled after transactions already existed.
 
                 .row.align-items-end.mb-3
+                    .col-auto
+                        label.small.mb-1 Period
+                        select.form-control.form-control-sm(onchange="glSetPeriod('geFrom','geTo',this.id)" id="gePeriod")
+                            option(value="this_month") This Month
+                            option(value="last_month") Last Month
+                            option(value="this_fy") This Financial Year
+                            option(value="last_fy") Last Financial Year
+                            option(value="custom" selected) Custom
                     .col-auto
                         label.small.mb-1 From Date
                         input.form-control.form-control-sm(type="date" id="geFrom" value=fromDate)

--- a/views/gl-day-book.pug
+++ b/views/gl-day-book.pug
@@ -11,7 +11,7 @@ block content
         form.row.align-items-end.mb-3(method="GET" action="/gl/day-book")
             .col-auto
                 label.small.mb-1 Period
-                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod('glFrom','glTo')")
+                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod(this)" data-from="glFrom" data-to="glTo")
                     option(value="this_month") This Month
                     option(value="last_month") Last Month
                     option(value="this_fy") This Financial Year

--- a/views/gl-day-book.pug
+++ b/views/gl-day-book.pug
@@ -10,11 +10,19 @@ block content
 
         form.row.align-items-end.mb-3(method="GET" action="/gl/day-book")
             .col-auto
+                label.small.mb-1 Period
+                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod('glFrom','glTo')")
+                    option(value="this_month") This Month
+                    option(value="last_month") Last Month
+                    option(value="this_fy") This Financial Year
+                    option(value="last_fy") Last Financial Year
+                    option(value="custom" selected) Custom
+            .col-auto
                 label.small.mb-1 From Date
-                input.form-control.form-control-sm(type="date" name="from_date" value=fromDate)
+                input.form-control.form-control-sm#glFrom(type="date" name="from_date" value=fromDate)
             .col-auto
                 label.small.mb-1 To Date
-                input.form-control.form-control-sm(type="date" name="to_date" value=toDate)
+                input.form-control.form-control-sm#glTo(type="date" name="to_date" value=toDate)
             .col-auto
                 label.small.mb-1 Type
                 select.form-control.form-control-sm(name="voucher_type")

--- a/views/gl-day-book.pug
+++ b/views/gl-day-book.pug
@@ -1,0 +1,89 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Day Book
+            a.btn.btn-sm.btn-outline-secondary(href="/home") &larr; Back
+
+        form.row.align-items-end.mb-3(method="GET" action="/gl/day-book")
+            .col-auto
+                label.small.mb-1 From Date
+                input.form-control.form-control-sm(type="date" name="from_date" value=fromDate)
+            .col-auto
+                label.small.mb-1 To Date
+                input.form-control.form-control-sm(type="date" name="to_date" value=toDate)
+            .col-auto
+                label.small.mb-1 Type
+                select.form-control.form-control-sm(name="voucher_type")
+                    option(value="" selected=!selectedType) All Types
+                    each vt in VOUCHER_TYPES
+                        option(value=vt selected=(selectedType === vt))= vt
+            .col-auto.align-self-end
+                button.btn.btn-primary.btn-sm(type="submit") View
+
+        .row.mb-3
+            .col-4
+                .card.text-center.py-2
+                    .small.text-muted Vouchers
+                    strong= vouchers.length
+            .col-4
+                .card.text-center.py-2
+                    .small.text-muted Total DR (₹)
+                    strong= grandTotalDr.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+            .col-4
+                .card.text-center.py-2
+                    .small.text-muted Total CR (₹)
+                    strong= grandTotalCr.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+
+        if !vouchers.length
+            .alert.alert-info.py-2 No vouchers found for this date range.
+        else
+            .table-responsive
+                table.table.table-bordered.table-sm#dayBookTable
+                    thead.thead-dark
+                        tr
+                            th(style="width:90px") Date
+                            th(style="width:95px") Voucher No
+                            th(style="width:80px") Type
+                            th Particulars
+                            th.text-right(style="width:110px") DR (₹)
+                            th.text-right(style="width:110px") CR (₹)
+                    tbody
+                        each v in vouchers
+                            tr.vhdr(class=(v.is_reversal === 'Y' ? 'table-warning' : 'table-light'))
+                                td.small= v.voucher_date
+                                td
+                                    strong= v.voucher_no
+                                    if v.is_reversal === 'Y'
+                                        |
+                                        span.badge.badge-warning REV
+                                td.text-center
+                                    - const typeClass = {SALES:'success',PURCHASE:'primary',PAYMENT:'danger',RECEIPT:'info',JOURNAL:'secondary',CONTRA:'dark'}[v.voucher_type] || 'secondary'
+                                    span.badge(class='badge-' + typeClass)= v.voucher_type
+                                td.small.text-muted(style="max-width:300px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title=v.narration)= v.narration
+                                td.text-right.small= v.total_dr.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+                                td.text-right.small= v.total_cr.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+                            each line in v.lines
+                                tr.vline(class=(v.is_reversal === 'Y' ? 'table-warning' : ''))
+                                    td(colspan="3")
+                                    td.small.pl-4= line.ledger_name
+                                    td.text-right.small
+                                        if line.dr_amount > 0
+                                            = line.dr_amount.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+                                    td.text-right.small
+                                        if line.cr_amount > 0
+                                            = line.cr_amount.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+                    tfoot
+                        tr.font-weight-bold.bg-light
+                            td(colspan="4") Grand Total
+                            td.text-right= grandTotalDr.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+                            td.text-right= grandTotalCr.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+
+    style.
+        #dayBookTable { font-size: 0.8rem; }
+        .vhdr td { border-bottom: none !important; }
+        .vline td { border-top: none !important; }
+        .vline td:first-child { border: none !important; }

--- a/views/gl-journal-form.pug
+++ b/views/gl-journal-form.pug
@@ -1,0 +1,257 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0= title
+            .d-flex.align-items-center
+                if voucher && !readOnly
+                    span already in read-only
+                if readOnly && voucher && voucher.is_reversal !== 'Y'
+                    button.btn.btn-sm.btn-warning.mr-2#btnReverse(data-id=voucher.voucher_id)
+                        i.bi.bi-arrow-counterclockwise.mr-1
+                        | Reverse
+                a.btn.btn-sm.btn-outline-secondary(href="/gl/journal") &larr; Back
+
+        if readOnly && voucher
+            .row.mb-3
+                .col-auto
+                    .small.text-muted Date
+                    strong= voucher.fmt_date
+                .col-auto
+                    .small.text-muted Voucher No
+                    strong= voucher.voucher_no
+                .col-auto
+                    .small.text-muted Type
+                    - const tc = {JOURNAL:'secondary',PAYMENT:'danger',RECEIPT:'info',CONTRA:'dark'}[voucher.voucher_type]||'secondary'
+                    span.badge(class='badge-'+tc)= voucher.voucher_type
+                if voucher.reversal_of_no
+                    .col-auto
+                        .small.text-muted Reversal of
+                        strong= voucher.reversal_of_no
+                .col-12.mt-1
+                    .small.text-muted Narration
+                    = voucher.narration
+
+        else
+            .row.mb-3
+                .col-md-2
+                    label.small.mb-1 Date *
+                    input.form-control.form-control-sm#voucherDate(type="date" value=voucherDate)
+                .col-md-2
+                    label.small.mb-1 Type
+                    select.form-control.form-control-sm#voucherType
+                        each vt in MANUAL_JOURNAL_TYPES
+                            option(value=vt)= vt
+                .col-md-6
+                    label.small.mb-1 Narration
+                    input.form-control.form-control-sm#narration(type="text" placeholder="Purpose of this journal entry")
+
+        .table-responsive.mt-3
+            table.table.table-sm.table-bordered#linesTable
+                thead.thead-dark
+                    tr
+                        th(style="width:30px") #
+                        th Ledger
+                        th.text-right(style="width:130px") DR (₹)
+                        th.text-right(style="width:130px") CR (₹)
+                        th Narration
+                        if !readOnly
+                            th.text-center(style="width:40px")
+                tbody#linesBody
+                    if readOnly
+                        each line in lines
+                            tr
+                                td.small.text-muted= line.line_no
+                                td.small= line.ledger_name
+                                td.text-right.small= line.dr_amount > 0 ? parseFloat(line.dr_amount).toLocaleString('en-IN',{minimumFractionDigits:2,maximumFractionDigits:2}) : ''
+                                td.text-right.small= line.cr_amount > 0 ? parseFloat(line.cr_amount).toLocaleString('en-IN',{minimumFractionDigits:2,maximumFractionDigits:2}) : ''
+                                td.small= line.narration || ''
+                tfoot
+                    tr.font-weight-bold.bg-light
+                        td(colspan="2") Total
+                        td.text-right#totalDr
+                            if readOnly
+                                = lines.reduce((s,l)=>s+parseFloat(l.dr_amount||0),0).toLocaleString('en-IN',{minimumFractionDigits:2,maximumFractionDigits:2})
+                            else
+                                | 0.00
+                        td.text-right#totalCr
+                            if readOnly
+                                = lines.reduce((s,l)=>s+parseFloat(l.cr_amount||0),0).toLocaleString('en-IN',{minimumFractionDigits:2,maximumFractionDigits:2})
+                            else
+                                | 0.00
+                        td(colspan=readOnly ? '1' : '2')
+                            if !readOnly
+                                span#balanceStatus
+
+        if !readOnly
+            .mt-2
+                button.btn.btn-sm.btn-outline-primary.mr-2#btnAddRow
+                    i.bi.bi-plus-lg.mr-1
+                    | Add Row
+                button.btn.btn-success.ml-auto#btnSave(disabled)
+                    i.bi.bi-save.mr-1
+                    | Save Journal
+
+    if !readOnly
+        script.
+            let rowCount = 0;
+
+            function fmtNum(n) {
+                return Math.abs(n).toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2});
+            }
+
+            function addRow(ledgerId, ledgerName, drAmt, crAmt, lineNarration) {
+                rowCount++;
+                const idx = rowCount;
+                const tr  = document.createElement('tr');
+                tr.dataset.rowIdx = idx;
+                tr.innerHTML = `
+                    <td class="small text-muted align-middle">${idx}</td>
+                    <td>
+                        <select class="form-control form-control-sm ledger-select" name="ledger_${idx}" style="width:100%">
+                            ${ledgerId ? `<option value="${ledgerId}" selected>${ledgerName}</option>` : '<option value="">— Search ledger —</option>'}
+                        </select>
+                    </td>
+                    <td><input type="number" class="form-control form-control-sm text-right dr-amt" min="0" step="0.01" value="${drAmt||''}" placeholder="0.00"></td>
+                    <td><input type="number" class="form-control form-control-sm text-right cr-amt" min="0" step="0.01" value="${crAmt||''}" placeholder="0.00"></td>
+                    <td><input type="text" class="form-control form-control-sm line-narr" value="${lineNarration||''}" placeholder="(optional)"></td>
+                    <td class="text-center align-middle">
+                        <button type="button" class="btn btn-outline-danger btn-sm btn-remove-row">
+                            <i class="bi bi-trash"></i>
+                        </button>
+                    </td>`;
+
+                document.getElementById('linesBody').appendChild(tr);
+
+                // Select2 for this row's ledger
+                $(tr).find('.ledger-select').select2({
+                    placeholder: '— Search ledger —',
+                    allowClear: true,
+                    minimumInputLength: 1,
+                    dropdownParent: $('body'),
+                    ajax: {
+                        url: '/gl/api/ledgers/search',
+                        dataType: 'json',
+                        delay: 250,
+                        data: (p) => ({ q: p.term }),
+                        processResults: (data) => ({
+                            results: data.map(l => ({ id: l.ledger_id, text: l.ledger_name }))
+                        })
+                    }
+                });
+
+                // DR clears CR and vice versa
+                $(tr).find('.dr-amt').on('input', function() {
+                    if (this.value) $(tr).find('.cr-amt').val('');
+                    recalc();
+                });
+                $(tr).find('.cr-amt').on('input', function() {
+                    if (this.value) $(tr).find('.dr-amt').val('');
+                    recalc();
+                });
+
+                $(tr).find('.btn-remove-row').on('click', function() {
+                    if (document.querySelectorAll('#linesBody tr').length <= 2) {
+                        alert('At least 2 lines are required.');
+                        return;
+                    }
+                    tr.remove();
+                    recalc();
+                });
+
+                recalc();
+            }
+
+            function recalc() {
+                let totalDr = 0, totalCr = 0;
+                document.querySelectorAll('#linesBody tr').forEach(function(tr) {
+                    totalDr += parseFloat(tr.querySelector('.dr-amt').value || 0);
+                    totalCr += parseFloat(tr.querySelector('.cr-amt').value || 0);
+                });
+                const diff = Math.abs(totalDr - totalCr);
+                document.getElementById('totalDr').textContent = fmtNum(totalDr);
+                document.getElementById('totalCr').textContent = fmtNum(totalCr);
+                const status = document.getElementById('balanceStatus');
+                if (diff < 0.005 && totalDr > 0) {
+                    status.innerHTML = '<span class="text-success small"><i class="bi bi-check-circle-fill"></i> Balanced</span>';
+                    document.getElementById('btnSave').disabled = false;
+                } else {
+                    status.innerHTML = diff < 0.005 ? '' :
+                        `<span class="text-danger small">Diff ₹${fmtNum(diff)}</span>`;
+                    document.getElementById('btnSave').disabled = true;
+                }
+            }
+
+            document.getElementById('btnAddRow').addEventListener('click', () => addRow());
+
+            document.getElementById('btnSave').addEventListener('click', async function() {
+                const lines = [];
+                let valid = true;
+                document.querySelectorAll('#linesBody tr').forEach(function(tr) {
+                    const ledgerId  = $(tr).find('.ledger-select').val();
+                    const drAmount  = parseFloat(tr.querySelector('.dr-amt').value || 0);
+                    const crAmount  = parseFloat(tr.querySelector('.cr-amt').value || 0);
+                    const narration = tr.querySelector('.line-narr').value;
+                    if (!ledgerId) { valid = false; return; }
+                    lines.push({ ledger_id: ledgerId, dr_amount: drAmount, cr_amount: crAmount, narration });
+                });
+                if (!valid) { alert('Please select a ledger for every line.'); return; }
+
+                const payload = {
+                    voucher_type: document.getElementById('voucherType').value,
+                    voucher_date: document.getElementById('voucherDate').value,
+                    narration:    document.getElementById('narration').value,
+                    lines
+                };
+
+                this.disabled = true;
+                this.textContent = 'Saving…';
+
+                try {
+                    const resp = await fetch('/gl/api/journal', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(payload)
+                    });
+                    const data = await resp.json();
+                    if (data.success) {
+                        window.location.href = '/gl/journal/' + data.voucher_id;
+                    } else {
+                        alert('Error: ' + data.error);
+                        this.disabled = false;
+                        this.textContent = 'Save Journal';
+                    }
+                } catch (e) {
+                    alert('Network error. Please try again.');
+                    this.disabled = false;
+                    this.textContent = 'Save Journal';
+                }
+            });
+
+            // Seed 2 blank rows on load
+            addRow(); addRow();
+
+    if readOnly && voucher && voucher.is_reversal !== 'Y'
+        script.
+            document.getElementById('btnReverse') && document.getElementById('btnReverse').addEventListener('click', async function() {
+                if (!confirm('Create a reversal entry for ' + this.dataset.id + '?')) return;
+                this.disabled = true;
+                this.textContent = 'Reversing…';
+                try {
+                    const resp = await fetch('/gl/api/journal/' + this.dataset.id + '/reverse', { method: 'POST' });
+                    const data = await resp.json();
+                    if (data.success) {
+                        window.location.href = '/gl/journal/' + data.voucher_id;
+                    } else {
+                        alert('Error: ' + data.error);
+                        this.disabled = false;
+                        this.innerHTML = '<i class="bi bi-arrow-counterclockwise mr-1"></i> Reverse';
+                    }
+                } catch (e) {
+                    alert('Network error.');
+                    this.disabled = false;
+                }
+            });

--- a/views/gl-journal-list.pug
+++ b/views/gl-journal-list.pug
@@ -13,7 +13,7 @@ block content
         form.row.align-items-end.mb-3(method="GET" action="/gl/journal")
             .col-auto
                 label.small.mb-1 Period
-                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod('glFrom','glTo')")
+                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod(this)" data-from="glFrom" data-to="glTo")
                     option(value="this_month") This Month
                     option(value="last_month") Last Month
                     option(value="this_fy") This Financial Year

--- a/views/gl-journal-list.pug
+++ b/views/gl-journal-list.pug
@@ -1,0 +1,54 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Manual Journals
+            a.btn.btn-sm.btn-success(href="/gl/journal/new")
+                i.bi.bi-plus-lg.mr-1
+                | New Journal
+
+        form.row.align-items-end.mb-3(method="GET" action="/gl/journal")
+            .col-auto
+                label.small.mb-1 From Date
+                input.form-control.form-control-sm(type="date" name="from_date" value=fromDate)
+            .col-auto
+                label.small.mb-1 To Date
+                input.form-control.form-control-sm(type="date" name="to_date" value=toDate)
+            .col-auto.align-self-end
+                button.btn.btn-primary.btn-sm(type="submit") View
+
+        if !journals.length
+            .alert.alert-info.py-2 No manual journals found for this date range.
+        else
+            .table-responsive
+                table.table.table-sm.table-bordered.table-hover
+                    thead.thead-dark
+                        tr
+                            th(style="width:90px") Date
+                            th(style="width:100px") Voucher No
+                            th(style="width:80px") Type
+                            th Narration
+                            th.text-right(style="width:120px") Amount (₹)
+                            th(style="width:90px") Posted By
+                            th.text-center(style="width:60px")
+                    tbody
+                        each j in journals
+                            tr(class=(j.is_reversal==='Y'?'table-warning':''))
+                                td.small= j.voucher_date
+                                td.small
+                                    = j.voucher_no
+                                    if j.is_reversal === 'Y'
+                                        |
+                                        span.badge.badge-warning REV
+                                td.text-center
+                                    - const tc = {JOURNAL:'secondary',PAYMENT:'danger',RECEIPT:'info',CONTRA:'dark'}[j.voucher_type]||'secondary'
+                                    span.badge(class='badge-'+tc)= j.voucher_type
+                                td.small= j.narration
+                                td.text-right.small= parseFloat(j.total_amount).toLocaleString('en-IN',{minimumFractionDigits:2,maximumFractionDigits:2})
+                                td.small= j.posted_by
+                                td.text-center
+                                    a.btn.btn-outline-secondary.btn-sm(href='/gl/journal/'+j.voucher_id title="View")
+                                        i.bi.bi-eye

--- a/views/gl-journal-list.pug
+++ b/views/gl-journal-list.pug
@@ -12,11 +12,19 @@ block content
 
         form.row.align-items-end.mb-3(method="GET" action="/gl/journal")
             .col-auto
+                label.small.mb-1 Period
+                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod('glFrom','glTo')")
+                    option(value="this_month") This Month
+                    option(value="last_month") Last Month
+                    option(value="this_fy") This Financial Year
+                    option(value="last_fy") Last Financial Year
+                    option(value="custom" selected) Custom
+            .col-auto
                 label.small.mb-1 From Date
-                input.form-control.form-control-sm(type="date" name="from_date" value=fromDate)
+                input.form-control.form-control-sm#glFrom(type="date" name="from_date" value=fromDate)
             .col-auto
                 label.small.mb-1 To Date
-                input.form-control.form-control-sm(type="date" name="to_date" value=toDate)
+                input.form-control.form-control-sm#glTo(type="date" name="to_date" value=toDate)
             .col-auto.align-self-end
                 button.btn.btn-primary.btn-sm(type="submit") View
 

--- a/views/gl-ledger-groups.pug
+++ b/views/gl-ledger-groups.pug
@@ -1,0 +1,134 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Ledger Groups
+            .d-flex.gap-2
+                a.btn.btn-sm.btn-outline-secondary.mr-2(href="/gl/ledgers") Ledgers &rarr;
+                button.btn.btn-sm.btn-success#btnAddGroup
+                    i.bi.bi-plus-lg.mr-1
+                    | Add Group
+
+        if messages && messages.error && messages.error.length
+            .alert.alert-danger.py-2= messages.error[0]
+
+        - const natures = ['ASSETS','LIABILITIES','INCOME','EXPENSES']
+        - const natureBadge = { ASSETS:'primary', LIABILITIES:'warning', INCOME:'success', EXPENSES:'danger' }
+
+        each nat in natures
+            - const grps = groups.filter(g => g.group_nature === nat)
+            if grps.length
+                h6.border-bottom.pb-1.mt-3
+                    span.badge(class='badge-'+natureBadge[nat])= nat
+                .table-responsive.mb-2
+                    table.table.table-sm.table-bordered
+                        thead.thead-light
+                            tr
+                                th Group Name
+                                th.text-center(style="width:120px") Active Ledgers
+                                th.text-center(style="width:80px")
+                        tbody
+                            each g in grps
+                                tr
+                                    td= g.group_name
+                                    td.text-center.small= g.ledger_count
+                                    td.text-center
+                                        button.btn.btn-outline-primary.btn-sm.btn-edit-group.mr-1(
+                                            data-id=g.group_id
+                                            data-name=g.group_name
+                                            data-nature=g.group_nature
+                                            title="Edit")
+                                            i.bi.bi-pencil
+                                        if g.ledger_count == 0
+                                            button.btn.btn-outline-danger.btn-sm.btn-del-group(
+                                                data-id=g.group_id
+                                                data-name=g.group_name
+                                                title="Delete")
+                                                i.bi.bi-trash
+
+    //- Add / Edit Modal
+    .modal.fade#groupModal(tabindex="-1")
+        .modal-dialog
+            .modal-content
+                .modal-header
+                    h5.modal-title#groupModalTitle Add Ledger Group
+                    button.close(data-dismiss="modal" aria-label="Close")
+                        span &times;
+                .modal-body
+                    .form-group
+                        label.small Group Name *
+                        input.form-control.form-control-sm#gName(type="text" maxlength="100")
+                    .form-group
+                        label.small Nature *
+                        select.form-control.form-control-sm#gNature
+                            option(value="ASSETS") ASSETS
+                            option(value="LIABILITIES") LIABILITIES
+                            option(value="INCOME") INCOME
+                            option(value="EXPENSES") EXPENSES
+                .modal-footer
+                    button.btn.btn-secondary.btn-sm(data-dismiss="modal") Cancel
+                    button.btn.btn-primary.btn-sm#btnSaveGroup Save
+
+    script.
+        let editingGroupId = null;
+
+        document.getElementById('btnAddGroup').addEventListener('click', function() {
+            editingGroupId = null;
+            document.getElementById('groupModalTitle').textContent = 'Add Ledger Group';
+            document.getElementById('gName').value = '';
+            document.getElementById('gNature').value = 'ASSETS';
+            $('#groupModal').modal('show');
+        });
+
+        document.querySelectorAll('.btn-edit-group').forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                editingGroupId = this.dataset.id;
+                document.getElementById('groupModalTitle').textContent = 'Edit Ledger Group';
+                document.getElementById('gName').value = this.dataset.name;
+                document.getElementById('gNature').value = this.dataset.nature;
+                $('#groupModal').modal('show');
+            });
+        });
+
+        document.getElementById('btnSaveGroup').addEventListener('click', async function() {
+            const name   = document.getElementById('gName').value.trim();
+            const nature = document.getElementById('gNature').value;
+            if (!name) { alert('Group name is required.'); return; }
+
+            this.disabled = true;
+            try {
+                const url    = editingGroupId ? '/gl/api/ledger-groups/' + editingGroupId : '/gl/api/ledger-groups';
+                const method = editingGroupId ? 'PUT' : 'POST';
+                const resp   = await fetch(url, {
+                    method,
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ group_name: name, group_nature: nature })
+                });
+                const data = await resp.json();
+                if (data.success) {
+                    location.reload();
+                } else {
+                    alert('Error: ' + data.error);
+                    this.disabled = false;
+                }
+            } catch (e) {
+                alert('Network error.');
+                this.disabled = false;
+            }
+        });
+
+        document.querySelectorAll('.btn-del-group').forEach(function(btn) {
+            btn.addEventListener('click', async function() {
+                if (!confirm('Delete group "' + this.dataset.name + '"?')) return;
+                const resp = await fetch('/gl/api/ledger-groups/' + this.dataset.id, { method: 'DELETE' });
+                const data = await resp.json();
+                if (data.success) {
+                    location.reload();
+                } else {
+                    alert('Error: ' + data.error);
+                }
+            });
+        });

--- a/views/gl-ledger-report.pug
+++ b/views/gl-ledger-report.pug
@@ -1,0 +1,125 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Ledger Report
+            a.btn.btn-sm.btn-outline-secondary(href="/gl/day-book") &larr; Day Book
+
+        form.row.align-items-end.mb-3(method="GET" action="/gl/ledger")
+            .col-md-4
+                label.small.mb-1 Ledger
+                select#ledgerSelect.form-control.form-control-sm(name="ledger_id")
+                    if ledger
+                        option(value=ledger.ledger_id selected)= ledger.ledger_name
+                    else
+                        option(value="") — Search ledger —
+            .col-auto
+                label.small.mb-1 From Date
+                input.form-control.form-control-sm(type="date" name="from_date" value=fromDate)
+            .col-auto
+                label.small.mb-1 To Date
+                input.form-control.form-control-sm(type="date" name="to_date" value=toDate)
+            .col-auto.align-self-end
+                button.btn.btn-primary.btn-sm(type="submit") View
+
+        if !ledger
+            .alert.alert-info.py-2 Select a ledger to view its account statement.
+        else
+            .mb-2
+                span.font-weight-bold= ledger.ledger_name
+                span.text-muted.ml-2.small= ledger.group_name + ' — ' + ledger.group_nature
+
+            - const fmt = (n) => Math.abs(n).toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+            - const balLabel = (n) => n >= 0 ? fmt(n) + ' Dr' : fmt(n) + ' Cr'
+
+            .row.mb-3
+                .col-3
+                    .card.text-center.py-2
+                        .small.text-muted Opening Balance
+                        strong(class=(obNet >= 0 ? 'text-dark' : 'text-danger'))= balLabel(obNet)
+                .col-3
+                    .card.text-center.py-2
+                        .small.text-muted Period DR (₹)
+                        strong= fmt(periodDr)
+                .col-3
+                    .card.text-center.py-2
+                        .small.text-muted Period CR (₹)
+                        strong= fmt(periodCr)
+                .col-3
+                    .card.text-center.py-2
+                        .small.text-muted Closing Balance
+                        strong(class=(closingBalance >= 0 ? 'text-dark' : 'text-danger'))= balLabel(closingBalance)
+
+            if !entries.length
+                .alert.alert-info.py-2 No transactions in this date range.
+            else
+                .table-responsive
+                    table.table.table-bordered.table-sm#ledgerTable
+                        thead.thead-dark
+                            tr
+                                th(style="width:90px") Date
+                                th(style="width:95px") Voucher No
+                                th(style="width:80px") Type
+                                th Particulars
+                                th.text-right(style="width:110px") DR (₹)
+                                th.text-right(style="width:110px") CR (₹)
+                                th.text-right(style="width:120px") Balance
+                        tbody
+                            tr.table-light.font-weight-bold
+                                td(colspan="6") Opening Balance
+                                td.text-right= balLabel(obNet)
+                            each e in entries
+                                tr(class=(e.is_reversal === 'Y' ? 'table-warning' : ''))
+                                    td.small= e.voucher_date
+                                    td.small
+                                        = e.voucher_no
+                                        if e.is_reversal === 'Y'
+                                            |
+                                            span.badge.badge-warning REV
+                                    td.text-center
+                                        - const tc = {SALES:'success',PURCHASE:'primary',PAYMENT:'danger',RECEIPT:'info',JOURNAL:'secondary',CONTRA:'dark'}[e.voucher_type] || 'secondary'
+                                        span.badge(class='badge-' + tc)= e.voucher_type
+                                    td.small(style="max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title=e.narration)= e.narration
+                                    td.text-right.small
+                                        if e.dr_amount > 0
+                                            = fmt(e.dr_amount)
+                                    td.text-right.small
+                                        if e.cr_amount > 0
+                                            = fmt(e.cr_amount)
+                                    td.text-right.small.font-weight-bold= balLabel(e.balance)
+                        tfoot
+                            tr.font-weight-bold.bg-light
+                                td(colspan="4") Closing Balance
+                                td.text-right= fmt(periodDr)
+                                td.text-right= fmt(periodCr)
+                                td.text-right= balLabel(closingBalance)
+
+    script.
+        $(document).ready(function() {
+            $('#ledgerSelect').select2({
+                placeholder: '— Search ledger —',
+                allowClear: true,
+                minimumInputLength: 1,
+                ajax: {
+                    url: '/gl/api/ledgers/search',
+                    dataType: 'json',
+                    delay: 250,
+                    data: function(params) {
+                        return { q: params.term };
+                    },
+                    processResults: function(data) {
+                        return {
+                            results: data.map(function(l) {
+                                return { id: l.ledger_id, text: l.ledger_name };
+                            })
+                        };
+                    }
+                }
+            });
+        });
+
+    style.
+        #ledgerTable { font-size: 0.8rem; }

--- a/views/gl-ledger-report.pug
+++ b/views/gl-ledger-report.pug
@@ -17,11 +17,19 @@ block content
                     else
                         option(value="") — Search ledger —
             .col-auto
+                label.small.mb-1 Period
+                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod('glFrom','glTo')")
+                    option(value="this_month") This Month
+                    option(value="last_month") Last Month
+                    option(value="this_fy") This Financial Year
+                    option(value="last_fy") Last Financial Year
+                    option(value="custom" selected) Custom
+            .col-auto
                 label.small.mb-1 From Date
-                input.form-control.form-control-sm(type="date" name="from_date" value=fromDate)
+                input.form-control.form-control-sm#glFrom(type="date" name="from_date" value=fromDate)
             .col-auto
                 label.small.mb-1 To Date
-                input.form-control.form-control-sm(type="date" name="to_date" value=toDate)
+                input.form-control.form-control-sm#glTo(type="date" name="to_date" value=toDate)
             .col-auto.align-self-end
                 button.btn.btn-primary.btn-sm(type="submit") View
 

--- a/views/gl-ledger-report.pug
+++ b/views/gl-ledger-report.pug
@@ -18,7 +18,7 @@ block content
                         option(value="") — Search ledger —
             .col-auto
                 label.small.mb-1 Period
-                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod('glFrom','glTo')")
+                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod(this)" data-from="glFrom" data-to="glTo")
                     option(value="this_month") This Month
                     option(value="last_month") Last Month
                     option(value="this_fy") This Financial Year

--- a/views/gl-ledgers.pug
+++ b/views/gl-ledgers.pug
@@ -1,0 +1,130 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Ledgers
+            .d-flex.gap-2
+                a.btn.btn-sm.btn-outline-secondary.mr-2(href="/gl/ledger-groups") &larr; Groups
+                button.btn.btn-sm.btn-success#btnAddLedger
+                    i.bi.bi-plus-lg.mr-1
+                    | Add Ledger
+
+        if messages && messages.error && messages.error.length
+            .alert.alert-danger.py-2= messages.error[0]
+
+        - const natures = ['ASSETS','LIABILITIES','INCOME','EXPENSES']
+        - const natureBadge = { ASSETS:'primary', LIABILITIES:'warning', INCOME:'success', EXPENSES:'danger' }
+
+        - const byNature = {}
+        - natures.forEach(n => { byNature[n] = {} })
+        - ledgers.forEach(function(l) { if (!byNature[l.group_nature]) byNature[l.group_nature] = {}; if (!byNature[l.group_nature][l.group_name]) byNature[l.group_nature][l.group_name] = []; byNature[l.group_nature][l.group_name].push(l); })
+
+        each nat in natures
+            - const grpMap = byNature[nat]
+            - const grpNames = Object.keys(grpMap)
+            if grpNames.length
+                h6.border-bottom.pb-1.mt-3
+                    span.badge(class='badge-'+natureBadge[nat])= nat
+                each grpName in grpNames
+                    h6.small.text-muted.mt-2.mb-1= grpName
+                    .table-responsive.mb-1
+                        table.table.table-sm.table-bordered
+                            tbody
+                                each l in grpMap[grpName]
+                                    tr(class=(l.active_flag === 'N' ? 'table-secondary text-muted' : ''))
+                                        td= l.ledger_name
+                                        td.text-center(style="width:60px")
+                                            if l.active_flag === 'N'
+                                                span.badge.badge-secondary Inactive
+                                        td.text-center(style="width:80px")
+                                            button.btn.btn-outline-primary.btn-sm.btn-edit-ledger(
+                                                data-id=l.ledger_id
+                                                data-name=l.ledger_name
+                                                data-group=l.group_id
+                                                data-active=l.active_flag
+                                                title="Edit")
+                                                i.bi.bi-pencil
+
+    //- Add / Edit Modal
+    .modal.fade#ledgerModal(tabindex="-1")
+        .modal-dialog
+            .modal-content
+                .modal-header
+                    h5.modal-title#ledgerModalTitle Add Ledger
+                    button.close(data-dismiss="modal" aria-label="Close")
+                        span &times;
+                .modal-body
+                    .form-group
+                        label.small Ledger Name *
+                        input.form-control.form-control-sm#lName(type="text" maxlength="150")
+                    .form-group
+                        label.small Group *
+                        select.form-control.form-control-sm#lGroup
+                            each g in groups
+                                option(value=g.group_id)= g.group_name + ' (' + g.group_nature + ')'
+                    .form-group#lActiveWrap
+                        .form-check
+                            input.form-check-input#lActive(type="checkbox" value="Y")
+                            label.form-check-label.small(for="lActive") Active
+                .modal-footer
+                    button.btn.btn-secondary.btn-sm(data-dismiss="modal") Cancel
+                    button.btn.btn-primary.btn-sm#btnSaveLedger Save
+
+    script.
+        let editingLedgerId = null;
+
+        document.getElementById('btnAddLedger').addEventListener('click', function() {
+            editingLedgerId = null;
+            document.getElementById('ledgerModalTitle').textContent = 'Add Ledger';
+            document.getElementById('lName').value = '';
+            document.getElementById('lGroup').selectedIndex = 0;
+            document.getElementById('lActive').checked = true;
+            document.getElementById('lActiveWrap').style.display = 'none';
+            $('#ledgerModal').modal('show');
+        });
+
+        document.querySelectorAll('.btn-edit-ledger').forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                editingLedgerId = this.dataset.id;
+                document.getElementById('ledgerModalTitle').textContent = 'Edit Ledger';
+                document.getElementById('lName').value = this.dataset.name;
+                document.getElementById('lGroup').value = this.dataset.group;
+                document.getElementById('lActive').checked = this.dataset.active === 'Y';
+                document.getElementById('lActiveWrap').style.display = '';
+                $('#ledgerModal').modal('show');
+            });
+        });
+
+        document.getElementById('btnSaveLedger').addEventListener('click', async function() {
+            const name      = document.getElementById('lName').value.trim();
+            const group_id  = document.getElementById('lGroup').value;
+            const active    = document.getElementById('lActive').checked ? 'Y' : 'N';
+            if (!name) { alert('Ledger name is required.'); return; }
+
+            this.disabled = true;
+            try {
+                const url    = editingLedgerId ? '/gl/api/ledger/' + editingLedgerId : '/gl/api/ledger';
+                const method = editingLedgerId ? 'PUT' : 'POST';
+                const body   = { ledger_name: name, group_id };
+                if (editingLedgerId) body.active_flag = active;
+
+                const resp = await fetch(url, {
+                    method,
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(body)
+                });
+                const data = await resp.json();
+                if (data.success) {
+                    location.reload();
+                } else {
+                    alert('Error: ' + data.error);
+                    this.disabled = false;
+                }
+            } catch (e) {
+                alert('Network error.');
+                this.disabled = false;
+            }
+        });

--- a/views/gl-profit-loss.pug
+++ b/views/gl-profit-loss.pug
@@ -10,11 +10,19 @@ block content
 
         form.row.align-items-end.mb-3(method="GET" action="/gl/profit-loss")
             .col-auto
+                label.small.mb-1 Period
+                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod('glFrom','glTo')")
+                    option(value="this_month") This Month
+                    option(value="last_month") Last Month
+                    option(value="this_fy") This Financial Year
+                    option(value="last_fy") Last Financial Year
+                    option(value="custom" selected) Custom
+            .col-auto
                 label.small.mb-1 From Date
-                input.form-control.form-control-sm(type="date" name="from_date" value=fromDate)
+                input.form-control.form-control-sm#glFrom(type="date" name="from_date" value=fromDate)
             .col-auto
                 label.small.mb-1 To Date
-                input.form-control.form-control-sm(type="date" name="to_date" value=toDate)
+                input.form-control.form-control-sm#glTo(type="date" name="to_date" value=toDate)
             .col-auto.align-self-end
                 button.btn.btn-primary.btn-sm(type="submit") View
 

--- a/views/gl-profit-loss.pug
+++ b/views/gl-profit-loss.pug
@@ -11,7 +11,7 @@ block content
         form.row.align-items-end.mb-3(method="GET" action="/gl/profit-loss")
             .col-auto
                 label.small.mb-1 Period
-                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod('glFrom','glTo')")
+                select.form-control.form-control-sm#glPeriod(onchange="glSetPeriod(this)" data-from="glFrom" data-to="glTo")
                     option(value="this_month") This Month
                     option(value="last_month") Last Month
                     option(value="this_fy") This Financial Year

--- a/views/gl-profit-loss.pug
+++ b/views/gl-profit-loss.pug
@@ -1,0 +1,94 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Profit &amp; Loss Statement
+            a.btn.btn-sm.btn-outline-secondary(href="/gl/trial-balance") &larr; Trial Balance
+
+        form.row.align-items-end.mb-3(method="GET" action="/gl/profit-loss")
+            .col-auto
+                label.small.mb-1 From Date
+                input.form-control.form-control-sm(type="date" name="from_date" value=fromDate)
+            .col-auto
+                label.small.mb-1 To Date
+                input.form-control.form-control-sm(type="date" name="to_date" value=toDate)
+            .col-auto.align-self-end
+                button.btn.btn-primary.btn-sm(type="submit") View
+
+        - const fmt = (n) => Math.abs(n).toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+
+        .row.mb-3
+            .col-4
+                .card.text-center.py-2
+                    .small.text-muted Total Income (₹)
+                    strong.text-success= fmt(totalIncome)
+            .col-4
+                .card.text-center.py-2
+                    .small.text-muted Total Expenses (₹)
+                    strong.text-danger= fmt(totalExpenses)
+            .col-4
+                .card.text-center.py-2(class=(netPL >= 0 ? 'border-success' : 'border-danger'))
+                    .small.text-muted= netPL >= 0 ? 'Net Profit (₹)' : 'Net Loss (₹)'
+                    strong(class=(netPL >= 0 ? 'text-success' : 'text-danger'))= fmt(netPL)
+
+        .row
+            .col-md-6
+                h6.text-success.border-bottom.pb-1 Income
+                if !incomeGroups.length
+                    p.text-muted.small No income entries for this period.
+                else
+                    table.table.table-sm.table-bordered#plIncomeTable
+                        tbody
+                            each g in incomeGroups
+                                tr.group-header
+                                    td.font-weight-bold(colspan="2")= g.group_name
+                                each row in g.rows
+                                    tr
+                                        td.pl-4
+                                            a(href='/gl/ledger?ledger_id=' + row.ledger_id + '&from_date=' + fromDate + '&to_date=' + toDate)= row.ledger_name
+                                        td.text-right.small= fmt(row.amount)
+                                tr.group-subtotal
+                                    td.text-right.font-weight-bold.text-muted.small #{g.group_name} Total
+                                    td.text-right.font-weight-bold.small= fmt(g.subtotal)
+                        tfoot
+                            tr.table-success.font-weight-bold
+                                td Total Income
+                                td.text-right= fmt(totalIncome)
+
+            .col-md-6
+                h6.text-danger.border-bottom.pb-1 Expenses
+                if !expenseGroups.length
+                    p.text-muted.small No expense entries for this period.
+                else
+                    table.table.table-sm.table-bordered#plExpenseTable
+                        tbody
+                            each g in expenseGroups
+                                tr.group-header
+                                    td.font-weight-bold(colspan="2")= g.group_name
+                                each row in g.rows
+                                    tr
+                                        td.pl-4
+                                            a(href='/gl/ledger?ledger_id=' + row.ledger_id + '&from_date=' + fromDate + '&to_date=' + toDate)= row.ledger_name
+                                        td.text-right.small= fmt(row.amount)
+                                tr.group-subtotal
+                                    td.text-right.font-weight-bold.text-muted.small #{g.group_name} Total
+                                    td.text-right.font-weight-bold.small= fmt(g.subtotal)
+                        tfoot
+                            tr.table-danger.font-weight-bold
+                                td Total Expenses
+                                td.text-right= fmt(totalExpenses)
+
+        .row.mt-3
+            .col-md-6.offset-md-6
+                table.table.table-sm.table-bordered
+                    tr(class=(netPL >= 0 ? 'table-success' : 'table-danger') ).font-weight-bold
+                        td= netPL >= 0 ? 'Net Profit for the Period' : 'Net Loss for the Period'
+                        td.text-right= fmt(netPL)
+
+    style.
+        #plIncomeTable, #plExpenseTable { font-size: 0.82rem; }
+        .group-header td  { background-color: #e9ecef; }
+        .group-subtotal td { background-color: #f8f9fa; border-top: 2px solid #dee2e6 !important; }

--- a/views/gl-trial-balance.pug
+++ b/views/gl-trial-balance.pug
@@ -11,7 +11,7 @@ block content
         form.row.align-items-end.mb-3(method="GET" action="/gl/trial-balance")
             .col-auto
                 label.small.mb-1 Quick Select
-                select.form-control.form-control-sm#glPeriodAsOf(onchange="glSetAsOf('glAsOf')")
+                select.form-control.form-control-sm#glPeriodAsOf(onchange="glSetAsOf(this)" data-target="glAsOf")
                     option(value="today") Today
                     option(value="end_last_month") End of Last Month
                     option(value="end_this_fy") End of This FY

--- a/views/gl-trial-balance.pug
+++ b/views/gl-trial-balance.pug
@@ -1,0 +1,72 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Trial Balance
+            a.btn.btn-sm.btn-outline-secondary(href="/gl/day-book") &larr; Day Book
+
+        form.row.align-items-end.mb-3(method="GET" action="/gl/trial-balance")
+            .col-auto
+                label.small.mb-1 As of Date
+                input.form-control.form-control-sm(type="date" name="as_of_date" value=asOfDate)
+            .col-auto.align-self-end
+                .form-check.mb-1
+                    input.form-check-input#showZero(type="checkbox" name="show_zero" value="1" checked=showZero)
+                    label.form-check-label.small(for="showZero") Show zero balances
+            .col-auto.align-self-end
+                button.btn.btn-primary.btn-sm(type="submit") View
+
+        if isBalanced
+            .alert.alert-success.py-2.mb-2
+                i.bi.bi-check-circle-fill.mr-1
+                | Books balance &mdash; DR = CR = ₹#{grandDr.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})}
+        else
+            .alert.alert-danger.py-2.mb-2
+                i.bi.bi-exclamation-triangle-fill.mr-1
+                | Out of balance &mdash; DR ₹#{grandDr.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})} vs CR ₹#{grandCr.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})} (diff ₹#{Math.abs(grandDr - grandCr).toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})})
+
+        - const fmt = (n) => n.toLocaleString('en-IN', {minimumFractionDigits:2, maximumFractionDigits:2})
+
+        if !groups.length
+            .alert.alert-info.py-2 No ledger activity found up to this date.
+        else
+            .table-responsive
+                table.table.table-bordered.table-sm#tbTable
+                    thead.thead-dark
+                        tr
+                            th Ledger
+                            th.text-right(style="width:140px") DR (₹)
+                            th.text-right(style="width:140px") CR (₹)
+                    tbody
+                        each g in groups
+                            tr.group-header
+                                td.font-weight-bold(colspan="3")
+                                    span.badge.mr-2(class=(g.group_nature==='ASSETS'||g.group_nature==='EXPENSES'?'badge-primary':'badge-success'))= g.group_nature
+                                    = g.group_name
+                            each row in g.rows
+                                tr
+                                    td.pl-4
+                                        a(href='/gl/ledger?ledger_id=' + row.ledger_id + '&from_date=' + asOfDate.substring(0,8) + '01&to_date=' + asOfDate)= row.ledger_name
+                                    td.text-right.small
+                                        if row.dr_balance > 0
+                                            = fmt(row.dr_balance)
+                                    td.text-right.small
+                                        if row.cr_balance > 0
+                                            = fmt(row.cr_balance)
+                            tr.group-subtotal
+                                td.text-right.font-weight-bold.text-muted.small #{g.group_name} Total
+                                td.text-right.font-weight-bold.small= g.subtotal_dr > 0 ? fmt(g.subtotal_dr) : ''
+                                td.text-right.font-weight-bold.small= g.subtotal_cr > 0 ? fmt(g.subtotal_cr) : ''
+                    tfoot
+                        tr.font-weight-bold(class=(isBalanced ? 'table-success' : 'table-danger'))
+                            td Grand Total
+                            td.text-right= fmt(grandDr)
+                            td.text-right= fmt(grandCr)
+
+    style.
+        #tbTable { font-size: 0.82rem; }
+        .group-header td { background-color: #e9ecef; }
+        .group-subtotal td { background-color: #f8f9fa; border-top: 2px solid #dee2e6 !important; }

--- a/views/gl-trial-balance.pug
+++ b/views/gl-trial-balance.pug
@@ -10,8 +10,16 @@ block content
 
         form.row.align-items-end.mb-3(method="GET" action="/gl/trial-balance")
             .col-auto
+                label.small.mb-1 Quick Select
+                select.form-control.form-control-sm#glPeriodAsOf(onchange="glSetAsOf('glAsOf')")
+                    option(value="today") Today
+                    option(value="end_last_month") End of Last Month
+                    option(value="end_this_fy") End of This FY
+                    option(value="end_last_fy") End of Last FY
+                    option(value="custom" selected) Custom
+            .col-auto
                 label.small.mb-1 As of Date
-                input.form-control.form-control-sm(type="date" name="as_of_date" value=asOfDate)
+                input.form-control.form-control-sm#glAsOf(type="date" name="as_of_date" value=asOfDate)
             .col-auto.align-self-end
                 .form-check.mb-1
                     input.form-check-input#showZero(type="checkbox" name="show_zero" value="1" checked=showZero)

--- a/views/product-ledger-map.pug
+++ b/views/product-ledger-map.pug
@@ -7,115 +7,167 @@ block content
             h4.mb-0.text-primary Product GL Ledger Map
             a.btn.btn-sm.btn-outline-secondary(href="/products") &larr; Back to Products
 
-        .alert.alert-info.py-2
+        .alert.alert-info.py-2.mb-3
             i.bi.bi-info-circle.me-1
-            | Assign GL ledgers for each product. Changes auto-save on selection.
-            | Output CGST / Output SGST only apply to GST products.
-
-        div#saveStatus.mb-2(style="min-height:24px;")
+            | Click Configure on any product to assign GL ledgers. Changes auto-save on selection.
 
         .table-responsive
-            table.table.table-bordered.table-hover.table-sm#ledgerMapTable
+            table.table.table-hover.table-sm.table-bordered
                 thead.thead-dark
                     tr
-                        th(style="min-width:200px;") Product
-                        th.text-center(style="width:50px;") CGST%
-                        th(style="min-width:180px;") Sales Ledger
-                        th(style="min-width:180px;") Purchase Ledger
-                        th(style="min-width:180px;") Output CGST
-                        th(style="min-width:180px;") Output SGST
+                        th Product
+                        th.text-center(style="width:70px;") CGST%
+                        th.text-center(style="width:120px;") Configured
+                        th.text-center(style="width:100px;") Action
                 tbody
                     each p in products
-                        - const isGst = p.cgst_percent > 0
-                        tr(class=isGst ? '' : 'table-secondary')
+                        - const pMaps = mappingLookup[p.product_id] || {}
+                        - const configCount = Object.keys(pMaps).length
+                        - const totalTypes = mapTypes.length
+                        tr
                             td
                                 strong= p.product_name
-                                if isGst
+                                if p.cgst_percent > 0
                                     span.badge.badge-warning.ml-1 GST
                             td.text-center= p.cgst_percent + '%'
-                            td
-                                select.form-control.form-control-sm.ledger-select(
-                                    data-product-id=p.product_id,
-                                    data-map-type="SALES")
-                                    option(value="") — Not Set —
-                                    each l in salesLedgers
-                                        option(value=l.ledger_id, selected=(p.sales_ledger_id == l.ledger_id))= l.ledger_name
-                            td
-                                select.form-control.form-control-sm.ledger-select(
-                                    data-product-id=p.product_id,
-                                    data-map-type="PURCHASE")
-                                    option(value="") — Not Set —
-                                    each l in purchaseLedgers
-                                        option(value=l.ledger_id, selected=(p.purchase_ledger_id == l.ledger_id))= l.ledger_name
-                            td
-                                if isGst
-                                    select.form-control.form-control-sm.ledger-select(
-                                        data-product-id=p.product_id,
-                                        data-map-type="OUTPUT_CGST")
-                                        option(value="") — Not Set —
-                                        each l in taxLedgers
-                                            option(value=l.ledger_id, selected=(p.output_cgst_ledger_id == l.ledger_id))= l.ledger_name
+                            td.text-center
+                                if configCount === 0
+                                    span.badge.badge-danger None
+                                else if configCount < totalTypes
+                                    span.badge.badge-warning #{configCount} / #{totalTypes}
                                 else
-                                    span.text-muted.small N/A
-                            td
-                                if isGst
-                                    select.form-control.form-control-sm.ledger-select(
-                                        data-product-id=p.product_id,
-                                        data-map-type="OUTPUT_SGST")
-                                        option(value="") — Not Set —
-                                        each l in taxLedgers
-                                            option(value=l.ledger_id, selected=(p.output_sgst_ledger_id == l.ledger_id))= l.ledger_name
-                                else
-                                    span.text-muted.small N/A
+                                    span.badge.badge-success All set
+                            td.text-center
+                                button.btn.btn-primary.btn-sm.btn-configure(
+                                    type="button",
+                                    data-product-id=p.product_id,
+                                    data-product-name=p.product_name,
+                                    data-cgst=p.cgst_percent)
+                                    i.bi.bi-gear-fill.mr-1
+                                    | Configure
 
-    style.
-        #ledgerMapTable thead th { position: sticky; top: 0; z-index: 1; }
-        .table-secondary td { color: #6c757d; }
-        select.saving { border-color: #ffc107 !important; }
-        select.saved  { border-color: #28a745 !important; }
-        select.error  { border-color: #dc3545 !important; }
+    // Configure Modal
+    .modal.fade#configureModal(tabindex="-1", role="dialog")
+        .modal-dialog(role="document")
+            .modal-content
+                .modal-header
+                    h5.modal-title#configureModalTitle Configure Ledgers
+                    button.close(type="button", data-dismiss="modal")
+                        span &times;
+                .modal-body
+                    p.text-muted.small.mb-3 Changes are saved automatically on selection.
+                    div#modalRows
+                .modal-footer
+                    button.btn.btn-secondary(type="button", data-dismiss="modal") Close
 
     script.
-        document.querySelectorAll('.ledger-select').forEach(function(sel) {
-            sel.addEventListener('change', function() {
-                const productId = this.dataset.productId;
-                const mapType   = this.dataset.mapType;
-                const ledgerId  = this.value;
-                const el        = this;
+        const MAP_TYPES = !{JSON.stringify(mapTypes)};
+        const LEDGERS   = !{JSON.stringify(ledgers)};
+        const MAPPINGS  = !{JSON.stringify(mappingLookup)};
 
-                el.classList.remove('saved', 'error');
-                el.classList.add('saving');
-                el.disabled = true;
+        document.querySelectorAll('.btn-configure').forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                const productId   = this.dataset.productId;
+                const productName = this.dataset.productName;
+                const cgst        = parseFloat(this.dataset.cgst) || 0;
 
-                fetch('/products/api/ledger-maps/' + productId + '/' + mapType, {
-                    method: 'PUT',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ ledger_id: ledgerId || null })
-                })
-                .then(r => r.json())
-                .then(data => {
-                    el.classList.remove('saving');
-                    el.disabled = false;
-                    if (data.success) {
-                        el.classList.add('saved');
-                        showStatus('Saved.', 'success');
-                        setTimeout(() => el.classList.remove('saved'), 2000);
-                    } else {
-                        el.classList.add('error');
-                        showStatus('Error: ' + data.error, 'danger');
-                    }
-                })
-                .catch(function(err) {
-                    el.classList.remove('saving');
-                    el.disabled = false;
-                    el.classList.add('error');
-                    showStatus('Error: ' + err.message, 'danger');
+                document.getElementById('configureModalTitle').textContent = productName;
+
+                const container = document.getElementById('modalRows');
+                container.innerHTML = '';
+
+                const currentMaps = MAPPINGS[productId] || {};
+
+                MAP_TYPES.forEach(function(mt) {
+                    const options = LEDGERS[mt.group] || [];
+                    const currentVal = currentMaps[mt.type] || '';
+
+                    const row = document.createElement('div');
+                    row.className = 'form-group row align-items-center mb-2';
+
+                    const labelCol = document.createElement('div');
+                    labelCol.className = 'col-4';
+                    labelCol.innerHTML = '<label class="mb-0">' + mt.label + '</label>';
+
+                    const selectCol = document.createElement('div');
+                    selectCol.className = 'col-7';
+
+                    const select = document.createElement('select');
+                    select.className = 'form-control form-control-sm';
+                    select.dataset.productId = productId;
+                    select.dataset.mapType   = mt.type;
+
+                    let html = '<option value="">— Not Set —</option>';
+                    options.forEach(function(l) {
+                        const sel = String(l.ledger_id) === String(currentVal) ? ' selected' : '';
+                        html += '<option value="' + l.ledger_id + '"' + sel + '>' + l.ledger_name + '</option>';
+                    });
+                    select.innerHTML = html;
+
+                    const statusCol = document.createElement('div');
+                    statusCol.className = 'col-1 text-center';
+                    statusCol.id = 'status-' + productId + '-' + mt.type;
+
+                    select.addEventListener('change', function() {
+                        saveMapping(this, productId, mt.type, this.value, statusCol);
+                    });
+
+                    selectCol.appendChild(select);
+                    row.appendChild(labelCol);
+                    row.appendChild(selectCol);
+                    row.appendChild(statusCol);
+                    container.appendChild(row);
                 });
+
+                $('#configureModal').modal('show');
             });
         });
 
-        function showStatus(msg, type) {
-            const el = document.getElementById('saveStatus');
-            el.innerHTML = '<span class="text-' + type + ' small">' + msg + '</span>';
-            setTimeout(() => { el.innerHTML = ''; }, 3000);
+        function saveMapping(selectEl, productId, mapType, ledgerId, statusEl) {
+            selectEl.disabled = true;
+            statusEl.innerHTML = '<i class="bi bi-hourglass-split text-warning"></i>';
+
+            fetch('/products/api/ledger-maps/' + productId + '/' + mapType, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ ledger_id: ledgerId || null })
+            })
+            .then(r => r.json())
+            .then(function(data) {
+                selectEl.disabled = false;
+                if (data.success) {
+                    // Update in-memory lookup so re-opening modal shows current values
+                    if (!MAPPINGS[productId]) MAPPINGS[productId] = {};
+                    if (ledgerId) {
+                        MAPPINGS[productId][mapType] = ledgerId;
+                    } else {
+                        delete MAPPINGS[productId][mapType];
+                    }
+                    updateBadge(productId);
+                    statusEl.innerHTML = '<i class="bi bi-check-circle-fill text-success"></i>';
+                    setTimeout(() => { statusEl.innerHTML = ''; }, 2000);
+                } else {
+                    statusEl.innerHTML = '<i class="bi bi-x-circle-fill text-danger" title="' + data.error + '"></i>';
+                }
+            })
+            .catch(function(err) {
+                selectEl.disabled = false;
+                statusEl.innerHTML = '<i class="bi bi-x-circle-fill text-danger"></i>';
+            });
+        }
+
+        function updateBadge(productId) {
+            const count = Object.keys(MAPPINGS[productId] || {}).length;
+            const total = MAP_TYPES.length;
+            const btn   = document.querySelector('.btn-configure[data-product-id="' + productId + '"]');
+            if (!btn) return;
+            const row   = btn.closest('tr');
+            const cell  = row.querySelector('td:nth-child(3)');
+            if (count === 0) {
+                cell.innerHTML = '<span class="badge badge-danger">None</span>';
+            } else if (count < total) {
+                cell.innerHTML = '<span class="badge badge-warning">' + count + ' / ' + total + '</span>';
+            } else {
+                cell.innerHTML = '<span class="badge badge-success">All set</span>';
+            }
         }

--- a/views/product-ledger-map.pug
+++ b/views/product-ledger-map.pug
@@ -1,0 +1,121 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0.text-primary Product GL Ledger Map
+            a.btn.btn-sm.btn-outline-secondary(href="/products") &larr; Back to Products
+
+        .alert.alert-info.py-2
+            i.bi.bi-info-circle.me-1
+            | Assign GL ledgers for each product. Changes auto-save on selection.
+            | Output CGST / Output SGST only apply to GST products.
+
+        div#saveStatus.mb-2(style="min-height:24px;")
+
+        .table-responsive
+            table.table.table-bordered.table-hover.table-sm#ledgerMapTable
+                thead.thead-dark
+                    tr
+                        th(style="min-width:200px;") Product
+                        th.text-center(style="width:50px;") CGST%
+                        th(style="min-width:180px;") Sales Ledger
+                        th(style="min-width:180px;") Purchase Ledger
+                        th(style="min-width:180px;") Output CGST
+                        th(style="min-width:180px;") Output SGST
+                tbody
+                    each p in products
+                        - const isGst = p.cgst_percent > 0
+                        tr(class=isGst ? '' : 'table-secondary')
+                            td
+                                strong= p.product_name
+                                if isGst
+                                    span.badge.badge-warning.ml-1 GST
+                            td.text-center= p.cgst_percent + '%'
+                            td
+                                select.form-control.form-control-sm.ledger-select(
+                                    data-product-id=p.product_id,
+                                    data-map-type="SALES")
+                                    option(value="") — Not Set —
+                                    each l in salesLedgers
+                                        option(value=l.ledger_id, selected=(p.sales_ledger_id == l.ledger_id))= l.ledger_name
+                            td
+                                select.form-control.form-control-sm.ledger-select(
+                                    data-product-id=p.product_id,
+                                    data-map-type="PURCHASE")
+                                    option(value="") — Not Set —
+                                    each l in purchaseLedgers
+                                        option(value=l.ledger_id, selected=(p.purchase_ledger_id == l.ledger_id))= l.ledger_name
+                            td
+                                if isGst
+                                    select.form-control.form-control-sm.ledger-select(
+                                        data-product-id=p.product_id,
+                                        data-map-type="OUTPUT_CGST")
+                                        option(value="") — Not Set —
+                                        each l in taxLedgers
+                                            option(value=l.ledger_id, selected=(p.output_cgst_ledger_id == l.ledger_id))= l.ledger_name
+                                else
+                                    span.text-muted.small N/A
+                            td
+                                if isGst
+                                    select.form-control.form-control-sm.ledger-select(
+                                        data-product-id=p.product_id,
+                                        data-map-type="OUTPUT_SGST")
+                                        option(value="") — Not Set —
+                                        each l in taxLedgers
+                                            option(value=l.ledger_id, selected=(p.output_sgst_ledger_id == l.ledger_id))= l.ledger_name
+                                else
+                                    span.text-muted.small N/A
+
+    style.
+        #ledgerMapTable thead th { position: sticky; top: 0; z-index: 1; }
+        .table-secondary td { color: #6c757d; }
+        select.saving { border-color: #ffc107 !important; }
+        select.saved  { border-color: #28a745 !important; }
+        select.error  { border-color: #dc3545 !important; }
+
+    script.
+        document.querySelectorAll('.ledger-select').forEach(function(sel) {
+            sel.addEventListener('change', function() {
+                const productId = this.dataset.productId;
+                const mapType   = this.dataset.mapType;
+                const ledgerId  = this.value;
+                const el        = this;
+
+                el.classList.remove('saved', 'error');
+                el.classList.add('saving');
+                el.disabled = true;
+
+                fetch('/products/api/ledger-maps/' + productId + '/' + mapType, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ ledger_id: ledgerId || null })
+                })
+                .then(r => r.json())
+                .then(data => {
+                    el.classList.remove('saving');
+                    el.disabled = false;
+                    if (data.success) {
+                        el.classList.add('saved');
+                        showStatus('Saved.', 'success');
+                        setTimeout(() => el.classList.remove('saved'), 2000);
+                    } else {
+                        el.classList.add('error');
+                        showStatus('Error: ' + data.error, 'danger');
+                    }
+                })
+                .catch(function(err) {
+                    el.classList.remove('saving');
+                    el.disabled = false;
+                    el.classList.add('error');
+                    showStatus('Error: ' + err.message, 'danger');
+                });
+            });
+        });
+
+        function showStatus(msg, type) {
+            const el = document.getElementById('saveStatus');
+            el.innerHTML = '<span class="text-' + type + ' small">' + msg + '</span>';
+            setTimeout(() => { el.innerHTML = ''; }, 3000);
+        }

--- a/views/products.pug
+++ b/views/products.pug
@@ -47,7 +47,7 @@ block content
                             th(scope="col") Edit
                     tbody
                         each val, index in products
-                            - const productPayload = encodeURIComponent(JSON.stringify({ id: val.id, name: val.name, sku_name: val.sku_name || '', sku_number: val.sku_number || '', hsn_code: val.hsn_code || '', unit: val.unit || '', price: val.price || '', ledger_name: val.ledger_name || '', cgst_percent: val.cgst_percent || 0, sgst_percent: val.sgst_percent || 0, is_tank_product: val.is_tank_product ? 1 : 0, is_lube_product: val.is_lube_product ? 1 : 0, can_edit_name: val.can_edit_name ? 1 : 0 }))
+                            - const productPayload = encodeURIComponent(JSON.stringify({ id: val.id, name: val.name, sku_name: val.sku_name || '', sku_number: val.sku_number || '', hsn_code: val.hsn_code || '', unit: val.unit || '', price: val.price || '', ledger_name: val.ledger_name || '', purchase_ledger_name: val.purchase_ledger_name || '', cgst_percent: val.cgst_percent || 0, sgst_percent: val.sgst_percent || 0, is_tank_product: val.is_tank_product ? 1 : 0, is_lube_product: val.is_lube_product ? 1 : 0, can_edit_name: val.can_edit_name ? 1 : 0 }))
                             tr(id=`product-row-${index}`)
                                 th(scope="row")= index + 1
                                 td(scope="row")
@@ -106,7 +106,7 @@ block content
         .mobile-cards-view.d-block.d-lg-none
             .row
                 each val, index in products
-                    - const mobileProductPayload = encodeURIComponent(JSON.stringify({ id: val.id, name: val.name, sku_name: val.sku_name || '', sku_number: val.sku_number || '', hsn_code: val.hsn_code || '', unit: val.unit || '', price: val.price || '', ledger_name: val.ledger_name || '', cgst_percent: val.cgst_percent || 0, sgst_percent: val.sgst_percent || 0, is_tank_product: val.is_tank_product ? 1 : 0, is_lube_product: val.is_lube_product ? 1 : 0, can_edit_name: val.can_edit_name ? 1 : 0 }))
+                    - const mobileProductPayload = encodeURIComponent(JSON.stringify({ id: val.id, name: val.name, sku_name: val.sku_name || '', sku_number: val.sku_number || '', hsn_code: val.hsn_code || '', unit: val.unit || '', price: val.price || '', ledger_name: val.ledger_name || '', purchase_ledger_name: val.purchase_ledger_name || '', cgst_percent: val.cgst_percent || 0, sgst_percent: val.sgst_percent || 0, is_tank_product: val.is_tank_product ? 1 : 0, is_lube_product: val.is_lube_product ? 1 : 0, can_edit_name: val.can_edit_name ? 1 : 0 }))
                     .col-12.mb-3
                         .card.product-card.shadow-sm(id=`mobile-product-card-${index}`)
                             .card-header.d-flex.justify-content-between.align-items-center
@@ -278,9 +278,18 @@ block content
                             .col-md-6.mb-3
                                 label.form-label Price
                                 input.form-control(type="number", name="price", step="0.01", required)
-                            .col-md-12.mb-3
-                                label.form-label Ledger Name
-                                input.form-control.text-uppercase(type="text", name="ledger_name", style="text-transform: uppercase;")
+                            .col-md-6.mb-3
+                                label.form-label Sales Ledger
+                                select.form-control(name="ledger_name")
+                                    option(value="") — Not Set —
+                                    each l in salesLedgers
+                                        option(value=l.ledger_name)= l.ledger_name
+                            .col-md-6.mb-3
+                                label.form-label Purchase Ledger
+                                select.form-control(name="purchase_ledger_name")
+                                    option(value="") — Not Set —
+                                    each l in purchaseLedgers
+                                        option(value=l.ledger_name)= l.ledger_name
                             .col-md-6.mb-3
                                 label.form-label CGST %
                                 input.form-control(type="number", name="cgst_percent", step="0.01", min="0", max="100")
@@ -346,9 +355,18 @@ block content
                             .col-md-6.mb-3
                                 label.form-label Price
                                 input#edit-price.form-control(type="number", step="0.01")
-                            .col-md-12.mb-3
-                                label.form-label Ledger Name
-                                input#edit-ledger-name.form-control.text-uppercase(type="text", style="text-transform: uppercase;")
+                            .col-md-6.mb-3
+                                label.form-label Sales Ledger
+                                select#edit-ledger-name.form-control
+                                    option(value="") — Not Set —
+                                    each l in salesLedgers
+                                        option(value=l.ledger_name)= l.ledger_name
+                            .col-md-6.mb-3
+                                label.form-label Purchase Ledger
+                                select#edit-purchase-ledger-name.form-control
+                                    option(value="") — Not Set —
+                                    each l in purchaseLedgers
+                                        option(value=l.ledger_name)= l.ledger_name
                             .col-md-6.mb-3
                                 label.form-label CGST %
                                 input#edit-cgst.form-control(type="number", step="0.01", min="0", max="100")
@@ -556,6 +574,7 @@ block content
             document.getElementById('edit-unit').value = product.unit || '';
             document.getElementById('edit-price').value = product.price || '';
             document.getElementById('edit-ledger-name').value = product.ledger_name || '';
+            document.getElementById('edit-purchase-ledger-name').value = product.purchase_ledger_name || '';
             document.getElementById('edit-cgst').value = product.cgst_percent || 0;
             document.getElementById('edit-sgst').value = product.sgst_percent || 0;
 
@@ -600,7 +619,8 @@ block content
                 m_product_name: document.getElementById('edit-product-name').value.toUpperCase().trim(),
                 m_product_price: document.getElementById('edit-price').value,
                 m_product_unit: document.getElementById('edit-unit').value.toUpperCase(),
-                m_product_ledger_name: document.getElementById('edit-ledger-name').value.toUpperCase(),
+                m_product_ledger_name: ($('#edit-ledger-name').val() || '').toUpperCase(),
+                m_product_purchase_ledger_name: ($('#edit-purchase-ledger-name').val() || '').toUpperCase(),
                 m_product_cgst: document.getElementById('edit-cgst').value,
                 m_product_sgst: document.getElementById('edit-sgst').value
             };
@@ -663,6 +683,8 @@ block content
         // Event listeners
         document.addEventListener('DOMContentLoaded', function() {
             document.getElementById('refreshDataBtn').addEventListener('click', refreshData);
+
+
             
             // Add uppercase event listeners to all text inputs in the modal
             const textInputs = document.querySelectorAll('input[type="text"].text-uppercase');

--- a/views/products.pug
+++ b/views/products.pug
@@ -38,7 +38,6 @@ block content
                             th(scope="col") HSN Code
                             th(scope="col") Unit
                             th(scope="col") Price
-                            th(scope="col") Ledger Name
                             th(scope="col") CGST%
                             th(scope="col") SGST%
                             if user.Role === 'SuperUser'
@@ -59,7 +58,6 @@ block content
                                         .input-group-prepend
                                             span.input-group-text ₹
                                         span.form-control-plaintext= val.price
-                                td(scope="row")= val.ledger_name || '-'
                                 td(scope="row") #{val.cgst_percent}%
                                 td(scope="row") #{val.sgst_percent}%
                                 if user.Role === 'SuperUser'
@@ -186,16 +184,6 @@ block content
                                                 )
                                     .col-6
                                         .product-detail
-                                            small.text-muted Ledger
-                                            input.mobile-input.fw-bold.text-uppercase(
-                                                type="text",
-                                                id=`mobile-ledger-${index}`,
-                                                value=val.ledger_name || 'N/A',
-                                                readonly,
-                                                style="border: none; background: transparent; padding: 0; font-weight: bold; text-transform: uppercase;"
-                                            )
-                                    .col-6
-                                        .product-detail
                                             small.text-muted CGST
                                             .input-group.input-group-sm
                                                 input.mobile-input.fw-bold(
@@ -279,18 +267,6 @@ block content
                                 label.form-label Price
                                 input.form-control(type="number", name="price", step="0.01", required)
                             .col-md-6.mb-3
-                                label.form-label Sales Ledger
-                                select.form-control(name="ledger_name")
-                                    option(value="") — Not Set —
-                                    each l in salesLedgers
-                                        option(value=l.ledger_name)= l.ledger_name
-                            .col-md-6.mb-3
-                                label.form-label Purchase Ledger
-                                select.form-control(name="purchase_ledger_name")
-                                    option(value="") — Not Set —
-                                    each l in purchaseLedgers
-                                        option(value=l.ledger_name)= l.ledger_name
-                            .col-md-6.mb-3
                                 label.form-label CGST %
                                 input.form-control(type="number", name="cgst_percent", step="0.01", min="0", max="100")
                             .col-md-6.mb-3
@@ -355,18 +331,6 @@ block content
                             .col-md-6.mb-3
                                 label.form-label Price
                                 input#edit-price.form-control(type="number", step="0.01")
-                            .col-md-6.mb-3
-                                label.form-label Sales Ledger
-                                select#edit-ledger-name.form-control
-                                    option(value="") — Not Set —
-                                    each l in salesLedgers
-                                        option(value=l.ledger_name)= l.ledger_name
-                            .col-md-6.mb-3
-                                label.form-label Purchase Ledger
-                                select#edit-purchase-ledger-name.form-control
-                                    option(value="") — Not Set —
-                                    each l in purchaseLedgers
-                                        option(value=l.ledger_name)= l.ledger_name
                             .col-md-6.mb-3
                                 label.form-label CGST %
                                 input#edit-cgst.form-control(type="number", step="0.01", min="0", max="100")
@@ -573,8 +537,6 @@ block content
             document.getElementById('edit-hsn-code').value = product.hsn_code || '';
             document.getElementById('edit-unit').value = product.unit || '';
             document.getElementById('edit-price').value = product.price || '';
-            document.getElementById('edit-ledger-name').value = product.ledger_name || '';
-            document.getElementById('edit-purchase-ledger-name').value = product.purchase_ledger_name || '';
             document.getElementById('edit-cgst').value = product.cgst_percent || 0;
             document.getElementById('edit-sgst').value = product.sgst_percent || 0;
 
@@ -619,8 +581,6 @@ block content
                 m_product_name: document.getElementById('edit-product-name').value.toUpperCase().trim(),
                 m_product_price: document.getElementById('edit-price').value,
                 m_product_unit: document.getElementById('edit-unit').value.toUpperCase(),
-                m_product_ledger_name: ($('#edit-ledger-name').val() || '').toUpperCase(),
-                m_product_purchase_ledger_name: ($('#edit-purchase-ledger-name').val() || '').toUpperCase(),
                 m_product_cgst: document.getElementById('edit-cgst').value,
                 m_product_sgst: document.getElementById('edit-sgst').value
             };


### PR DESCRIPTION
## Summary
- GL concurrent batch requests table (`gl_batch_requests`) with Oracle-style PENDING→RUNNING→COMPLETED/ERROR lifecycle and configurable log verbosity (`GL_LOG_LEVEL`)
- Create Accounting and Generate Events wrapped in batch requests; stale RUNNING requests auto-recovered on GL Control page load
- Dev DB Refresh Control page (`/dev-db-refresh`) — pause/resume 4-hourly S3 cron, trigger immediate refresh, view log tail
- Events Monitor improvements: source type filter, free text search, 2000 row limit with overflow warning
- Recent Batch Runs moved into Create Accounting and Generate Events tab panes
- Fixed wrong column names in DAY_BILL (`taxable_amount`) and TANK_INVOICE/LUBES_INVOICE (`invoice_number`) handlers
- Events Monitor: multiselect checkboxes + bulk retry for ERROR events; new `POST /gl/api/retry-events` endpoint

## Test plan
- [ ] GL Control → Create Accounting runs and shows batch request in Recent Runs
- [ ] GL Control → Generate Events runs and shows batch request
- [ ] Events Monitor: source type + free text filters work; overflow warning appears >2000 rows
- [ ] Events Monitor: checkboxes appear on ERROR rows; Retry Selected resets them to UNPROCESSED
- [ ] `/dev-db-refresh` page loads (dev only; returns 404 on prod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)