### PR TITLE
Stock: 3-source model, off_meter_sale flag, GST B2B/B2C split

### DIFF
--- a/controllers/reports-gst-summary-controller.js
+++ b/controllers/reports-gst-summary-controller.js
@@ -53,14 +53,16 @@ module.exports = {
       const purchaseDataPromise = GstSummaryDao.getpurchasesummary(locationCode, fromDate, toDate);
       const salesDataPromise = GstSummaryDao.getSalesConsolidated(locationCode, fromDate, toDate);
       const nonFuelSalesDataPromise = GstSummaryDao.getNonFuelSalesConsolidated(locationCode, fromDate, toDate);
+      const nonFuelB2BSalesByBillPromise = GstSummaryDao.getNonFuelB2BSalesByBill(locationCode, fromDate, toDate);
       const nonFuelSalesByItemPromise = GstSummaryDao.getNonFuelSalesByItem(locationCode, fromDate, toDate);
       const nonFuelPurchaseInvoicesPromise = GstSummaryDao.getNonFuelPurchaseInvoicesByGST(locationCode, fromDate, toDate);
 
       const [purchaseData, salesData, nonFuelSalesData,
-            nonFuelSalesByItem, nonFuelPurchaseInvoices] = await Promise.all([
+            nonFuelB2BSalesByBill, nonFuelSalesByItem, nonFuelPurchaseInvoices] = await Promise.all([
         purchaseDataPromise,
         salesDataPromise,
         nonFuelSalesDataPromise,
+        nonFuelB2BSalesByBillPromise,
         nonFuelSalesByItemPromise,
         nonFuelPurchaseInvoicesPromise
       ]);
@@ -95,7 +97,7 @@ module.exports = {
       });
       
 
-        // Group non-fuel sales item-wise by GST rate (one table per rate in the view)
+        // Group B2C non-fuel sales by GST rate
         const groupedNonFuelSalesByGST = nonFuelSalesByItem.reduce((acc, row) => {
           const key = row.gst_rate;
           if (!acc[key]) acc[key] = [];
@@ -136,6 +138,7 @@ module.exports = {
         purchaseTransactionlist: groupedTransactions,
         salesSummaryList: salesSummaryList,
         nonFuelSalesSummaryList: nonFuelSalesSummaryList,
+        nonFuelB2BSalesByBill: nonFuelB2BSalesByBill,
         groupedNonFuelSalesByGST: groupedNonFuelSalesByGST,
         groupedNonFuelPurchaseInvoices: groupedNonFuelPurchaseInvoices
       }
@@ -176,12 +179,15 @@ module.exports = {
         // Fetch all data
         const purchaseDataPromise = GstSummaryDao.getpurchasesummary(locationCode, fromDate, toDate);
         const salesDataPromise = GstSummaryDao.getSalesConsolidated(locationCode, fromDate, toDate);
+        const nonFuelB2BSalesByBillPromise = GstSummaryDao.getNonFuelB2BSalesByBill(locationCode, fromDate, toDate);
         const nonFuelSalesByItemPromise = GstSummaryDao.getNonFuelSalesByItem(locationCode, fromDate, toDate);
         const nonFuelPurchaseInvoicesPromise = GstSummaryDao.getNonFuelPurchaseInvoicesByGST(locationCode, fromDate, toDate);
 
-        const [purchaseData, salesData, nonFuelSalesByItem, nonFuelPurchaseInvoices] = await Promise.all([
+        const [purchaseData, salesData, nonFuelB2BSalesByBill,
+               nonFuelSalesByItem, nonFuelPurchaseInvoices] = await Promise.all([
           purchaseDataPromise,
           salesDataPromise,
+          nonFuelB2BSalesByBillPromise,
           nonFuelSalesByItemPromise,
           nonFuelPurchaseInvoicesPromise
         ]);
@@ -256,7 +262,42 @@ module.exports = {
         
         currentRow++;
         
-        // Non-Fuel Sales - item-wise grouped by GST rate
+        // B2B Non-Fuel Sales - invoice-level detail
+        if (nonFuelB2BSalesByBill.length > 0) {
+            salesSheet.getCell(`A${currentRow}`).value = 'B2B NON-FUEL SALES (Invoice-wise)';
+            salesSheet.getCell(`A${currentRow}`).font = { bold: true, size: 12 };
+            currentRow++;
+
+            const b2bHeaderRow = salesSheet.getRow(currentRow);
+            b2bHeaderRow.values = ['Bill No', 'Date', 'Customer', 'GSTIN', 'Product', 'Qty', 'Amount', 'CGST', 'SGST'];
+            b2bHeaderRow.font = { bold: true };
+            b2bHeaderRow.eachCell((cell) => {
+                cell.border = { top: { style: 'thin' }, left: { style: 'thin' }, bottom: { style: 'thin' }, right: { style: 'thin' } };
+                cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFD3D3D3' } };
+            });
+            currentRow++;
+
+            nonFuelB2BSalesByBill.forEach(row => {
+                const dataRow = salesSheet.getRow(currentRow);
+                dataRow.getCell(1).value = row['Bill No'];
+                dataRow.getCell(2).value = row['Date'];
+                dataRow.getCell(3).value = row['Customer'];
+                dataRow.getCell(4).value = row['GSTIN'];
+                dataRow.getCell(5).value = row['Product'];
+                dataRow.getCell(6).value = toNumber(row['Qty']);
+                dataRow.getCell(7).value = toNumber(row['Amount']);
+                dataRow.getCell(8).value = toNumber(row['CGST']);
+                dataRow.getCell(9).value = toNumber(row['SGST']);
+                for (let i = 6; i <= 9; i++) dataRow.getCell(i).numFmt = '#,##0.00';
+                dataRow.eachCell((cell) => {
+                    cell.border = { top: { style: 'thin' }, left: { style: 'thin' }, bottom: { style: 'thin' }, right: { style: 'thin' } };
+                });
+                currentRow++;
+            });
+            currentRow++;
+        }
+
+        // B2C Non-Fuel Sales - product summary grouped by GST rate
         const nonFuelSalesGrouped = {};
         nonFuelSalesByItem.forEach(row => {
             const key = row.gst_rate || '0%';
@@ -264,36 +305,42 @@ module.exports = {
             nonFuelSalesGrouped[key].push(row);
         });
 
-        Object.keys(nonFuelSalesGrouped).sort().forEach(gstRate => {
-            salesSheet.getCell(`A${currentRow}`).value = `NON-FUEL SALES - GST @ ${gstRate}`;
+        if (Object.keys(nonFuelSalesGrouped).length > 0) {
+            salesSheet.getCell(`A${currentRow}`).value = 'B2C NON-FUEL SALES (Product Summary)';
             salesSheet.getCell(`A${currentRow}`).font = { bold: true, size: 12 };
             currentRow++;
 
-            const nonFuelSalesHeaderRow = salesSheet.getRow(currentRow);
-            nonFuelSalesHeaderRow.values = ['Product', 'Quantity', 'Amount', 'CGST', 'SGST', 'Total GST'];
-            nonFuelSalesHeaderRow.font = { bold: true };
-            nonFuelSalesHeaderRow.eachCell((cell) => {
-                cell.border = { top: { style: 'thin' }, left: { style: 'thin' }, bottom: { style: 'thin' }, right: { style: 'thin' } };
-                cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFD3D3D3' } };
-            });
-            currentRow++;
+            Object.keys(nonFuelSalesGrouped).sort().forEach(gstRate => {
+                salesSheet.getCell(`A${currentRow}`).value = `GST @ ${gstRate}`;
+                salesSheet.getCell(`A${currentRow}`).font = { bold: true };
+                currentRow++;
 
-            nonFuelSalesGrouped[gstRate].forEach(row => {
-                const dataRow = salesSheet.getRow(currentRow);
-                dataRow.getCell(1).value = row.product_name;
-                dataRow.getCell(2).value = toNumber(row.total_qty);
-                dataRow.getCell(3).value = toNumber(row.total_amount);
-                dataRow.getCell(4).value = toNumber(row.total_cgst);
-                dataRow.getCell(5).value = toNumber(row.total_sgst);
-                dataRow.getCell(6).value = toNumber(row.total_cgst) + toNumber(row.total_sgst);
-                for (let i = 2; i <= 6; i++) dataRow.getCell(i).numFmt = '#,##0.00';
-                dataRow.eachCell((cell) => {
+                const nonFuelSalesHeaderRow = salesSheet.getRow(currentRow);
+                nonFuelSalesHeaderRow.values = ['Product', 'Quantity', 'Amount', 'CGST', 'SGST', 'Total GST'];
+                nonFuelSalesHeaderRow.font = { bold: true };
+                nonFuelSalesHeaderRow.eachCell((cell) => {
                     cell.border = { top: { style: 'thin' }, left: { style: 'thin' }, bottom: { style: 'thin' }, right: { style: 'thin' } };
+                    cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFD3D3D3' } };
+                });
+                currentRow++;
+
+                nonFuelSalesGrouped[gstRate].forEach(row => {
+                    const dataRow = salesSheet.getRow(currentRow);
+                    dataRow.getCell(1).value = row.product_name;
+                    dataRow.getCell(2).value = toNumber(row.total_qty);
+                    dataRow.getCell(3).value = toNumber(row.total_amount);
+                    dataRow.getCell(4).value = toNumber(row.total_cgst);
+                    dataRow.getCell(5).value = toNumber(row.total_sgst);
+                    dataRow.getCell(6).value = toNumber(row.total_cgst) + toNumber(row.total_sgst);
+                    for (let i = 2; i <= 6; i++) dataRow.getCell(i).numFmt = '#,##0.00';
+                    dataRow.eachCell((cell) => {
+                        cell.border = { top: { style: 'thin' }, left: { style: 'thin' }, bottom: { style: 'thin' }, right: { style: 'thin' } };
+                    });
+                    currentRow++;
                 });
                 currentRow++;
             });
-            currentRow++;
-        });
+        }
 
         // Set column widths
         salesSheet.columns = [

--- a/dao/report-gst-summary-dao.js
+++ b/dao/report-gst-summary-dao.js
@@ -159,7 +159,50 @@ module.exports = {
 
 
   
-  // Get Non-Fuel Sales item-wise (by product) with GST amounts
+  // B2B non-fuel sales: one row per bill × product, for customers with a GSTIN.
+  getNonFuelB2BSalesByBill: async (locationCode, reportFromDate, reportToDate) => {
+    const query = `
+      SELECT
+        tc.bill_no                                                                    AS \`Bill No\`,
+        DATE_FORMAT(COALESCE(tc.credit_bill_date, DATE(tcl.closing_date)), '%d-%b-%Y') AS \`Date\`,
+        COALESCE(mcl.Company_Name, '')                                                AS \`Customer\`,
+        mcl.gst                                                                       AS \`GSTIN\`,
+        mp.product_name                                                               AS \`Product\`,
+        SUM(tc.qty)                                                                   AS \`Qty\`,
+        SUM(tc.amount)                                                                AS \`Amount\`,
+        ROUND(SUM(tc.amount * COALESCE(mp.cgst_percent, 0)
+              / (100 + COALESCE(mp.cgst_percent, 0) + COALESCE(mp.sgst_percent, 0))), 2) AS \`CGST\`,
+        ROUND(SUM(tc.amount * COALESCE(mp.sgst_percent, 0)
+              / (100 + COALESCE(mp.cgst_percent, 0) + COALESCE(mp.sgst_percent, 0))), 2) AS \`SGST\`
+      FROM t_credits tc
+      JOIN t_closing tcl ON tc.closing_id = tcl.closing_id
+      LEFT JOIN m_credit_list mcl ON tc.creditlist_id = mcl.creditlist_id
+      JOIN m_product mp ON tc.product_id = mp.product_id
+      WHERE tcl.closing_status = 'CLOSED'
+        AND tcl.location_code = :locationCode
+        AND DATE(tcl.closing_date) BETWEEN :reportFromDate AND :reportToDate
+        AND mcl.gst IS NOT NULL AND mcl.gst != ''
+        AND (
+          COALESCE(mp.is_lube_product, 0) = 1
+          OR mp.product_name NOT IN (
+              SELECT DISTINCT product_code FROM m_pump WHERE location_code = :locationCode
+          )
+        )
+      GROUP BY tc.bill_no,
+               COALESCE(tc.credit_bill_date, DATE(tcl.closing_date)),
+               mcl.Company_Name, mcl.gst, mp.product_name
+      ORDER BY COALESCE(tc.credit_bill_date, DATE(tcl.closing_date)), tc.bill_no;
+    `;
+
+    const result = await db.sequelize.query(query, {
+      replacements: { locationCode, reportFromDate, reportToDate },
+      type: Sequelize.QueryTypes.SELECT,
+    });
+
+    return result;
+  },
+
+  // B2C non-fuel sales: product-level summary (credit without GSTIN + cash + metered lubes).
   getNonFuelSalesByItem: async (locationCode, reportFromDate, reportToDate) => {
     const query = `
       SELECT
@@ -170,32 +213,50 @@ module.exports = {
         SUM(total_cgst) AS total_cgst,
         SUM(total_sgst) AS total_sgst
       FROM (
-        -- Packed lube sales via t_credits / t_cashsales
+        -- Credit sales where customer has no GSTIN
         SELECT
           mp.product_name,
           CONCAT(COALESCE(mp.cgst_percent, 0) + COALESCE(mp.sgst_percent, 0), '%') AS gst_rate,
-          SUM(s.qty) AS total_qty,
-          SUM(s.amount) AS total_amount,
-          SUM(s.amount * COALESCE(mp.cgst_percent, 0) / (100 + COALESCE(mp.cgst_percent, 0) + COALESCE(mp.sgst_percent, 0))) AS total_cgst,
-          SUM(s.amount * COALESCE(mp.sgst_percent, 0) / (100 + COALESCE(mp.cgst_percent, 0) + COALESCE(mp.sgst_percent, 0))) AS total_sgst
-        FROM (
-          SELECT closing_id, product_id, qty, amount
-          FROM t_credits
-          UNION ALL
-          SELECT closing_id, product_id, qty, amount
-          FROM t_cashsales
-        ) s
-        JOIN t_closing tc ON s.closing_id = tc.closing_id
-        JOIN m_product mp ON s.product_id = mp.product_id
-        WHERE tc.closing_status = 'CLOSED'
-          AND tc.location_code = :locationCode
-          AND DATE(tc.closing_date) BETWEEN :reportFromDate AND :reportToDate
+          SUM(tc.qty) AS total_qty,
+          SUM(tc.amount) AS total_amount,
+          SUM(tc.amount * COALESCE(mp.cgst_percent, 0) / (100 + COALESCE(mp.cgst_percent, 0) + COALESCE(mp.sgst_percent, 0))) AS total_cgst,
+          SUM(tc.amount * COALESCE(mp.sgst_percent, 0) / (100 + COALESCE(mp.cgst_percent, 0) + COALESCE(mp.sgst_percent, 0))) AS total_sgst
+        FROM t_credits tc
+        JOIN t_closing tcl ON tc.closing_id = tcl.closing_id
+        LEFT JOIN m_credit_list mcl ON tc.creditlist_id = mcl.creditlist_id
+        JOIN m_product mp ON tc.product_id = mp.product_id
+        WHERE tcl.closing_status = 'CLOSED'
+          AND tcl.location_code = :locationCode
+          AND DATE(tcl.closing_date) BETWEEN :reportFromDate AND :reportToDate
+          AND (mcl.gst IS NULL OR mcl.gst = '')
           AND (
             COALESCE(mp.is_lube_product, 0) = 1
             OR mp.product_name NOT IN (
-                SELECT DISTINCT product_code
-                FROM m_pump
-                WHERE location_code = :locationCode
+                SELECT DISTINCT product_code FROM m_pump WHERE location_code = :locationCode
+            )
+          )
+        GROUP BY mp.product_name, mp.cgst_percent, mp.sgst_percent
+
+        UNION ALL
+
+        -- Cash sales
+        SELECT
+          mp.product_name,
+          CONCAT(COALESCE(mp.cgst_percent, 0) + COALESCE(mp.sgst_percent, 0), '%') AS gst_rate,
+          SUM(tcs.qty) AS total_qty,
+          SUM(tcs.amount) AS total_amount,
+          SUM(tcs.amount * COALESCE(mp.cgst_percent, 0) / (100 + COALESCE(mp.cgst_percent, 0) + COALESCE(mp.sgst_percent, 0))) AS total_cgst,
+          SUM(tcs.amount * COALESCE(mp.sgst_percent, 0) / (100 + COALESCE(mp.cgst_percent, 0) + COALESCE(mp.sgst_percent, 0))) AS total_sgst
+        FROM t_cashsales tcs
+        JOIN t_closing tcl ON tcs.closing_id = tcl.closing_id
+        JOIN m_product mp ON tcs.product_id = mp.product_id
+        WHERE tcl.closing_status = 'CLOSED'
+          AND tcl.location_code = :locationCode
+          AND DATE(tcl.closing_date) BETWEEN :reportFromDate AND :reportToDate
+          AND (
+            COALESCE(mp.is_lube_product, 0) = 1
+            OR mp.product_name NOT IN (
+                SELECT DISTINCT product_code FROM m_pump WHERE location_code = :locationCode
             )
           )
         GROUP BY mp.product_name, mp.cgst_percent, mp.sgst_percent

--- a/dao/stock-reports-dao.js
+++ b/dao/stock-reports-dao.js
@@ -181,25 +181,24 @@ getStockLedger: async (productId, locationCode, fromDate, toDate) => {
 
                 UNION ALL
 
-                -- Meter Sales (fuel + metered lubes like 2T LOOSE) — grouped by day
+                -- Day Bill Sales (cash + digital portions; credits are tracked separately above)
                 SELECT
-                    DATE(c.closing_date) as txn_date,
-                    CONVERT('METER SALE' USING utf8mb4) as txn_type,
+                    tdb.bill_date as txn_date,
+                    CONVERT('DAY BILL' USING utf8mb4) as txn_type,
                     CONVERT('' USING utf8mb4) as reference_no,
-                    SUM(r.closing_reading - r.opening_reading - COALESCE(r.testing, 0)) as quantity,
-                    SUM(r.closing_reading - r.opening_reading - COALESCE(r.testing, 0)) as out_qty,
+                    SUM(tdi.quantity) as quantity,
+                    SUM(tdi.quantity) as out_qty,
                     0 as in_qty,
-                    CONVERT('Meter Sale' USING utf8mb4) as party_name,
-                    MAX(r.price) as rate,
-                    SUM((r.closing_reading - r.opening_reading - COALESCE(r.testing, 0)) * r.price) as amount
-                FROM t_reading r
-                JOIN t_closing c ON r.closing_id = c.closing_id
-                JOIN m_pump mp ON r.pump_id = mp.pump_id
-                JOIN m_product p ON mp.product_code = p.product_name AND p.product_id = ?
-                WHERE c.location_code = ?
-                AND DATE(c.closing_date) BETWEEN ? AND ?
-                AND (r.closing_reading - r.opening_reading - COALESCE(r.testing, 0)) > 0
-                GROUP BY DATE(c.closing_date)
+                    CONVERT('Day Bill' USING utf8mb4) as party_name,
+                    MAX(tdi.rate) as rate,
+                    SUM(tdi.total_amount) as amount
+                FROM t_day_bill tdb
+                JOIN t_day_bill_header tdbh ON tdbh.day_bill_id = tdb.day_bill_id
+                JOIN t_day_bill_items tdi ON tdi.header_id = tdbh.header_id
+                WHERE tdi.product_id = ?
+                AND tdb.location_code = ?
+                AND tdb.bill_date BETWEEN ? AND ?
+                GROUP BY tdb.bill_date
 
                 UNION ALL
 
@@ -231,7 +230,7 @@ getStockLedger: async (productId, locationCode, fromDate, toDate) => {
                 productId, locationCode, fromDate, toDate,  // Cash Sales
                 productId, locationCode, fromDate, toDate,  // Credit Sales
                 productId, locationCode, fromDate, toDate,  // 2T Oil
-                productId, locationCode, fromDate, toDate,  // Meter Sales
+                productId, locationCode, fromDate, toDate,  // Day Bill Sales
                 productId, locationCode, fromDate, toDate   // Adjustments
             ],
             type: Sequelize.QueryTypes.SELECT

--- a/db/migrations/bowser-intercompany-adjustments.sql
+++ b/db/migrations/bowser-intercompany-adjustments.sql
@@ -40,7 +40,9 @@ BEGIN
     FROM t_reading
     WHERE closing_id = p_closing_id;
 
-    -- Credit amount for pump products in this closing
+    -- Credit amount for pump products in this closing.
+    -- Excludes off_meter_sale = 1 (barrel/bulk handovers) because those were
+    -- never in the pump meter reading and must not be counted against meter revenue.
     SELECT COALESCE(SUM(tc.price * tc.qty), 0) INTO creditamt
     FROM t_credits tc
     INNER JOIN m_product mp ON tc.product_id = mp.product_id
@@ -50,7 +52,8 @@ BEGIN
         INNER JOIN m_pump mp2 ON tr.pump_id = mp2.pump_id
         WHERE tr.closing_id = p_closing_id
     ) pump_products ON mp.product_name = pump_products.product_code
-    WHERE tc.closing_id = p_closing_id;
+    WHERE tc.closing_id = p_closing_id
+      AND COALESCE(tc.off_meter_sale, 0) = 0;
 
     -- Cash sales for NON-PUMP products in this closing
     SELECT COALESCE(SUM((cs.price - cs.price_discount) * cs.qty), 0) INTO cashasaleamt
@@ -328,6 +331,7 @@ BEGIN
                                             WHERE session_id = l_session_id)
                       AND tc.closing_status = 'CLOSED'
                       AND mp.product_name = a.product_code
+                      AND COALESCE(tcr.off_meter_sale, 0) = 0
                     GROUP BY mp.product_name) AS crsaleamtwithoutdisc
             FROM (
                 SELECT mp.pump_code,

--- a/db/migrations/credits-off-meter-sale.sql
+++ b/db/migrations/credits-off-meter-sale.sql
@@ -1,0 +1,9 @@
+-- Migration: add off_meter_sale flag to t_credits
+-- Purpose: distinguish metered credit sales (went through the pump dispenser)
+--          from off-meter credit sales (physical barrel/bulk handover, not metered).
+--          The day bill procedure excludes off_meter_sale = 1 rows when deducting
+--          credits from pump readings, so barrel sales do not cause a floor error.
+-- Run on: all environments (dev, prod)
+
+ALTER TABLE t_credits
+ADD COLUMN off_meter_sale TINYINT(1) NOT NULL DEFAULT 0;

--- a/db/migrations/generate-day-bill-procedure.sql
+++ b/db/migrations/generate-day-bill-procedure.sql
@@ -203,7 +203,9 @@ generate_day_bill_sp: BEGIN
              digital_amount DESC
     LIMIT 1;
 
-    -- ── 8. Credit quantities for the day ────────────────────────────────────
+    -- ── 8. Credit quantities — exclude off-meter (barrel) sales ─────────────
+    --    off_meter_sale = 1 means the product was handed over physically without
+    --    going through the pump meter, so it must NOT be deducted from pumped_qty.
     CREATE TEMPORARY TABLE tmp_db_credit
     SELECT
         tc.product_id,
@@ -213,6 +215,7 @@ generate_day_bill_sp: BEGIN
     WHERE c.location_code = p_location_code
       AND DATE(c.closing_date) = p_bill_date
       AND c.closing_status = 'CLOSED'
+      AND COALESCE(tc.off_meter_sale, 0) = 0
     GROUP BY tc.product_id;
 
     -- ── 9. Proportionate digital items ───────────────────────────────────────

--- a/db/migrations/stock-summary-day-bill.sql
+++ b/db/migrations/stock-summary-day-bill.sql
@@ -1,0 +1,438 @@
+-- Migration: Switch stock balance function + summary procedure to use day bill
+-- instead of t_reading (meter) for is_tank_product=1 products.
+--
+-- Sales sources are now unified to 3:
+--   1. t_day_bill_items  — cash + digital metered portion  (is_tank_product=1)
+--   2. t_cashsales       — directly billed cash sales      (all products)
+--   3. t_credits         — credit customer sales           (all products)
+--   Plus t_2toil for lube products.
+--
+-- This eliminates the double-counting that occurred when metered credit fills
+-- appeared in both t_reading and t_credits for is_lube_product=1 + is_tank_product=1
+-- products (e.g. MAK ADBLUE - LOOSE).
+--
+-- Prerequisite: day bill backfill must be complete for all locations from their
+-- respective stock_start_date.
+--
+-- Run order:
+--   1. DROP/CREATE get_closing_product_stock_balance
+--   2. DROP/CREATE get_all_products_stock_summary
+
+-- ─── 1. get_closing_product_stock_balance ─────────────────────────────────────
+
+DROP FUNCTION IF EXISTS `get_closing_product_stock_balance`;
+
+DELIMITER ;;
+CREATE DEFINER=`petromath_prod`@`%` FUNCTION `get_closing_product_stock_balance`(
+    p_product_id       INT,
+    p_location_code    VARCHAR(50),
+    p_closing_bal_date DATE
+) RETURNS decimal(15,2)
+BEGIN
+    DECLARE l_stock_start_date  DATE;
+    DECLARE l_is_tank_product   TINYINT DEFAULT 0;
+    DECLARE l_is_lube_product   TINYINT DEFAULT 0;
+    DECLARE l_total_purchases   DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_total_adj_in      DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_total_adj_out     DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_cashsales         DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_creditsales       DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_2toil             DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_daybill           DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_total_sales       DECIMAL(15,2) DEFAULT 0;
+    DECLARE l_balance           DECIMAL(15,2) DEFAULT 0;
+
+    SELECT is_tank_product, is_lube_product
+    INTO   l_is_tank_product, l_is_lube_product
+    FROM   m_product
+    WHERE  product_id = p_product_id;
+
+    SELECT MIN(adjustment_date) INTO l_stock_start_date
+    FROM   t_lubes_stock_adjustment
+    WHERE  product_id    = p_product_id
+      AND  location_code = p_location_code;
+
+    IF l_stock_start_date IS NULL OR p_closing_bal_date < l_stock_start_date THEN
+        RETURN NULL;
+    END IF;
+
+    -- ── Purchases ─────────────────────────────────────────────────────────────
+
+    IF l_is_lube_product = 1 THEN
+        SELECT COALESCE(SUM(li.qty), 0)
+        INTO   l_total_purchases
+        FROM   t_lubes_inv_lines li
+        JOIN   t_lubes_inv_hdr hdr ON li.lubes_hdr_id = hdr.lubes_hdr_id
+        WHERE  li.product_id    = p_product_id
+          AND  hdr.location_code = p_location_code
+          AND  DATE(hdr.invoice_date) >= l_stock_start_date
+          AND  DATE(hdr.invoice_date) <= p_closing_bal_date;
+    ELSE
+        SELECT COALESCE(SUM(
+            IF(COALESCE(tid.qty_unit, 'KL') = 'KL', tid.quantity * 1000, tid.quantity)
+        ), 0)
+        INTO   l_total_purchases
+        FROM   t_tank_invoice_dtl tid
+        JOIN   t_tank_invoice ti ON tid.invoice_id = ti.id
+        WHERE  tid.product_id  = p_product_id
+          AND  ti.location_id  = p_location_code
+          AND  DATE(ti.invoice_date) >= l_stock_start_date
+          AND  DATE(ti.invoice_date) <= p_closing_bal_date;
+    END IF;
+
+    -- ── Cash sales (all stock-tracked products) ────────────────────────────────
+
+    SELECT COALESCE(SUM(cs.qty), 0)
+    INTO   l_cashsales
+    FROM   t_cashsales cs
+    JOIN   t_closing c ON cs.closing_id = c.closing_id
+    WHERE  cs.product_id   = p_product_id
+      AND  c.location_code = p_location_code
+      AND  DATE(c.closing_date) >= l_stock_start_date
+      AND  DATE(c.closing_date) <= p_closing_bal_date;
+
+    -- ── Credit sales (all stock-tracked products) ──────────────────────────────
+
+    SELECT COALESCE(SUM(tc.qty), 0)
+    INTO   l_creditsales
+    FROM   t_credits tc
+    JOIN   t_closing c ON tc.closing_id = c.closing_id
+    WHERE  tc.product_id   = p_product_id
+      AND  c.location_code = p_location_code
+      AND  DATE(c.closing_date) >= l_stock_start_date
+      AND  DATE(c.closing_date) <= p_closing_bal_date;
+
+    -- ── 2T oil (lube products only) ────────────────────────────────────────────
+
+    IF l_is_lube_product = 1 THEN
+        SELECT COALESCE(SUM(o.given_qty - o.returned_qty), 0)
+        INTO   l_2toil
+        FROM   t_2toil o
+        JOIN   t_closing c ON o.closing_id = c.closing_id
+        WHERE  o.product_id    = p_product_id
+          AND  c.location_code = p_location_code
+          AND  DATE(c.closing_date) >= l_stock_start_date
+          AND  DATE(c.closing_date) <= p_closing_bal_date;
+    END IF;
+
+    -- ── Day bill (metered products: is_tank_product=1) ─────────────────────────
+    --    Covers the cash + digital portion of metered sales.
+    --    Credits and cashsales (deducted by the day bill procedure) are tracked
+    --    separately above, so together they equal the full pump throughput.
+
+    IF l_is_tank_product = 1 THEN
+        SELECT COALESCE(SUM(tdi.quantity), 0)
+        INTO   l_daybill
+        FROM   t_day_bill tdb
+        JOIN   t_day_bill_header tdbh ON tdbh.day_bill_id = tdb.day_bill_id
+        JOIN   t_day_bill_items  tdi  ON tdi.header_id    = tdbh.header_id
+        WHERE  tdi.product_id    = p_product_id
+          AND  tdb.location_code = p_location_code
+          AND  tdb.bill_date    >= l_stock_start_date
+          AND  tdb.bill_date    <= p_closing_bal_date;
+    END IF;
+
+    SET l_total_sales = l_cashsales + l_creditsales + l_2toil + l_daybill;
+
+    -- ── Adjustments ────────────────────────────────────────────────────────────
+
+    SELECT COALESCE(SUM(qty), 0)
+    INTO   l_total_adj_in
+    FROM   t_lubes_stock_adjustment
+    WHERE  product_id      = p_product_id
+      AND  location_code   = p_location_code
+      AND  adjustment_type IN ('IN', 'OPENING')
+      AND  DATE(adjustment_date) >= l_stock_start_date
+      AND  DATE(adjustment_date) <= p_closing_bal_date;
+
+    SELECT COALESCE(SUM(qty), 0)
+    INTO   l_total_adj_out
+    FROM   t_lubes_stock_adjustment
+    WHERE  product_id      = p_product_id
+      AND  location_code   = p_location_code
+      AND  adjustment_type = 'OUT'
+      AND  DATE(adjustment_date) >= l_stock_start_date
+      AND  DATE(adjustment_date) <= p_closing_bal_date;
+
+    SET l_balance = l_total_purchases + l_total_adj_in - l_total_sales - l_total_adj_out;
+
+    RETURN l_balance;
+END ;;
+DELIMITER ;
+
+
+-- ─── 2. get_all_products_stock_summary ───────────────────────────────────────
+
+DROP PROCEDURE IF EXISTS `get_all_products_stock_summary`;
+
+DELIMITER ;;
+CREATE DEFINER=`petromath_prod`@`%` PROCEDURE `get_all_products_stock_summary`(
+    IN p_location_code VARCHAR(50),
+    IN p_from_date     DATE,
+    IN p_to_date       DATE
+)
+BEGIN
+    DECLARE l_opening_date DATE;
+    SET l_opening_date = DATE_SUB(p_from_date, INTERVAL 1 DAY);
+
+    SELECT
+        p.product_id,
+        p.product_name,
+        p.unit,
+        p.is_tank_product,
+        p.is_lube_product,
+
+        -- ── Opening balance ───────────────────────────────────────────────────
+        COALESCE(
+            get_closing_product_stock_balance(p.product_id, p_location_code, l_opening_date),
+            (SELECT SUM(qty)
+             FROM t_lubes_stock_adjustment
+             WHERE product_id    = p.product_id
+               AND location_code = p_location_code
+               AND adjustment_type = 'OPENING'
+               AND DATE(adjustment_date) = p_from_date)
+        ) AS opening_balance,
+
+        -- ── Closing balance ───────────────────────────────────────────────────
+        get_closing_product_stock_balance(p.product_id, p_location_code, p_to_date) AS closing_balance,
+
+        -- ── Opening price ─────────────────────────────────────────────────────
+        COALESCE(
+            CASE WHEN p.is_lube_product = 0 AND p.is_tank_product = 1 THEN
+                (SELECT r.price
+                 FROM t_reading r
+                 JOIN t_closing c  ON r.closing_id = c.closing_id
+                 JOIN m_pump mp    ON r.pump_id = mp.pump_id AND mp.location_code = p_location_code
+                 WHERE mp.product_code = p.product_name
+                   AND c.location_code = p_location_code
+                   AND DATE(c.closing_date) <= l_opening_date
+                 ORDER BY c.closing_date DESC, r.reading_id DESC
+                 LIMIT 1)
+            ELSE
+                (SELECT li.net_rate
+                 FROM t_lubes_inv_lines li
+                 JOIN t_lubes_inv_hdr hdr ON li.lubes_hdr_id = hdr.lubes_hdr_id
+                 WHERE li.product_id    = p.product_id
+                   AND hdr.location_code = p_location_code
+                   AND DATE(hdr.invoice_date) <= l_opening_date
+                 ORDER BY hdr.invoice_date DESC
+                 LIMIT 1)
+            END
+        , 0) AS opening_price,
+
+        -- ── Closing price ─────────────────────────────────────────────────────
+        COALESCE(
+            CASE WHEN p.is_lube_product = 0 AND p.is_tank_product = 1 THEN
+                (SELECT r.price
+                 FROM t_reading r
+                 JOIN t_closing c  ON r.closing_id = c.closing_id
+                 JOIN m_pump mp    ON r.pump_id = mp.pump_id AND mp.location_code = p_location_code
+                 WHERE mp.product_code = p.product_name
+                   AND c.location_code = p_location_code
+                   AND DATE(c.closing_date) <= p_to_date
+                 ORDER BY c.closing_date DESC, r.reading_id DESC
+                 LIMIT 1)
+            ELSE
+                (SELECT li.net_rate
+                 FROM t_lubes_inv_lines li
+                 JOIN t_lubes_inv_hdr hdr ON li.lubes_hdr_id = hdr.lubes_hdr_id
+                 WHERE li.product_id    = p.product_id
+                   AND hdr.location_code = p_location_code
+                   AND DATE(hdr.invoice_date) <= p_to_date
+                 ORDER BY hdr.invoice_date DESC
+                 LIMIT 1)
+            END
+        , 0) AS closing_price,
+
+        -- ── Total IN (qty) ────────────────────────────────────────────────────
+        COALESCE((
+            SELECT SUM(qty) FROM (
+
+                -- Lube invoices (is_lube_product=1)
+                SELECT li.qty AS qty
+                FROM t_lubes_inv_lines li
+                JOIN t_lubes_inv_hdr hdr ON li.lubes_hdr_id = hdr.lubes_hdr_id
+                WHERE li.product_id    = p.product_id
+                  AND hdr.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(hdr.invoice_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- Fuel invoices (fuel only: is_tank_product=1, is_lube_product=0)
+                SELECT IF(COALESCE(tid.qty_unit, 'KL') = 'KL', tid.quantity * 1000, tid.quantity) AS qty
+                FROM t_tank_invoice_dtl tid
+                JOIN t_tank_invoice ti ON tid.invoice_id = ti.id
+                WHERE tid.product_id    = p.product_id
+                  AND ti.location_id    = p_location_code
+                  AND p.is_tank_product = 1
+                  AND p.is_lube_product = 0
+                  AND DATE(ti.invoice_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- Adjustments IN (all products)
+                SELECT qty
+                FROM t_lubes_stock_adjustment
+                WHERE product_id      = p.product_id
+                  AND location_code   = p_location_code
+                  AND adjustment_type = 'IN'
+                  AND DATE(adjustment_date) BETWEEN p_from_date AND p_to_date
+
+            ) AS ins
+        ), 0) AS total_in,
+
+        -- ── Purchase value ────────────────────────────────────────────────────
+        COALESCE((
+            SELECT SUM(amt) FROM (
+
+                SELECT (li.qty * li.net_rate) AS amt
+                FROM t_lubes_inv_lines li
+                JOIN t_lubes_inv_hdr hdr ON li.lubes_hdr_id = hdr.lubes_hdr_id
+                WHERE li.product_id    = p.product_id
+                  AND hdr.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(hdr.invoice_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                SELECT trd.amount AS amt
+                FROM t_tank_stk_rcpt_dtl trd
+                JOIN t_tank_stk_rcpt tr ON trd.ttank_id = tr.ttank_id
+                JOIN m_tank t           ON trd.tank_id  = t.tank_id
+                WHERE t.product_code    = p.product_name
+                  AND tr.location_code  = p_location_code
+                  AND p.is_tank_product = 1
+                  AND p.is_lube_product = 0
+                  AND DATE(tr.invoice_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                SELECT tid.total_line_amount AS amt
+                FROM t_tank_invoice_dtl tid
+                JOIN t_tank_invoice ti ON tid.invoice_id = ti.id
+                WHERE tid.product_id    = p.product_id
+                  AND ti.location_id    = p_location_code
+                  AND p.is_tank_product = 1
+                  AND p.is_lube_product = 0
+                  AND DATE(ti.invoice_date) BETWEEN p_from_date AND p_to_date
+
+            ) AS purch_amts
+        ), 0) AS purchase_value,
+
+        -- ── Total OUT (qty) ───────────────────────────────────────────────────
+        COALESCE((
+            SELECT SUM(qty) FROM (
+
+                -- Cash sales (all stock-tracked products)
+                SELECT cs.qty
+                FROM t_cashsales cs
+                JOIN t_closing c ON cs.closing_id = c.closing_id
+                WHERE cs.product_id   = p.product_id
+                  AND c.location_code = p_location_code
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- Credit sales (all stock-tracked products)
+                SELECT cr.qty
+                FROM t_credits cr
+                JOIN t_closing c ON cr.closing_id = c.closing_id
+                WHERE cr.product_id   = p.product_id
+                  AND c.location_code = p_location_code
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- 2T oil (lube products only)
+                SELECT (o.given_qty - o.returned_qty)
+                FROM t_2toil o
+                JOIN t_closing c ON o.closing_id = c.closing_id
+                WHERE o.product_id    = p.product_id
+                  AND c.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+                  AND (o.given_qty - o.returned_qty) > 0
+
+                UNION ALL
+
+                -- Day bill (metered products: is_tank_product=1)
+                -- Covers cash + digital portion; credits and cashsales tracked above.
+                SELECT tdi.quantity AS qty
+                FROM t_day_bill tdb
+                JOIN t_day_bill_header tdbh ON tdbh.day_bill_id = tdb.day_bill_id
+                JOIN t_day_bill_items  tdi  ON tdi.header_id    = tdbh.header_id
+                WHERE tdi.product_id    = p.product_id
+                  AND tdb.location_code = p_location_code
+                  AND p.is_tank_product = 1
+                  AND tdb.bill_date BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- Adjustments OUT (all products)
+                SELECT qty
+                FROM t_lubes_stock_adjustment
+                WHERE product_id      = p.product_id
+                  AND location_code   = p_location_code
+                  AND adjustment_type = 'OUT'
+                  AND DATE(adjustment_date) BETWEEN p_from_date AND p_to_date
+
+            ) AS outs
+        ), 0) AS total_out,
+
+        -- ── Sales value ───────────────────────────────────────────────────────
+        COALESCE((
+            SELECT SUM(amt) FROM (
+
+                -- Cash sale amounts (all stock-tracked products)
+                SELECT cs.amount AS amt
+                FROM t_cashsales cs
+                JOIN t_closing c ON cs.closing_id = c.closing_id
+                WHERE cs.product_id   = p.product_id
+                  AND c.location_code = p_location_code
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- Credit sale amounts (all stock-tracked products)
+                SELECT cr.amount AS amt
+                FROM t_credits cr
+                JOIN t_closing c ON cr.closing_id = c.closing_id
+                WHERE cr.product_id   = p.product_id
+                  AND c.location_code = p_location_code
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+
+                UNION ALL
+
+                -- 2T oil amounts (lube only)
+                SELECT ((o.given_qty - o.returned_qty) * o.price) AS amt
+                FROM t_2toil o
+                JOIN t_closing c ON o.closing_id = c.closing_id
+                WHERE o.product_id    = p.product_id
+                  AND c.location_code = p_location_code
+                  AND p.is_lube_product = 1
+                  AND DATE(c.closing_date) BETWEEN p_from_date AND p_to_date
+                  AND (o.given_qty - o.returned_qty) > 0
+
+                UNION ALL
+
+                -- Day bill amounts (metered products: is_tank_product=1)
+                SELECT tdi.total_amount AS amt
+                FROM t_day_bill tdb
+                JOIN t_day_bill_header tdbh ON tdbh.day_bill_id = tdb.day_bill_id
+                JOIN t_day_bill_items  tdi  ON tdi.header_id    = tdbh.header_id
+                WHERE tdi.product_id    = p.product_id
+                  AND tdb.location_code = p_location_code
+                  AND p.is_tank_product = 1
+                  AND tdb.bill_date BETWEEN p_from_date AND p_to_date
+
+            ) AS sale_amts
+        ), 0) AS sales_value
+
+    FROM m_product p
+    WHERE p.location_code = p_location_code
+      AND (p.is_lube_product = 1 OR (p.is_tank_product = 1 AND p.is_lube_product = 0))
+    ORDER BY p.is_lube_product ASC, p.product_name;
+
+END ;;
+DELIMITER ;

--- a/db/txn-credits.js
+++ b/db/txn-credits.js
@@ -97,6 +97,11 @@ module.exports = function(sequelize, DataTypes) {
             type: DataTypes.DECIMAL(12, 2),
             allowNull: true,
             comment: 'Vehicle odometer reading at time of fuelling for mileage calculation'
+        },
+        off_meter_sale: {
+            field: 'off_meter_sale',
+            type: DataTypes.TINYINT(1),
+            defaultValue: 0
         }
     }, {
         timestamps: false,

--- a/views/reports-gst-summary.pug
+++ b/views/reports-gst-summary.pug
@@ -8,6 +8,7 @@ block content
             var purchaseTransactionFromServer = !{JSON.stringify(purchaseTransactionlist)}
             var salesSummaryFromServer = !{JSON.stringify(salesSummaryList)}
             var nonFuelSalesSummaryFromServer = !{JSON.stringify(nonFuelSalesSummaryList)}
+            var nonFuelB2BSalesByBillFromServer = !{JSON.stringify(nonFuelB2BSalesByBill)}
             var groupedNonFuelSalesByGSTFromServer = !{JSON.stringify(groupedNonFuelSalesByGST)}
             var groupedNonFuelPurchaseInvoicesFromServer = !{JSON.stringify(groupedNonFuelPurchaseInvoices)}
 
@@ -96,18 +97,29 @@ block content
                     "col-sm-8 mx-auto"
                 );
                 
-                // 2. Non Fuel Sales - Item Wise (one table per GST rate)
-                let nonFuelSalesHtml = "";
-                Object.keys(groupedNonFuelSalesByGSTFromServer).sort().forEach(gstRate => {
-                    const rows = groupedNonFuelSalesByGSTFromServer[gstRate];
-                    nonFuelSalesHtml += renderTable(
-                        rows,
-                        `Non Fuel Sales - GST @ ${gstRate}`,
-                        ['Quantity', 'Amount', 'CGST', 'SGST', 'Total GST'],
-                        "col-sm-10 mx-auto"
-                    );
-                });
-                document.getElementById('NonFuelSalesByItem-table-container').innerHTML = nonFuelSalesHtml;
+                // 2a. B2B Non Fuel Sales - invoice-level detail
+                document.getElementById('NonFuelB2BSales-table-container').innerHTML = renderTable(
+                    nonFuelB2BSalesByBillFromServer,
+                    'B2B Non-Fuel Sales',
+                    ['Qty', 'Amount', 'CGST', 'SGST'],
+                    "col-sm-12 mx-auto"
+                );
+
+                // 2b. B2C Non Fuel Sales - product summary grouped by GST rate
+                let nonFuelB2CHtml = "";
+                if (Object.keys(groupedNonFuelSalesByGSTFromServer).length === 0) {
+                    nonFuelB2CHtml = "<p class='text-center'><strong>*** No B2C Non-Fuel Sales ***</strong></p>";
+                } else {
+                    Object.keys(groupedNonFuelSalesByGSTFromServer).sort().forEach(gstRate => {
+                        nonFuelB2CHtml += renderTable(
+                            groupedNonFuelSalesByGSTFromServer[gstRate],
+                            `B2C Non-Fuel Sales - GST @ ${gstRate}`,
+                            ['Quantity', 'Amount', 'CGST', 'SGST', 'Total GST'],
+                            "col-sm-10 mx-auto"
+                        );
+                    });
+                }
+                document.getElementById('NonFuelB2CSales-table-container').innerHTML = nonFuelB2CHtml;
                 
                 // 3. Fuel Purchase Invoice Details (grouped by product)
                 let fuelInvoiceHtml = "";
@@ -224,10 +236,19 @@ block content
                 div.row &nbsp;
                 div(id="FuelSales-table-container")
             
-            //- 2. Non Fuel Sales - Item Wise (grouped by GST rate)
+            //- 2a. B2B Non Fuel Sales (credit customers with GSTIN)
             div.col-md-12
                 div.row &nbsp;
-                div(id="NonFuelSalesByItem-table-container")
+                h5.text-center B2B Non-Fuel Sales
+                p.text-center.text-muted(style='font-size:0.85em') Credit customers with GSTIN
+                div(id="NonFuelB2BSales-table-container")
+
+            //- 2b. B2C Non Fuel Sales (cash sales & credit without GSTIN)
+            div.col-md-12
+                div.row &nbsp;
+                h5.text-center B2C Non-Fuel Sales
+                p.text-center.text-muted(style='font-size:0.85em') Cash sales &amp; credit customers without GSTIN
+                div(id="NonFuelB2CSales-table-container")
             
             //- 3. Purchase Invoice Details - Fuel (grouped by product)
             div.col-md-12


### PR DESCRIPTION
## Summary
- Add `off_meter_sale` flag to `t_credits` to distinguish barrel/bulk handover (not through pump meter) from metered credit sales — excludes flagged rows from day bill pump deduction, CALCULATE_EXSHORTAGE, and generate_cashflow
- Migrate stock ledger and stock summary from `t_reading` to `t_day_bill_items` (3-source model: day bill + cashsales + credits)
- GST summary: split non-fuel sales into B2B (credit customers with GSTIN, invoice-level detail) and B2C (no GSTIN + cash, product summary)

## Migrations to run
- `db/migrations/credits-off-meter-sale.sql` — ALTER TABLE t_credits ADD off_meter_sale
- `db/migrations/stock-summary-day-bill.sql` — replace get_closing_product_stock_balance + get_all_products_stock_summary
- `db/migrations/generate-day-bill-procedure.sql` — updated generate_day_bill procedure
- `db/migrations/bowser-intercompany-adjustments.sql` — updated CALCULATE_EXSHORTAGE + generate_cashflow

## Test plan
- [ ] Stock ledger: verify OUT quantities match GST summary for a metered product (e.g. MAK ADBLUE - LOOSE)
- [ ] Stock summary: verify totals consistent with stock ledger
- [ ] Day bill: verify barrel AdBlue credit (off_meter_sale=1) does not reduce pump qty or cause floor
- [ ] Ex-shortage: verify shift with barrel credit shows correct shortage/excess
- [ ] GST summary: verify B2B section shows invoice-level rows for GSTIN customers; B2C shows product summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)