### PR TITLE
GL ledger master: fix Company_Name, CREDIT source type, guard Create button

### DIFF
--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -926,10 +926,10 @@ router.get('/ledgers', [isLoginEnsured, security.isAdmin()], async function(req,
                 SELECT l.ledger_id, l.ledger_name, l.tally_ledger_name, l.active_flag,
                        g.group_id, g.group_name, g.group_nature,
                        l.source_type, l.source_id,
-                       cl.cust_name AS linked_customer_name
+                       cl.Company_Name AS linked_customer_name
                 FROM gl_ledgers l
                 JOIN gl_ledger_groups g ON g.group_id = l.group_id
-                LEFT JOIN m_credit_list cl ON cl.creditlist_id = l.source_id AND l.source_type = 'CUSTOMER'
+                LEFT JOIN m_credit_list cl ON cl.creditlist_id = l.source_id AND l.source_type IN ('CUSTOMER','CREDIT')
                 WHERE l.location_code = :locationCode
                 ORDER BY FIELD(g.group_nature,'ASSETS','LIABILITIES','INCOME','EXPENSES'), g.group_name, l.ledger_name
             `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT }),

--- a/views/gl-ledgers.pug
+++ b/views/gl-ledgers.pug
@@ -289,9 +289,14 @@ block content
                 const labelEl     = document.getElementById('lSourceLabel');
                 if (srcType) {
                     let label = srcType;
-                    if (srcType === 'CUSTOMER' && linkedCust) label = 'Customer — ' + linkedCust + ' (ID: ' + srcId + ')';
-                    else if (srcType === 'CUSTOMER' && srcId)  label = 'Customer (ID: ' + srcId + ')';
-                    else if (srcType === 'STATIC' && srcId)    label = 'Static account (ID: ' + srcId + ')';
+                    if ((srcType === 'CUSTOMER' || srcType === 'CREDIT') && linkedCust)
+                        label = 'Credit customer — ' + linkedCust + ' (ID: ' + srcId + ')';
+                    else if ((srcType === 'CUSTOMER' || srcType === 'CREDIT') && srcId)
+                        label = 'Credit customer (ID: ' + srcId + ')';
+                    else if (srcType === 'STATIC' && srcId)
+                        label = 'Static account (ID: ' + srcId + ')';
+                    else if (srcType === 'STATIC')
+                        label = 'Static (manually created)';
                     labelEl.textContent  = label;
                     infoEl.style.display = '';
                 } else {
@@ -442,6 +447,11 @@ block content
             document.getElementById('saveResult').style.display    = 'none';
             document.getElementById('ledgerSearch').value          = '';
             $('#reconcileBody select.row-ledger-id').select2({ width: '100%', placeholder: '— skip —', dropdownParent: $('body') });
+            // Hide + Create when a ledger is selected; show when cleared
+            $('#reconcileBody').on('change', 'select.row-ledger-id', function() {
+                const btn = $(this).closest('div').find('.btn-create');
+                btn.toggle(!this.value);
+            });
             tbody.querySelectorAll('.btn-create').forEach(function(btn) {
                 btn.addEventListener('click', function() {
                     const suggestedGroupId = this.dataset.suggestedGroup || '';


### PR DESCRIPTION
## Summary
- Fix `Unknown column 'cl.cust_name'` — correct column is `Company_Name`
- JOIN now covers `source_type IN ('CUSTOMER','CREDIT')` so digital credit vendors also show linked name in Edit modal
- `+ Create` button now hides when a ledger is already selected in the dropdown, preventing accidental duplicates

## Test plan
- [ ] `/gl/ledgers` loads without column error
- [ ] Edit a CREDIT-linked ledger — shows "Credit customer — NAME (ID: X)"
- [ ] In Tally Import tab, selecting a ledger from dropdown hides the + Create button

🤖 Generated with [Claude Code](https://claude.com/claude-code)