### PR TITLE
products-routes: add missing db import for copy-to endpoint

### DIFF
--- a/routes/products-routes.js
+++ b/routes/products-routes.js
@@ -6,6 +6,7 @@ const isLoginEnsured = login.ensureLoggedIn({});
 const security = require("../utils/app-security");
 const ProductDao = require('../dao/product-dao');
 const ProductLedgerMapDao = require('../dao/product-ledger-map-dao');
+const db        = require('../db/db-connection');
 const dbMapping = require("../db/ui-db-field-mapping")
 const config = require('../config/app-config');
 const locationConfigDao = require('../dao/location-config-dao');


### PR DESCRIPTION
Fix 'db is not defined' error when using Apply to other products.