### PR TITLE
Bank upload: CSB Bank template with single-amount-column support

### DIFF
--- a/controllers/transaction-upload-controller.js
+++ b/controllers/transaction-upload-controller.js
@@ -132,6 +132,13 @@ function columnToIndex(column) {
 // }
 
 
+// Strips currency prefixes ("INR ", "USD " etc.) and commas before parsing
+function parseAmount(raw) {
+    if (raw === null || raw === undefined || raw === '') return 0;
+    const cleaned = String(raw).replace(/[A-Z]{2,3}\s*/g, '').replace(/,/g, '').trim();
+    return parseFloat(cleaned) || 0;
+}
+
 function parseExcelDate(value, dateFormat = 'AUTO') {
     if (!value) return null;
     
@@ -821,12 +828,19 @@ previewTransactions: async (req, res) => {
                 continue;
             }
 
-            const debitRaw = row[columnToIndex(template.debit_column)] || '';
-            const creditRaw = row[columnToIndex(template.credit_column)] || '';
             const balanceRaw = row[columnToIndex(template.balance_column)] || '';
 
-            const debitAmount = parseFloat(String(debitRaw).replace(/,/g, '')) || 0;
-            const creditAmount = parseFloat(String(creditRaw).replace(/,/g, '')) || 0;
+            let debitAmount, creditAmount;
+            if (template.transaction_type_column) {
+                // Single-amount column format (e.g. CSB Bank): type column says "Credit" or "Debit"
+                const txnType = String(row[columnToIndex(template.transaction_type_column)] || '').trim().toLowerCase();
+                const amount = parseAmount(row[columnToIndex(template.debit_column)]);
+                debitAmount = txnType === 'debit' ? amount : 0;
+                creditAmount = txnType === 'credit' ? amount : 0;
+            } else {
+                debitAmount = parseAmount(row[columnToIndex(template.debit_column)]);
+                creditAmount = parseAmount(row[columnToIndex(template.credit_column)]);
+            }
 
             // ===== SKIP TOTAL/SUMMARY ROWS =====
             // Rows with BOTH debit and credit are typically total/summary rows
@@ -845,8 +859,8 @@ previewTransactions: async (req, res) => {
                 description: row[columnToIndex(template.description_column)] || '',
                 debit_amount: debitAmount,
                 credit_amount: creditAmount,
-                balance_amount: parseFloat(String(balanceRaw).replace(/,/g, '')) || 0,
-                running_balance: parseFloat(String(balanceRaw).replace(/,/g, '')) || null,
+                balance_amount: parseAmount(balanceRaw),
+                running_balance: parseAmount(balanceRaw) || null,
                 statement_ref: row[columnToIndex(template.reference_column)] || null,
                 source_file: req.file.originalname,
                 retained_file_name: retainedFileName,

--- a/db/migrations/csb-bank-template.sql
+++ b/db/migrations/csb-bank-template.sql
@@ -1,0 +1,40 @@
+-- Add support for single-amount-column banks (e.g. CSB Bank)
+-- where one column holds the amount and another column says "Credit" or "Debit"
+ALTER TABLE m_bank_statement_template
+  ADD COLUMN transaction_type_column VARCHAR(5) DEFAULT NULL
+    COMMENT 'Column letter for Credit/Debit type indicator. Set when the bank uses a single Amount column instead of separate Debit/Credit columns.';
+
+-- CSB Bank statement template
+-- Format: Transaction Date(A), Description(B), Reference(C), Type(D), Amount(E), Balance(F)
+-- Data starts at row 30 (29 header/account-detail rows + 1 column-header row)
+-- Date format: DD/MM/YY (e.g. 06/04/26)
+-- Amount format: "INR 6,039.00" — handled by parseAmount() in the controller
+INSERT INTO m_bank_statement_template (
+    template_name,
+    bank_name,
+    date_column,
+    value_date_column,
+    debit_column,
+    credit_column,
+    description_column,
+    reference_column,
+    balance_column,
+    transaction_type_column,
+    data_start_row,
+    date_format,
+    is_active
+) VALUES (
+    'CSB Bank',
+    'CSB Bank',
+    'A',
+    NULL,
+    'E',
+    'E',
+    'B',
+    'C',
+    'F',
+    'D',
+    30,
+    'DD/MM/YY',
+    1
+);


### PR DESCRIPTION
## Summary
- Adds `transaction_type_column` to `m_bank_statement_template` for single-amount-column banks (CSB Bank)
- New `parseAmount()` helper strips currency prefixes (INR etc.) and commas — backward-compatible
- CSB Bank template inserted (Date=A, Desc=B, Ref=C, Type=D, Amount=E, Balance=F, row 30, DD/MM/YY)

🤖 Generated with [Claude Code](https://claude.com/claude-code)