### PR TITLE
GL ledgers: tally_ledger_name field + Tally Master.txt import/reconcile

### DIFF
--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -946,7 +946,7 @@ router.get('/ledgers', [isLoginEnsured, security.isAdmin()], async function(req,
     try {
         const [ledgers, groups] = await Promise.all([
             db.sequelize.query(`
-                SELECT l.ledger_id, l.ledger_name, l.active_flag,
+                SELECT l.ledger_id, l.ledger_name, l.tally_ledger_name, l.active_flag,
                        g.group_id, g.group_name, g.group_nature
                 FROM gl_ledgers l
                 JOIN gl_ledger_groups g ON g.group_id = l.group_id
@@ -1000,19 +1000,141 @@ router.post('/api/ledger', [isLoginEnsured, security.isAdmin()], async function(
 router.put('/api/ledger/:id', [isLoginEnsured, security.isAdmin()], async function(req, res) {
     const locationCode = req.user.location_code;
     const ledgerId = parseInt(req.params.id);
-    const { ledger_name, group_id, active_flag } = req.body;
+    const { ledger_name, group_id, active_flag, tally_ledger_name } = req.body;
     if (!ledger_name || !group_id) return res.status(400).json({ success: false, error: 'ledger_name and group_id are required' });
     try {
         await db.sequelize.query(`
-            UPDATE gl_ledgers SET ledger_name=:ledger_name, group_id=:group_id, active_flag=:active_flag, updated_by=:user
+            UPDATE gl_ledgers SET ledger_name=:ledger_name, group_id=:group_id, active_flag=:active_flag,
+                tally_ledger_name=:tally_ledger_name, updated_by=:user
             WHERE ledger_id=:ledgerId AND location_code=:locationCode
         `, {
-            replacements: { ledgerId, locationCode, ledger_name, group_id: parseInt(group_id), active_flag: active_flag === 'Y' ? 'Y' : 'N', user: req.user.username },
+            replacements: {
+                ledgerId, locationCode, ledger_name, group_id: parseInt(group_id),
+                active_flag: active_flag === 'Y' ? 'Y' : 'N',
+                tally_ledger_name: tally_ledger_name || null,
+                user: req.user.username
+            },
             type: db.Sequelize.QueryTypes.UPDATE
         });
         res.json({ success: true });
     } catch (err) {
         res.status(500).json({ success: false, error: err.message });
+    }
+});
+
+// ── Tally Import ──────────────────────────────────────────────────────────────
+// GET  /gl/tally-import  — upload page
+// POST /gl/tally-import  — parse file, return reconcile data as JSON
+
+const multer  = require('multer');
+const upload  = multer({ storage: multer.memoryStorage(), limits: { fileSize: 10 * 1024 * 1024 } });
+
+function parseTallyMasterTxt(buf) {
+    // Auto-detect UTF-16 LE (BOM: FF FE) vs UTF-8/ASCII
+    const isUtf16 = buf[0] === 0xFF && buf[1] === 0xFE;
+    const content = buf.toString(isUtf16 ? 'utf16le' : 'utf8');
+    // Extract all double-quoted strings
+    const names = [];
+    const re = /"([^"]+)"/g;
+    let m;
+    while ((m = re.exec(content)) !== null) {
+        const name = m[1].trim();
+        if (name) names.push(name);
+    }
+    return names;
+}
+
+router.get('/tally-import', [isLoginEnsured, security.isAdmin()], function(req, res) {
+    res.render('gl-tally-import', {
+        title:   'Tally Ledger Import',
+        user:    req.user,
+        config:  require('../config/app-config').APP_CONFIGS,
+        messages: req.flash()
+    });
+});
+
+router.post('/tally-import/parse', [isLoginEnsured, security.isAdmin()], upload.single('tally_file'), async function(req, res) {
+    if (!req.file) return res.status(400).json({ error: 'No file uploaded' });
+
+    const locationCode = req.user.location_code;
+    try {
+        const tallyNames = parseTallyMasterTxt(req.file.buffer);
+
+        // Load PetroMath ledgers and groups
+        const [ledgers, groups] = await Promise.all([
+            db.sequelize.query(`
+                SELECT l.ledger_id, l.ledger_name, l.tally_ledger_name, l.active_flag,
+                       g.group_name
+                FROM gl_ledgers l
+                JOIN gl_ledger_groups g ON g.group_id = l.group_id
+                WHERE l.location_code = :locationCode
+                ORDER BY l.ledger_name
+            `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT }),
+            db.sequelize.query(`
+                SELECT group_name FROM gl_ledger_groups WHERE location_code = :locationCode
+            `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT })
+        ]);
+
+        const groupNames = new Set(groups.map(g => g.group_name.toLowerCase()));
+
+        // Build lookup map: lowercase ledger_name → ledger
+        const ledgerByName = new Map();
+        for (const l of ledgers) ledgerByName.set(l.ledger_name.toLowerCase(), l);
+
+        // Filter out Tally group names, deduplicate, reconcile
+        const seen = new Set();
+        const rows = [];
+        for (const tallyName of tallyNames) {
+            const key = tallyName.toLowerCase();
+            if (seen.has(key)) continue;
+            seen.add(key);
+            if (groupNames.has(key)) continue; // skip Tally group names
+
+            const matched = ledgerByName.get(key) || null;
+            rows.push({
+                tally_name:  tallyName,
+                ledger_id:   matched ? matched.ledger_id   : null,
+                ledger_name: matched ? matched.ledger_name : null,
+                tally_ledger_name: matched ? matched.tally_ledger_name : null,
+                match:       matched ? 'exact' : 'none'
+            });
+        }
+
+        res.json({ rows, ledgers });
+    } catch (err) {
+        console.error('Tally import parse error:', err);
+        res.status(500).json({ error: err.message });
+    }
+});
+
+router.post('/tally-import/save', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const { mappings } = req.body; // [{ ledger_id, tally_name }]
+
+    if (!Array.isArray(mappings) || !mappings.length) {
+        return res.status(400).json({ error: 'No mappings provided' });
+    }
+
+    try {
+        let updated = 0;
+        for (const m of mappings) {
+            const ledgerId  = parseInt(m.ledger_id);
+            const tallyName = (m.tally_name || '').trim() || null;
+            if (!ledgerId) continue;
+            await db.sequelize.query(`
+                UPDATE gl_ledgers
+                SET tally_ledger_name = :tallyName, updated_by = :user
+                WHERE ledger_id = :ledgerId AND location_code = :locationCode
+            `, {
+                replacements: { ledgerId, locationCode, tallyName, user: req.user.username },
+                type: db.Sequelize.QueryTypes.UPDATE
+            });
+            updated++;
+        }
+        res.json({ success: true, updated });
+    } catch (err) {
+        console.error('Tally import save error:', err);
+        res.status(500).json({ error: err.message });
     }
 });
 

--- a/views/gl-ledgers.pug
+++ b/views/gl-ledgers.pug
@@ -8,6 +8,9 @@ block content
             h4.mb-0 Ledgers
             .d-flex.gap-2
                 a.btn.btn-sm.btn-outline-secondary.mr-2(href="/gl/ledger-groups") &larr; Groups
+                a.btn.btn-sm.btn-outline-info.mr-2(href="/gl/tally-import")
+                    i.bi.bi-upload.mr-1
+                    | Tally Import
                 button.btn.btn-sm.btn-success#btnAddLedger
                     i.bi.bi-plus-lg.mr-1
                     | Add Ledger
@@ -36,6 +39,7 @@ block content
                                 each l in grpMap[grpName]
                                     tr(class=(l.active_flag === 'N' ? 'table-secondary text-muted' : ''))
                                         td= l.ledger_name
+                                        td.text-muted.small= l.tally_ledger_name || ''
                                         td.text-center(style="width:60px")
                                             if l.active_flag === 'N'
                                                 span.badge.badge-secondary Inactive
@@ -43,6 +47,7 @@ block content
                                             button.btn.btn-outline-primary.btn-sm.btn-edit-ledger(
                                                 data-id=l.ledger_id
                                                 data-name=l.ledger_name
+                                                data-tally=l.tally_ledger_name || ''
                                                 data-group=l.group_id
                                                 data-active=l.active_flag
                                                 title="Edit")
@@ -60,6 +65,10 @@ block content
                     .form-group
                         label.small Ledger Name *
                         input.form-control.form-control-sm#lName(type="text" maxlength="150")
+                    .form-group
+                        label.small Tally Ledger Name
+                        input.form-control.form-control-sm#lTallyName(type="text" maxlength="250" placeholder="Leave blank to use Ledger Name")
+                        small.form-text.text-muted Used in Tally export — set only if Tally uses a different name
                     .form-group
                         label.small Group *
                         select.form-control.form-control-sm#lGroup
@@ -80,6 +89,7 @@ block content
             editingLedgerId = null;
             document.getElementById('ledgerModalTitle').textContent = 'Add Ledger';
             document.getElementById('lName').value = '';
+            document.getElementById('lTallyName').value = '';
             document.getElementById('lGroup').selectedIndex = 0;
             document.getElementById('lActive').checked = true;
             document.getElementById('lActiveWrap').style.display = 'none';
@@ -91,6 +101,7 @@ block content
                 editingLedgerId = this.dataset.id;
                 document.getElementById('ledgerModalTitle').textContent = 'Edit Ledger';
                 document.getElementById('lName').value = this.dataset.name;
+                document.getElementById('lTallyName').value = this.dataset.tally || '';
                 document.getElementById('lGroup').value = this.dataset.group;
                 document.getElementById('lActive').checked = this.dataset.active === 'Y';
                 document.getElementById('lActiveWrap').style.display = '';
@@ -108,7 +119,8 @@ block content
             try {
                 const url    = editingLedgerId ? '/gl/api/ledger/' + editingLedgerId : '/gl/api/ledger';
                 const method = editingLedgerId ? 'PUT' : 'POST';
-                const body   = { ledger_name: name, group_id };
+                const tallyName = document.getElementById('lTallyName').value.trim();
+                const body   = { ledger_name: name, group_id, tally_ledger_name: tallyName || null };
                 if (editingLedgerId) body.active_flag = active;
 
                 const resp = await fetch(url, {

--- a/views/gl-tally-import.pug
+++ b/views/gl-tally-import.pug
@@ -1,0 +1,195 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        .d-flex.justify-content-between.align-items-center.mb-3
+            h4.mb-0 Tally Ledger Import
+            a.btn.btn-sm.btn-outline-secondary(href="/gl/ledgers") &larr; Ledgers
+
+        if messages && messages.error && messages.error.length
+            .alert.alert-danger.py-2= messages.error[0]
+
+        //- Step 1: Upload
+        #stepUpload
+            .card.mb-4
+                .card-body
+                    p.text-muted.small.mb-3
+                        | Export ledger master from Tally:
+                        strong Gateway → Display → List of Accounts → Ledgers → Export → ASCII (Comma Delimited)
+                        | . Upload the resulting
+                        code Master.txt
+                        |  below. Works with all Tally versions.
+                    .form-group
+                        label.small.font-weight-bold Tally Master File (Master.txt)
+                        .custom-file
+                            input.custom-file-input#tallyFile(type="file" accept=".txt,.csv")
+                            label.custom-file-label(for="tallyFile") Choose file…
+                    button.btn.btn-primary#btnParse(type="button" disabled)
+                        i.bi.bi-upload.mr-1
+                        | Upload & Parse
+
+        //- Step 2: Reconcile table (hidden until parsed)
+        #stepReconcile(style="display:none")
+            .d-flex.justify-content-between.align-items-center.mb-2
+                div
+                    span.font-weight-bold Reconcile Results
+                    span.text-muted.small.ml-2#reconcileSummary
+                .d-flex.gap-2
+                    button.btn.btn-sm.btn-outline-secondary#btnBack(type="button") &larr; Upload Different File
+                    button.btn.btn-success#btnSave(type="button")
+                        i.bi.bi-check2-all.mr-1
+                        | Save Matched
+
+            .alert.alert-info.small.py-2.mb-2
+                | Exact matches are pre-confirmed. For mismatches, select the correct PetroMath ledger or leave blank to skip.
+
+            .table-responsive
+                table.table.table-sm.table-bordered#reconcileTable
+                    thead.thead-dark
+                        tr
+                            th(style="width:32px")
+                                input(type="checkbox" id="chkAll" title="Select all matched" checked)
+                            th Tally Ledger Name
+                            th PetroMath Ledger
+                            th(style="width:90px") Status
+                    tbody#reconcileBody
+
+            .mt-3
+                button.btn.btn-success#btnSave2(type="button")
+                    i.bi.bi-check2-all.mr-1
+                    | Save Matched
+
+        //- Result
+        .alert.alert-success.mt-3(id="saveResult" style="display:none")
+
+    script.
+        let parsedLedgers = [];
+        let parsedRows    = [];
+
+        // File input label
+        document.getElementById('tallyFile').addEventListener('change', function() {
+            const label = this.nextElementSibling;
+            label.textContent = this.files[0] ? this.files[0].name : 'Choose file…';
+            document.getElementById('btnParse').disabled = !this.files[0];
+        });
+
+        document.getElementById('btnParse').addEventListener('click', async function() {
+            const file = document.getElementById('tallyFile').files[0];
+            if (!file) return;
+
+            this.disabled = true;
+            this.innerHTML = '<span class="spinner-border spinner-border-sm mr-1"></span> Parsing…';
+
+            const fd = new FormData();
+            fd.append('tally_file', file);
+
+            const resp = await fetch('/gl/tally-import/parse', { method: 'POST', body: fd });
+            const data = await resp.json();
+
+            this.disabled = false;
+            this.innerHTML = '<i class="bi bi-upload mr-1"></i> Upload & Parse';
+
+            if (!resp.ok || data.error) {
+                alert('Error: ' + (data.error || 'Unknown error'));
+                return;
+            }
+
+            parsedRows    = data.rows;
+            parsedLedgers = data.ledgers;
+            renderReconcile();
+        });
+
+        document.getElementById('btnBack').addEventListener('click', function() {
+            document.getElementById('stepUpload').style.display = '';
+            document.getElementById('stepReconcile').style.display = 'none';
+            document.getElementById('saveResult').style.display = 'none';
+        });
+
+        function renderReconcile() {
+            const tbody = document.getElementById('reconcileBody');
+            tbody.innerHTML = '';
+
+            const ledgerOptions = parsedLedgers
+                .map(l => `<option value="${l.ledger_id}">${l.ledger_name} (${l.group_name})</option>`)
+                .join('');
+
+            let exactCount = 0, noneCount = 0;
+
+            parsedRows.forEach(function(r, i) {
+                const isExact = r.match === 'exact';
+                if (isExact) exactCount++; else noneCount++;
+
+                const statusBadge = isExact
+                    ? '<span class="badge badge-success">Matched</span>'
+                    : '<span class="badge badge-warning">No match</span>';
+
+                const ledgerCell = isExact
+                    ? `<span class="small">${r.ledger_name}</span><input type="hidden" class="row-ledger-id" value="${r.ledger_id}">`
+                    : `<select class="form-control form-control-sm row-ledger-id" style="min-width:200px">
+                           <option value="">— skip —</option>
+                           ${ledgerOptions}
+                       </select>`;
+
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td class="text-center"><input type="checkbox" class="chk-row" ${isExact ? 'checked' : ''}></td>
+                    <td class="small">${r.tally_name}</td>
+                    <td>${ledgerCell}</td>
+                    <td class="text-center">${statusBadge}</td>`;
+                tbody.appendChild(tr);
+            });
+
+            document.getElementById('reconcileSummary').textContent =
+                `${exactCount} matched, ${noneCount} unmatched`;
+
+            document.getElementById('stepUpload').style.display = 'none';
+            document.getElementById('stepReconcile').style.display = '';
+            document.getElementById('saveResult').style.display = 'none';
+        }
+
+        // Select all checkbox
+        document.getElementById('chkAll').addEventListener('change', function() {
+            document.querySelectorAll('.chk-row').forEach(c => c.checked = this.checked);
+        });
+
+        async function doSave() {
+            const rows = document.querySelectorAll('#reconcileBody tr');
+            const mappings = [];
+            rows.forEach(function(tr) {
+                const chk      = tr.querySelector('.chk-row');
+                const ledgerEl = tr.querySelector('.row-ledger-id');
+                const tallyTd  = tr.querySelectorAll('td')[1];
+                if (!chk || !chk.checked || !ledgerEl) return;
+                const ledgerId = ledgerEl.value;
+                if (!ledgerId) return;
+                mappings.push({ ledger_id: ledgerId, tally_name: tallyTd.textContent.trim() });
+            });
+
+            if (!mappings.length) { alert('No rows selected.'); return; }
+
+            document.getElementById('btnSave').disabled  = true;
+            document.getElementById('btnSave2').disabled = true;
+
+            const resp = await fetch('/gl/tally-import/save', {
+                method:  'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body:    JSON.stringify({ mappings })
+            });
+            const data = await resp.json();
+
+            document.getElementById('btnSave').disabled  = false;
+            document.getElementById('btnSave2').disabled = false;
+
+            if (data.success) {
+                const el = document.getElementById('saveResult');
+                el.textContent = `✓ ${data.updated} ledger(s) updated with Tally name.`;
+                el.style.display = '';
+            } else {
+                alert('Error: ' + data.error);
+            }
+        }
+
+        document.getElementById('btnSave').addEventListener('click', doSave);
+        document.getElementById('btnSave2').addEventListener('click', doSave);


### PR DESCRIPTION
## Summary
- Expose `tally_ledger_name` in GL Ledgers list (new column) and edit modal — editable via PUT endpoint
- New `/gl/tally-import` page: upload Tally `Master.txt`, auto-detect UTF-16 LE vs UTF-8 (works all Tally versions), filter group names, exact-match against `gl_ledgers`, reconcile table with pre-checked matches and dropdown for mismatches, save writes `tally_ledger_name`
- "Tally Import" button added to GL Ledgers page

## Test plan
- [ ] Edit a ledger → Tally Ledger Name field appears, saves correctly
- [ ] Ledger list shows Tally Name column
- [ ] Upload `Master.txt` → parses correctly, matched rows pre-checked
- [ ] Save → `tally_ledger_name` updated on matched ledgers

🤖 Generated with [Claude Code](https://claude.com/claude-code)