### PR TITLE
GL accounting: fix generate events count, tank invoice column, null external_source

### DIFF
--- a/services/create-accounting-service.js
+++ b/services/create-accounting-service.js
@@ -138,7 +138,7 @@ async function generateMissingEvents(locationCode, fromDate, toDate, createdBy, 
             replacements: { locationCode, fromDate, toDate, createdBy },
             type: QueryTypes.INSERT
         });
-        const n = meta?.affectedRows || 0;
+        const n = (typeof meta === 'object' ? meta?.affectedRows : meta) || 0;
         counts[sourceType] = n;
         total += n;
         log.debug(`${sourceType}: inserted ${n} missing event(s)`);
@@ -1029,7 +1029,7 @@ async function processTankInvoiceEvent(event, processedBy) {
     // Product purchase lines
     const dtlRows = await db.sequelize.query(`
         SELECT
-            d.dtl_id,
+            d.id AS dtl_id,
             d.product_id,
             p.product_name,
             d.total_line_amount
@@ -1114,9 +1114,9 @@ function deriveBankVoucherType(txn, bankIsDr) {
 async function resolveCounterpartLedger(txn, locationCode, eventId, processedBy) {
     const { external_source, external_id, ledger_name } = txn;
 
-    if (external_source === 'Static') {
+    if (external_source === 'Static' || (!external_source && ledger_name)) {
         const info = await resolveLedgerByName(locationCode, ledger_name);
-        if (!info) throw new Error(`Static GL ledger '${ledger_name}' not found for location ${locationCode}`);
+        if (!info) throw new Error(`GL ledger '${ledger_name}' not found for location ${locationCode}`);
         if (info.group_name === 'Purchase Accounts') {
             // Purchase invoices are journaled by the PURCHASE_INVOICE handler — skip here
             await markEventProcessed(eventId, null, processedBy);


### PR DESCRIPTION
## Summary
- `generateMissingEvents`: fix reported count always showing 0 — `meta` from `QueryTypes.INSERT` is a plain integer, not an object with `.affectedRows`
- TANK_INVOICE handler: fix `d.dtl_id` → `d.id AS dtl_id` (actual PK column in `t_tank_invoice_dtl`)
- `resolveCounterpartLedger`: treat `external_source=NULL` + `ledger_name` as Static — handles old bank transactions entered before `external_source` field was in use

## Test plan
- [ ] Generate Events shows correct count after run
- [ ] TANK_INVOICE events process without column error
- [ ] Bank transactions with null external_source and a ledger name (CASH, OTHERS etc.) process correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)