### PR TITLE
GL ledger master: show source linkage in Edit modal

### DIFF
--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -924,9 +924,12 @@ router.get('/ledgers', [isLoginEnsured, security.isAdmin()], async function(req,
         const [ledgers, groups] = await Promise.all([
             db.sequelize.query(`
                 SELECT l.ledger_id, l.ledger_name, l.tally_ledger_name, l.active_flag,
-                       g.group_id, g.group_name, g.group_nature
+                       g.group_id, g.group_name, g.group_nature,
+                       l.source_type, l.source_id,
+                       cl.cust_name AS linked_customer_name
                 FROM gl_ledgers l
                 JOIN gl_ledger_groups g ON g.group_id = l.group_id
+                LEFT JOIN m_credit_list cl ON cl.creditlist_id = l.source_id AND l.source_type = 'CUSTOMER'
                 WHERE l.location_code = :locationCode
                 ORDER BY FIELD(g.group_nature,'ASSETS','LIABILITIES','INCOME','EXPENSES'), g.group_name, l.ledger_name
             `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT }),

--- a/views/gl-ledgers.pug
+++ b/views/gl-ledgers.pug
@@ -61,6 +61,9 @@ block content
                                                         data-tally=l.tally_ledger_name || ''
                                                         data-group=l.group_id
                                                         data-active=l.active_flag
+                                                        data-source-type=l.source_type || ''
+                                                        data-source-id=l.source_id || ''
+                                                        data-linked-customer=l.linked_customer_name || ''
                                                         title="Edit")
                                                         i.bi.bi-pencil
 
@@ -175,6 +178,9 @@ block content
                     button.close(data-dismiss="modal" aria-label="Close")
                         span &times;
                 .modal-body
+                    .alert.alert-light.border.py-1.px-2.small.mb-3#lSourceInfo(style="display:none")
+                        span.text-muted Source:
+                        strong.ml-1#lSourceLabel
                     .form-group
                         label.small Ledger Name *
                         input.form-control.form-control-sm#lName(type="text" maxlength="150")
@@ -261,6 +267,7 @@ block content
             document.getElementById('lGroup').selectedIndex = 0;
             document.getElementById('lActive').checked = true;
             document.getElementById('lActiveWrap').style.display = 'none';
+            document.getElementById('lSourceInfo').style.display = 'none';
             $('#ledgerModal').modal('show');
         });
 
@@ -273,6 +280,24 @@ block content
                 document.getElementById('lGroup').value = this.dataset.group;
                 document.getElementById('lActive').checked = this.dataset.active === 'Y';
                 document.getElementById('lActiveWrap').style.display = '';
+
+                // Source linkage info
+                const srcType     = this.dataset.sourceType || '';
+                const srcId       = this.dataset.sourceId   || '';
+                const linkedCust  = this.dataset.linkedCustomer || '';
+                const infoEl      = document.getElementById('lSourceInfo');
+                const labelEl     = document.getElementById('lSourceLabel');
+                if (srcType) {
+                    let label = srcType;
+                    if (srcType === 'CUSTOMER' && linkedCust) label = 'Customer — ' + linkedCust + ' (ID: ' + srcId + ')';
+                    else if (srcType === 'CUSTOMER' && srcId)  label = 'Customer (ID: ' + srcId + ')';
+                    else if (srcType === 'STATIC' && srcId)    label = 'Static account (ID: ' + srcId + ')';
+                    labelEl.textContent  = label;
+                    infoEl.style.display = '';
+                } else {
+                    infoEl.style.display = 'none';
+                }
+
                 $('#ledgerModal').modal('show');
             });
         });


### PR DESCRIPTION
## Summary
- Edit Ledger modal now shows a read-only **Source** line at the top
- For `CUSTOMER` ledgers: shows customer name + creditlist_id (e.g. `Customer — EMERALD CONSTRUCTION (ID: 42)`)
- For `STATIC` ledgers: shows static account ID
- Hidden for new ledgers (Add modal)
- Ledger query JOINs `m_credit_list` to resolve the customer name

## Test plan
- [ ] Edit a customer-linked ledger — Source line shows customer name and ID
- [ ] Edit a static ledger — Source line shows static account ID
- [ ] Click Add Ledger — Source line is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)