### PR TITLE
Credit statement: period summary / statement no / CR-DR / balance column configs

### DIFF
--- a/controllers/reports-controller.js
+++ b/controllers/reports-controller.js
@@ -136,10 +136,10 @@ module.exports = {
                  
                   // Helper function to format odometer reading with Indian number format
                 const formatOdometerReading = (reading) => {
-                  if (!reading || reading === null) return '';
-                  const formatted = new Intl.NumberFormat('en-IN', { 
-                    minimumFractionDigits: 2, 
-                    maximumFractionDigits: 2 
+                  if (!reading || reading === null || Number(reading) === 0) return '';
+                  const formatted = new Intl.NumberFormat('en-IN', {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2
                   }).format(reading);
                   return formatted + ' km';
                 };
@@ -194,25 +194,46 @@ module.exports = {
               }
               
                         const formattedFromDate = moment(fromDate).format('DD/MM/YYYY');
-                        const formattedToDate = moment(toDate).format('DD/MM/YYYY'); 
-                        
+                        const formattedToDate = moment(toDate).format('DD/MM/YYYY');
+
+                        const showPeriodSummary = await locationConfig.getLocationConfigValue(locationCode, 'CREDIT_STMT_SHOW_PERIOD_SUMMARY', 'Y');
+                        const showStatementNumber = await locationConfig.getLocationConfigValue(locationCode, 'CREDIT_STMT_SHOW_STATEMENT_NUMBER', 'N');
+                        const balanceCrDrFormat = await locationConfig.getLocationConfigValue(locationCode, 'CREDIT_STMT_BALANCE_CRDR_FORMAT', 'N');
+                        const showBalanceCol = await locationConfig.getLocationConfigValue(locationCode, 'CREDIT_STMT_SHOW_BALANCE', 'Y');
+                        let statementNumber = null;
+                        if (showStatementNumber === 'Y' && cid && cid != -1) {
+                            try {
+                                statementNumber = await ReportDao.createStatementRecord(
+                                    locationCode, cid, fromDate, toDate,
+                                    reportType || 'CreditDetails',
+                                    req.user ? req.user.username || req.user.email : null
+                                );
+                            } catch (stmtErr) {
+                                console.error('getCreditReport: failed to create statement record:', stmtErr.message);
+                            }
+                        }
+
                           // Prepare the render data
                       renderData ={
-                        title: 'Reports', 
-                        user: req.user, 
+                        title: 'Reports',
+                        user: req.user,
                         fromClosingDate: fromDate,
-                        toClosingDate: toDate, 
+                        toClosingDate: toDate,
                         formattedFromDate: formattedFromDate,
                         formattedToDate: formattedToDate,
-                        credits: credits, 
+                        credits: credits,
                         company_id: cid,
                         creditstmt: Creditstmtlist,
                         openingbalance: OpeningBal,
                         closingbalance: closingBal,
-                        cidparam: cid, 
+                        cidparam: cid,
                         totalDebits: totalDebits,
                         totalCredits: totalCredits,
                         showVehicleBreakup: showVehicleBreakup,
+                        showPeriodSummary: showPeriodSummary === 'Y',
+                        statementNumber: statementNumber,
+                        balanceCrDr: balanceCrDrFormat === 'Y',
+                        showBalance: showBalanceCol === 'Y',
                         enableCreditExcelDownload: (await locationConfig.getLocationConfigValue(locationCode, 'ENABLE_CREDIT_REPORT_EXCEL_DOWNLOAD', 'N')) === 'Y',
                       }
 

--- a/dao/report-dao.js
+++ b/dao/report-dao.js
@@ -248,6 +248,16 @@ getCreditStmt: (locationCode, closingQueryFromDate, closingQueryToDate, creditId
     );
 },
 
+createStatementRecord: (locationCode, creditlistId, fromDate, toDate, reportType, generatedBy) => {
+    return db.sequelize.query(
+        `INSERT INTO t_credit_statement (location_code, creditlist_id, from_date, to_date, report_type, generated_by)
+         VALUES (:locationCode, :creditlistId, :fromDate, :toDate, :reportType, :generatedBy)`,
+        {
+            replacements: { locationCode, creditlistId: creditlistId || null, fromDate, toDate, reportType, generatedBy: generatedBy || null },
+            type: db.Sequelize.QueryTypes.INSERT
+        }
+    ).then(([insertId]) => insertId);
+},
 
 
 // MODIFIED getDigitalStmt METHOD

--- a/db/migrations/credit-statement-seq.sql
+++ b/db/migrations/credit-statement-seq.sql
@@ -1,0 +1,17 @@
+-- Migration: create t_credit_statement for statement number sequencing
+-- Purpose: each time a credit detail/ledger report is generated with
+--          SHOW_STATEMENT_NUMBER=Y, a row is inserted and the auto-increment
+--          ID (starting at 1000) becomes the statement number.
+-- Run on: all environments (dev, prod)
+
+CREATE TABLE IF NOT EXISTS t_credit_statement (
+    statement_id   INT          NOT NULL AUTO_INCREMENT,
+    location_code  VARCHAR(10)  NOT NULL,
+    creditlist_id  INT,
+    from_date      DATE         NOT NULL,
+    to_date        DATE         NOT NULL,
+    report_type    VARCHAR(20)  NOT NULL,
+    generated_by   VARCHAR(100),
+    generated_at   DATETIME     NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (statement_id)
+) AUTO_INCREMENT = 1000;

--- a/views/reports-credit-ledger.pug
+++ b/views/reports-credit-ledger.pug
@@ -62,34 +62,37 @@ block content
         if creditstmt && creditstmt.length > 0
             - var companyName = creditstmt[0].companyName
             - var cidparam = creditstmt[0].cidparam
+            - function displayBalance(bal) { var fmt = new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }); if (balanceCrDr) { var a = Math.abs(bal); var f = fmt.format(a); if (bal > 0) return f + ' DR'; if (bal < 0) return f + ' CR'; return '0.00'; } return fmt.format(bal); }
             div.row &nbsp;
             h6.font-weight-bold.text-center= "Credit Ledger"
             if(cidparam == -1)
                 h5.font-weight-bold.text-center.text-uppercase= 'All Companies'
             else
                 h5.font-weight-bold.text-center.text-uppercase= companyName                 
-                h6.text-center.text-muted= `${formattedFromDate}   to   ${formattedToDate}`      
+                h6.text-center.text-muted= `${formattedFromDate}   to   ${formattedToDate}`
             h4.font-weight-bold.text-success.text-center
+            if statementNumber
+                h6.text-center.text-muted= `Statement No: ${statementNumber}`
             .container
                 .row.justify-content-center
                     .col-12
-                        if(cidparam != -1 && typeof totalDebits !== 'undefined' && typeof totalCredits !== 'undefined')
+                        if(cidparam != -1 && showPeriodSummary && typeof totalDebits !== 'undefined' && typeof totalCredits !== 'undefined')
                             .alert.mb-4.period-summary(style="background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 8px; padding: 20px;")
                                 div(style="font-size: 1.1em; color: #495057; line-height: 1.6;")
                                     div(style="text-align: center; margin-bottom: 15px;")
                                         strong(style="font-size: 1.2em; color: #212529;") Period Summary
                                     div(style="text-align: right; margin-bottom: 4px;")
-                                        span(style="display: inline-block; width: 80px; text-align: right; padding-right: 10px;") Opening: 
-                                        span(style="font-weight: 600;")  #{new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(openingbalance)}
+                                        span(style="display: inline-block; width: 80px; text-align: right; padding-right: 10px;") Opening:
+                                        span(style="font-weight: 600;")= displayBalance(openingbalance)
                                     div(style="text-align: right; margin-bottom: 4px;")
-                                        span(style="display: inline-block; width: 80px; text-align: right; padding-right: 10px;") Invoices: 
+                                        span(style="display: inline-block; width: 80px; text-align: right; padding-right: 10px;") Invoices:
                                         span(style="font-weight: 600;") #{new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(totalDebits)}
                                     div(style="text-align: right; margin-bottom: 4px;")
-                                        span(style="display: inline-block; width: 80px; text-align: right; padding-right: 10px;") Payments: 
+                                        span(style="display: inline-block; width: 80px; text-align: right; padding-right: 10px;") Payments:
                                         span(style="font-weight: 600;") #{new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(totalCredits)}
                                     div(style="text-align: right; margin-bottom: 4px;")
-                                        span(style="display: inline-block; width: 80px; text-align: right; padding-right: 10px;") Closing: 
-                                        span(style="color: #495057;font-weight: 600;") #{new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(closingbalance)}
+                                        span(style="display: inline-block; width: 80px; text-align: right; padding-right: 10px;") Closing:
+                                        span(style="color: #495057;font-weight: 600;")= displayBalance(closingbalance)
                         table.table.table-bordered.border.table-sm
                             thead(class="thead-light")
                                 tr
@@ -97,23 +100,27 @@ block content
                                     th.text-center Particulars                                              
                                     th.text-center Debit (Rs.)
                                     th.text-center Credit (Rs.)
-                                    th.text-center Balance (Rs.)
+                                    if showBalance
+                                        th.text-center Balance (Rs.)
                                     th.text-center Narration
                             tbody
                                 if(cidparam != -1)
-                                    tr  
+                                    tr
                                         td &nbsp;
                                         td.text-left.font-weight-bold Opening Balance
                                         td &nbsp;
-                                        td &nbsp;                           
-                                        td.text-right.font-weight-bold #{new Intl.NumberFormat('en-IN',{ minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(openingbalance)}                      
+                                        td &nbsp;
+                                        td.text-right.font-weight-bold= displayBalance(openingbalance)
+                                        if showBalance
+                                            td &nbsp;
                                 each val in creditstmt
                                     tr(class=(val.price === null ? 'font-weight-bold text-success' : ''))
                                         td.text-center(scope="row")= val.Date                            
                                         td.text-left(scope="row")= val.Particulars                                                        
                                         td.text-right(scope="row") #{val.Debit !== null ? new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(val.Debit) : ''}
                                         td.text-right(scope="row") #{val.Credit !== null ? new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(val.Credit) : ''}
-                                        td.text-right(scope="row") #{val.Balance !== null ? new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(val.Balance) : ''}                            
+                                        if showBalance
+                                            td.text-right(scope="row")= val.Balance !== null ? displayBalance(val.Balance) : ''
                                         td(scope="row")= val.Narration                                                        
                                 if(totalDebits > 0 || totalCredits > 0)
                                     tr.bg-light.font-weight-bold
@@ -121,15 +128,18 @@ block content
                                         td.text-left Total
                                         td.text-right #{new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(totalDebits)}
                                         td.text-right #{new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(totalCredits)}
-                                        td &nbsp;
+                                        if showBalance
+                                            td &nbsp;
                                         td &nbsp;
                                 if(cidparam != -1)
                                     tr
-                                        td &nbsp;                                     
-                                        td.text-left.font-weight-bold Closing Balance 
                                         td &nbsp;
-                                        td &nbsp;                                                  
-                                        td.text-right.font-weight-bold #{new Intl.NumberFormat('en-IN',{ minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(closingbalance)}                      
+                                        td.text-left.font-weight-bold Closing Balance
+                                        td &nbsp;
+                                        td &nbsp;
+                                        td.text-right.font-weight-bold= displayBalance(closingbalance)
+                                        if showBalance
+                                            td &nbsp;
                         div.col-12.text-right E &amp; OE
                         div.col-12.text-center Any discrepencies in this report should be reported to the management within 2 days of the report being generated.                
         else

--- a/views/reports.pug
+++ b/views/reports.pug
@@ -65,27 +65,30 @@ block content
             - var showPriceDiscountColumn = creditstmt.some(val => val['Price Discount'] != null && val['Price Discount'] != '' && val['Price Discount'] != 0)
             - var showVehicleColumn = creditstmt.some(val => val['Vehicle Number'] != null && val['Vehicle Number'] != '')
             - var showOdometerColumn = creditstmt.some(val => val['Odometer Reading'] != null && val['Odometer Reading'] != '')
+            - function displayBalance(bal) { var fmt = new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }); if (balanceCrDr) { var a = Math.abs(bal); var f = fmt.format(a); if (bal > 0) return f + ' DR'; if (bal < 0) return f + ' CR'; return '0.00'; } return fmt.format(bal); }
             div.row &nbsp;
-            h6.font-weight-bold.text-center= "Credit Detail Report"
+            h6.font-weight-bold.text-center= "Credit Statement"
             if(cidparam == -1)
                 h5.font-weight-bold.text-center.text-uppercase= 'All Companies'
             else
                 h5.font-weight-bold.text-center.text-uppercase= companyName                 
-                h6.text-center.text-muted= `${formattedFromDate}   to   ${formattedToDate}`      
+                h6.text-center.text-muted= `${formattedFromDate}   to   ${formattedToDate}`
             h4.font-weight-bold.text-success.text-center
-            
+            if statementNumber
+                h6.text-center.text-muted= `Statement No: ${statementNumber}`
+
             .container
                 .row.justify-content-center
                     .col-12
                         // Period Summary Section
-                        if(cidparam != -1 && typeof totalDebits !== 'undefined' && typeof totalCredits !== 'undefined')
+                        if(cidparam != -1 && showPeriodSummary && typeof totalDebits !== 'undefined' && typeof totalCredits !== 'undefined')
                             .alert.mb-4.period-summary(style="background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 8px; padding: 20px;")
                                 div(style="font-size: 1.1em; color: #495057; line-height: 1.6;")
                                     div(style="text-align: center; margin-bottom: 15px;")
                                         strong(style="font-size: 1.2em; color: #212529;") Period Summary
                                     div(style="text-align: right; margin-bottom: 4px;")
                                         span(style="display: inline-block; width: 80px; text-align: right; padding-right: 10px;") Opening:
-                                        span(style="font-weight: 600;") #{new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(openingbalance)}
+                                        span(style="font-weight: 600;")= displayBalance(openingbalance)
                                     div(style="text-align: right; margin-bottom: 4px;")
                                         span(style="display: inline-block; width: 80px; text-align: right; padding-right: 10px;") Invoices:
                                         span(style="font-weight: 600;") #{new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(totalDebits)}
@@ -94,7 +97,7 @@ block content
                                         span(style="font-weight: 600;") #{new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(totalCredits)}
                                     div(style="text-align: right; margin-bottom: 4px;")
                                         span(style="display: inline-block; width: 80px; text-align: right; padding-right: 10px;") Closing:
-                                        span(style="color: #495057;font-weight: 600;") #{new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(closingbalance)}
+                                        span(style="color: #495057;font-weight: 600;")= displayBalance(closingbalance)
 
                         // Detailed Transaction Table
                         table.table.table-bordered.border.table-sm
@@ -113,11 +116,12 @@ block content
                                     th.text-center Quantity
                                     th.text-center Debit (Rs.)
                                     th.text-center Credit (Rs.)
-                                    th.text-center Balance (Rs.)
+                                    if showBalance
+                                        th.text-center Balance (Rs.)
                                     th.text-center Narration
                             tbody
                                 if(cidparam != -1)
-                                    tr  
+                                    tr
                                         td &nbsp;
                                         td.text-left.font-weight-bold Opening Balance
                                         td &nbsp;
@@ -130,9 +134,10 @@ block content
                                             td &nbsp;
                                         td &nbsp;
                                         td &nbsp;
-                                        td &nbsp;                           
-                                        td.text-right.font-weight-bold #{new Intl.NumberFormat('en-IN',{ minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(openingbalance)}
-                                        td &nbsp;                      
+                                        td &nbsp;
+                                        td.text-right.font-weight-bold= displayBalance(openingbalance)
+                                        if showBalance
+                                            td &nbsp;
                                 each val in creditstmt
                                     tr(class=(val.price === null ? 'font-weight-bold text-success' : ''))
                                         td.text-center(scope="row")= val.Date                            
@@ -148,12 +153,13 @@ block content
                                         td.text-right(scope="row") #{val.Qty !== null ? new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(val.Qty) : ''}                                                        
                                         td.text-right(scope="row") #{val.Debit !== null ? new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(val.Debit) : ''}
                                         td.text-right(scope="row") #{val.Credit !== null ? new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(val.Credit) : ''}
-                                        td.text-right(scope="row") #{val.Balance !== null ? new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(val.Balance) : ''}                            
+                                        if showBalance
+                                            td.text-right(scope="row")= val.Balance !== null ? displayBalance(val.Balance) : ''
                                         td(scope="row")= val.Narration                                
                                 // Closing Balance Row
                                 if(cidparam != -1)
                                     tr
-                                        td &nbsp;                                     
+                                        td &nbsp;
                                         td.text-left.font-weight-bold Closing Balance
                                         td &nbsp;
                                         td &nbsp;
@@ -165,10 +171,11 @@ block content
                                             td &nbsp;
                                         td &nbsp;
                                         td &nbsp;
-                                        td &nbsp;                                                  
-                                        td.text-right.font-weight-bold #{new Intl.NumberFormat('en-IN',{ minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(closingbalance)}
-                                        td &nbsp;                      
-                        
+                                        td &nbsp;
+                                        td.text-right.font-weight-bold= displayBalance(closingbalance)
+                                        if showBalance
+                                            td &nbsp;
+
                         div.col-12
                         
                             // Vehicle Breakup Addendum


### PR DESCRIPTION
## Summary
- Report title renamed from \"Credit Detail Report\" to \"Credit Statement\"
- All new behaviours are config-gated via `CREDIT_STMT_*` location config keys:
  - `CREDIT_STMT_SHOW_PERIOD_SUMMARY` (default `Y`) — hide the period summary box
  - `CREDIT_STMT_SHOW_STATEMENT_NUMBER` (default `N`) — sequential statement number from `t_credit_statement` (starts at 1000)
  - `CREDIT_STMT_BALANCE_CRDR_FORMAT` (default `N`) — show balance as `1,234.56 DR/CR` instead of plain number
  - `CREDIT_STMT_SHOW_BALANCE` (default `Y`) — hide running balance column while keeping opening/closing balance rows
- Odometer column auto-hidden when all readings are zero

## DB changes (already applied on dev and prod)
- Run `db/migrations/credit-statement-seq.sql` to create `t_credit_statement`
- Insert the 4 `CREDIT_STMT_*` rows into `m_location_config`

## Test plan
- [ ] Credit Statement report renders correctly for a single company
- [ ] Statement number increments on each generation when config is Y
- [ ] Period summary shows/hides based on config
- [ ] Balance column hides but opening/closing balance rows remain visible
- [ ] CR/DR suffix appears on balances when config is Y
- [ ] Odometer column absent when all readings are 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)