### PR TITLE
Add intercompany bowser ledger report

### DIFF
--- a/controllers/stock-reports-controller.js
+++ b/controllers/stock-reports-controller.js
@@ -345,6 +345,95 @@ getStockLedgerReport: async (req, res, next) => {
     }
 },
 
+getIntercompanyLedgerReport: async (req, res, next) => {
+    try {
+        const locationCode = req.user.location_code;
+        const caller = req.body.caller || 'notpdf';
+        const bowserId = req.body.bowserId || req.query.bowserId || null;
+        let fromDate = req.body.fromDate || req.query.fromDate;
+        let toDate = req.body.toDate || req.query.toDate;
+
+        if (fromDate instanceof Date) {
+            fromDate = moment(fromDate).format('YYYY-MM-DD');
+        } else if (fromDate) {
+            fromDate = moment(fromDate).format('YYYY-MM-DD');
+        }
+
+        if (toDate instanceof Date) {
+            toDate = moment(toDate).format('YYYY-MM-DD');
+        } else if (toDate) {
+            toDate = moment(toDate).format('YYYY-MM-DD');
+        }
+
+        const bowsers = await stockReportsDao.getIntercompanyBowsers(locationCode);
+
+        let ledgerData = [];
+        let bowserInfo = null;
+        let openingBalance = 0;
+        let closingBalance = 0;
+        let totalIn = 0;
+        let totalOut = 0;
+
+        if (bowserId && fromDate && toDate) {
+            bowserInfo = bowsers.find(b => String(b.bowser_id) === String(bowserId)) || null;
+            openingBalance = await stockReportsDao.getIntercompanyLedgerOpening(
+                bowserId,
+                locationCode,
+                fromDate
+            );
+            ledgerData = await stockReportsDao.getIntercompanyLedger(
+                bowserId,
+                locationCode,
+                fromDate,
+                toDate
+            );
+            totalIn = ledgerData.reduce((sum, txn) => sum + parseFloat(txn.in_qty || 0), 0);
+            totalOut = ledgerData.reduce((sum, txn) => sum + parseFloat(txn.out_qty || 0), 0);
+            closingBalance = openingBalance + totalIn - totalOut;
+        }
+
+        const formattedFromDate = fromDate ? moment(fromDate).format('DD-MMM-YYYY') : '';
+        const formattedToDate = toDate ? moment(toDate).format('DD-MMM-YYYY') : '';
+        const currentDate = moment().format('YYYY-MM-DD');
+        const renderData = {
+            title: 'Intercompany Ledger Report',
+            user: req.user,
+            bowsers,
+            ledgerData,
+            bowserInfo,
+            openingBalance: openingBalance.toFixed(3),
+            closingBalance: closingBalance.toFixed(3),
+            totalIn: totalIn.toFixed(3),
+            totalOut: totalOut.toFixed(3),
+            fromDate,
+            toDate,
+            formattedFromDate,
+            formattedToDate,
+            selectedBowserId: bowserId,
+            currentDate
+        };
+
+        if (caller === 'notpdf') {
+            res.render('reports-intercompany-ledger', renderData);
+        } else {
+            return new Promise((resolve, reject) => {
+                res.render('reports-intercompany-ledger', renderData, (err, html) => {
+                    if (err) {
+                        console.error('getIntercompanyLedgerReport: Error in res.render:', err);
+                        reject(err);
+                    } else {
+                        resolve(html);
+                    }
+                });
+            });
+        }
+    } catch (error) {
+        console.error('Error in getIntercompanyLedgerReport:', error);
+        req.flash('error', 'Failed to generate intercompany ledger report');
+        res.redirect('/home');
+    }
+},
+
 getTankVarianceReport: async (req, res, next) => {
     try {
         const locationCode = req.user.location_code;

--- a/dao/stock-reports-dao.js
+++ b/dao/stock-reports-dao.js
@@ -243,6 +243,115 @@ getStockSummaryOptimized: async (locationCode, fromDate, toDate) => {
     }
 },
 
+getIntercompanyBowsers: async (locationCode) => {
+    try {
+        return await db.sequelize.query(
+            `SELECT b.bowser_id, b.bowser_name, b.location_code, b.product_id,
+                    p.product_name, p.unit, b.is_active
+             FROM m_bowser b
+             JOIN m_product p ON p.product_id = b.product_id
+             WHERE b.location_code = :locationCode
+             ORDER BY b.bowser_name`,
+            {
+                replacements: { locationCode },
+                type: Sequelize.QueryTypes.SELECT
+            }
+        );
+    } catch (error) {
+        console.error('Error fetching intercompany bowsers:', error);
+        throw error;
+    }
+},
+
+getIntercompanyLedgerOpening: async (bowserId, locationCode, fromDate) => {
+    try {
+        const query = `
+            SELECT ROUND(
+                COALESCE((
+                    SELECT SUM(tci.quantity)
+                    FROM t_closing_intercompany tci
+                    WHERE tci.bowser_id = :bowserId
+                      AND tci.location_code = :locationCode
+                      AND DATE(tci.closing_date) < :fromDate
+                ), 0)
+                -
+                COALESCE((
+                    SELECT SUM(bcl.closing_meter - bcl.opening_meter - COALESCE(bcl.testing_qty, 0))
+                    FROM t_bowser_closing bcl
+                    WHERE bcl.bowser_id = :bowserId
+                      AND bcl.location_code = :locationCode
+                      AND bcl.status = 'CLOSED'
+                      AND DATE(bcl.closing_date) < :fromDate
+                ), 0)
+            , 3) AS opening_qty
+        `;
+
+        const rows = await db.sequelize.query(query, {
+            replacements: { bowserId, locationCode, fromDate },
+            type: Sequelize.QueryTypes.SELECT
+        });
+
+        return parseFloat(rows[0]?.opening_qty || 0);
+    } catch (error) {
+        console.error('Error fetching intercompany ledger opening:', error);
+        throw error;
+    }
+},
+
+getIntercompanyLedger: async (bowserId, locationCode, fromDate, toDate) => {
+    try {
+        const query = `
+            SELECT
+                txn_date,
+                txn_type,
+                reference_no,
+                particulars,
+                qty_in AS in_qty,
+                qty_out AS out_qty,
+                sort_order
+            FROM (
+                SELECT
+                    DATE(tci.closing_date) AS txn_date,
+                    CONVERT('FILL IN' USING utf8mb4) AS txn_type,
+                    CONVERT(CAST(tci.closing_id AS CHAR) USING utf8mb4) AS reference_no,
+                    CONVERT(CONCAT('Shift Closing #', tci.closing_id) USING utf8mb4) AS particulars,
+                    ROUND(tci.quantity, 3) AS qty_in,
+                    CAST(0 AS DECIMAL(12,3)) AS qty_out,
+                    1 AS sort_order
+                FROM t_closing_intercompany tci
+                WHERE tci.bowser_id = :bowserId
+                  AND tci.location_code = :locationCode
+                  AND DATE(tci.closing_date) BETWEEN :fromDate AND :toDate
+
+                UNION ALL
+
+                SELECT
+                    DATE(bcl.closing_date) AS txn_date,
+                    CONVERT('SALE OUT' USING utf8mb4) AS txn_type,
+                    CONVERT(CAST(bcl.bowser_closing_id AS CHAR) USING utf8mb4) AS reference_no,
+                    CONVERT(CONCAT('Bowser Closing #', bcl.bowser_closing_id) USING utf8mb4) AS particulars,
+                    CAST(0 AS DECIMAL(12,3)) AS qty_in,
+                    ROUND(bcl.closing_meter - bcl.opening_meter - COALESCE(bcl.testing_qty, 0), 3) AS qty_out,
+                    2 AS sort_order
+                FROM t_bowser_closing bcl
+                WHERE bcl.bowser_id = :bowserId
+                  AND bcl.location_code = :locationCode
+                  AND bcl.status = 'CLOSED'
+                  AND DATE(bcl.closing_date) BETWEEN :fromDate AND :toDate
+            ) ledger
+            ORDER BY txn_date, sort_order, reference_no
+        `;
+
+        return await db.sequelize.query(query, {
+            replacements: { bowserId, locationCode, fromDate, toDate },
+            type: Sequelize.QueryTypes.SELECT
+        });
+    } catch (error) {
+        console.error('Error fetching intercompany ledger:', error);
+        throw error;
+    }
+},
+
 // Tank variance input data (tank dips + dip chart + pump readings + receipts)
 getTankVarianceInputs: async (locationCode, fromDate, toDate) => {
     try {

--- a/db/migrations/intercompany-ledger-report-menu.sql
+++ b/db/migrations/intercompany-ledger-report-menu.sql
@@ -1,0 +1,35 @@
+INSERT IGNORE INTO m_menu_items
+    (menu_code, menu_name, url_path, parent_code, sequence, group_code, effective_start_date, effective_end_date)
+VALUES
+    ('INTERCOMPANY_LEDGER_REPORT', 'Intercompany Ledger', '/reports/stock/intercompany-ledger', 'REPORTS', 92, 'REPORTS_SECTION', CURDATE(), '9999-12-31');
+
+INSERT IGNORE INTO m_menu_access_global
+    (role, menu_code, allowed, effective_start_date, effective_end_date, created_by, updated_by)
+SELECT
+    role,
+    'INTERCOMPANY_LEDGER_REPORT',
+    allowed,
+    CURDATE(),
+    effective_end_date,
+    'system',
+    'system'
+FROM m_menu_access_global
+WHERE menu_code = 'STOCK_LEDGER';
+
+INSERT IGNORE INTO m_menu_access_override
+    (role, location_code, menu_code, allowed, effective_start_date, effective_end_date, created_by, updated_by)
+SELECT
+    role,
+    location_code,
+    'INTERCOMPANY_LEDGER_REPORT',
+    allowed,
+    CURDATE(),
+    effective_end_date,
+    'system',
+    'system'
+FROM m_menu_access_override
+WHERE menu_code = 'STOCK_LEDGER';
+
+SELECT menu_code, menu_name, url_path, sequence
+FROM m_menu_items
+WHERE menu_code = 'INTERCOMPANY_LEDGER_REPORT';

--- a/public/javascripts/app-generate-pdf.js
+++ b/public/javascripts/app-generate-pdf.js
@@ -65,6 +65,11 @@ function generatePDF(currentPage,isPrint = 'N') {
         requestBody.fromDate = document.getElementById('fromDate').value;
         requestBody.toDate = document.getElementById('toDate').value;
         requestBody.productId = document.getElementById('productId').value;
+    }else if (currentPage.includes('reports/stock/intercompany-ledger')) {
+        requestBody.reportType = 'IntercompanyLedger';
+        requestBody.fromDate = document.getElementById('fromDate').value;
+        requestBody.toDate = document.getElementById('toDate').value;
+        requestBody.bowserId = document.getElementById('bowserId').value;
     }else if (currentPage.includes('reports-digital-recon')) {
         requestBody.reportType = 'DigitalRecon';
         requestBody.fromClosingDate = document.getElementById('fromclosingDate').value;

--- a/routes/stock-reports-routes.js
+++ b/routes/stock-reports-routes.js
@@ -37,6 +37,19 @@ router.post('/ledger', isLoginEnsured, function (req, res, next) {
     stockReportsController.getStockLedgerReport(req, res, next);
 });
 
+// Intercompany Ledger Report - GET (initial load)
+router.get('/intercompany-ledger', isLoginEnsured, function (req, res, next) {
+    req.body.fromDate = new Date(Date.now());
+    req.body.toDate = new Date(Date.now());
+    req.body.caller = 'notpdf';
+    stockReportsController.getIntercompanyLedgerReport(req, res, next);
+});
+
+// Intercompany Ledger Report - POST (form submit / PDF generation)
+router.post('/intercompany-ledger', isLoginEnsured, function (req, res, next) {
+    stockReportsController.getIntercompanyLedgerReport(req, res, next);
+});
+
 // Tank Variance Report - GET (initial load)
 router.get('/tank-variance', isLoginEnsured, function (req, res, next) {
     req.body.fromDate = new Date(Date.now());

--- a/utils/app-pdf-generator.js
+++ b/utils/app-pdf-generator.js
@@ -104,6 +104,9 @@ module.exports = {
         else if (req.body.reportType == 'StockLedger') {
             htmlContent = await stockReportsController.getStockLedgerReport(req, res, next);
         }
+        else if (req.body.reportType == 'IntercompanyLedger') {
+            htmlContent = await stockReportsController.getIntercompanyLedgerReport(req, res, next);
+        }
         else if (req.body.reportType == 'TankVariance') {
             htmlContent = await stockReportsController.getTankVarianceReport(req, res, next);
         }

--- a/views/reports-intercompany-ledger.pug
+++ b/views/reports-intercompany-ledger.pug
@@ -1,0 +1,109 @@
+extends layout
+
+block content
+    form(method='POST' action='/reports/stock/intercompany-ledger')
+        table.center
+            tr
+                td From Date:
+                td
+                    input#fromDate.form-control(type='date', name='fromDate', value=fromDate, max=currentDate, required)
+                td &nbsp;
+                td To Date:
+                td
+                    input#toDate.form-control(type='date', name='toDate', value=toDate, max=currentDate, required)
+                td &nbsp;
+                td Bowser:
+                td
+                    select#bowserId.form-control(name='bowserId', required)
+                        option(value='') Select Bowser
+                        each bowser in bowsers
+                            option(value=bowser.bowser_id, selected=selectedBowserId == bowser.bowser_id)= `${bowser.bowser_name} - ${bowser.product_name}`
+                td &nbsp;
+                include report-print-download.pug
+    div &nbsp;
+    div
+        if selectedBowserId && bowserInfo
+            div.row &nbsp;
+            h6.font-weight-bold.text-center Intercompany Ledger
+            h5.font-weight-bold.text-center.text-uppercase= bowserInfo.bowser_name
+            h6.text-center.text-muted= `${formattedFromDate}   to   ${formattedToDate}`
+
+            .container
+                .row.justify-content-center
+                    .col-12
+                        .alert.mb-4.period-summary(style="background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 8px; padding: 20px;")
+                            div(style="font-size: 1.1em; color: #495057; margin-bottom: 10px;")
+                                strong Period Summary
+                            .row
+                                .col-md-3
+                                    div(style="padding: 10px; background: white; border-radius: 4px; margin-bottom: 10px;")
+                                        div(style="color: #6c757d; font-size: 0.9em;") Opening Qty
+                                        div(style="font-size: 1.3em; font-weight: bold; color: #007bff;")= openingBalance + ' L'
+                                .col-md-3
+                                    div(style="padding: 10px; background: white; border-radius: 4px; margin-bottom: 10px;")
+                                        div(style="color: #6c757d; font-size: 0.9em;") Total Fills
+                                        div(style="font-size: 1.3em; font-weight: bold; color: #28a745;")= totalIn + ' L'
+                                .col-md-3
+                                    div(style="padding: 10px; background: white; border-radius: 4px; margin-bottom: 10px;")
+                                        div(style="color: #6c757d; font-size: 0.9em;") Total Sales
+                                        div(style="font-size: 1.3em; font-weight: bold; color: #dc3545;")= totalOut + ' L'
+                                .col-md-3
+                                    div(style="padding: 10px; background: white; border-radius: 4px; margin-bottom: 10px;")
+                                        div(style="color: #6c757d; font-size: 0.9em;") Closing Qty
+                                        div(style="font-size: 1.3em; font-weight: bold; color: #007bff;")= closingBalance + ' L'
+
+                        if ledgerData && ledgerData.length > 0
+                            .table-responsive
+                                table.table.table-bordered.table-hover
+                                    thead.thead-light
+                                        tr
+                                            th Date
+                                            th Type
+                                            th Reference
+                                            th Particulars
+                                            th.text-right IN
+                                            th.text-right OUT
+                                            th.text-right Balance
+                                    tbody
+                                        - var runningBalance = parseFloat(openingBalance)
+                                        tr.table-info
+                                            td(colspan='6')
+                                                strong Opening Balance
+                                            td.text-right
+                                                strong= runningBalance.toFixed(3)
+
+                                        each txn in ledgerData
+                                            - runningBalance = runningBalance + parseFloat(txn.in_qty || 0) - parseFloat(txn.out_qty || 0)
+                                            tr
+                                                td= new Date(txn.txn_date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' }).replace(/ /g, '-')
+                                                td= txn.txn_type
+                                                td= txn.reference_no || '-'
+                                                td= txn.particulars || '-'
+                                                td.text-right
+                                                    if parseFloat(txn.in_qty) > 0
+                                                        span.text-success= parseFloat(txn.in_qty).toFixed(3)
+                                                    else
+                                                        | -
+                                                td.text-right
+                                                    if parseFloat(txn.out_qty) > 0
+                                                        span.text-danger= parseFloat(txn.out_qty).toFixed(3)
+                                                    else
+                                                        | -
+                                                td.text-right(class=runningBalance < 0 ? 'text-danger font-weight-bold' : '')
+                                                    = runningBalance.toFixed(3)
+                                    tfoot.bg-light
+                                        tr.font-weight-bold
+                                            td(colspan='4') Total
+                                            td.text-right.text-success= totalIn
+                                            td.text-right.text-danger= totalOut
+                                            td.text-right Closing: #{closingBalance}
+                        else
+                            div.row &nbsp;
+                            div.row.bg-light No Transactions for the selected period.
+        else
+            div.row &nbsp;
+            div.alert.alert-info.text-center
+                i.fas.fa-info-circle
+                |  Please select a bowser and date range to view the intercompany ledger.
+
+    include overlay.pug


### PR DESCRIPTION
## Summary
- add an in-app intercompany ledger report under stock reports
- show bowser-wise quantity movement with fills in from shift intercompany and sales out from bowser closing
- support PDF/print flow and add a menu migration for sidebar visibility

## Validation
- pulled latest PetroMath_dev_new before commit
- node --check passed for the touched JS files