### PR TITLE
Onboarding: web-based onboarding form

### DIFF
--- a/app.js
+++ b/app.js
@@ -250,6 +250,8 @@ const documentRoutes  = require('./routes/document-routes');
 const tankReceiptRoutes = require('./routes/tank-receipt-routes');
 const purchasesRoutes   = require('./routes/purchases-routes');
 const devDbRefreshRoutes = require('./routes/dev-db-refresh-routes');
+const onboardingRoutes = require('./routes/onboarding-routes');
+const onboardingAdminRoutes = require('./routes/onboarding-admin-routes');
 
 //const auditingUtilitiesRoutes = require('./routes/auditing-utilities-routes');
 
@@ -423,6 +425,8 @@ app.use('/documents', documentRoutes);
 app.use('/gl', glRoutes);
 app.use('/dev-db-refresh', devDbRefreshRoutes);
 app.use('/bowser', bowserRoutes);
+app.use('/onboard', onboardingRoutes);
+app.use('/admin/onboarding', onboardingAdminRoutes);
 
 
 

--- a/controllers/onboarding-controller.js
+++ b/controllers/onboarding-controller.js
@@ -1,0 +1,149 @@
+// controllers/onboarding-controller.js
+const { randomUUID } = require('crypto');
+const OnboardingDao = require('../dao/onboarding-dao');
+const dateFormat = require('dateformat');
+
+function formatDateForInput(d) {
+    if (!d) return '';
+    return new Date(d).toISOString().split('T')[0];
+}
+
+function formatDateForDisplay(d) {
+    if (!d) return '';
+    return dateFormat(new Date(d), 'dd-mmm-yyyy');
+}
+
+module.exports = {
+    // ── Public form ────────────────────────────────────────────────────────────
+    getForm: async (req, res, next) => {
+        try {
+            const onboarding = await OnboardingDao.findByToken(req.params.token);
+            if (!onboarding) {
+                return res.status(404).render('error', { message: 'Onboarding link not found or expired.', error: {} });
+            }
+            const formData = await OnboardingDao.getAllData(onboarding.id);
+            formData.nozzles = formData.nozzles.map(n => ({
+                ...n,
+                next_stamping_date: formatDateForInput(n.next_stamping_date),
+            }));
+            res.render('onboarding/form', {
+                title: `Onboarding – ${onboarding.location_name}`,
+                token: req.params.token,
+                onboarding,
+                formData,
+            });
+        } catch (e) {
+            next(e);
+        }
+    },
+
+    upsertRo: async (req, res, next) => {
+        try {
+            const onboarding = await OnboardingDao.findByToken(req.params.token);
+            if (!onboarding) return res.status(404).json({ error: 'Not found' });
+            await OnboardingDao.upsertRo(onboarding.id, req.body);
+            res.json({ ok: true });
+        } catch (e) {
+            next(e);
+        }
+    },
+
+    addRow: async (req, res, next) => {
+        try {
+            const { token, section } = req.params;
+            if (!OnboardingDao.SECTION_MAP[section]) return res.status(400).json({ error: 'Invalid section' });
+            const onboarding = await OnboardingDao.findByToken(token);
+            if (!onboarding) return res.status(404).json({ error: 'Not found' });
+            const id = await OnboardingDao.addRow(onboarding.id, section);
+            res.json({ id });
+        } catch (e) {
+            next(e);
+        }
+    },
+
+    updateRow: async (req, res, next) => {
+        try {
+            const { token, section, rowId } = req.params;
+            if (!OnboardingDao.SECTION_MAP[section]) return res.status(400).json({ error: 'Invalid section' });
+            const onboarding = await OnboardingDao.findByToken(token);
+            if (!onboarding) return res.status(404).json({ error: 'Not found' });
+            await OnboardingDao.updateRow(onboarding.id, section, parseInt(rowId, 10), req.body);
+            res.json({ ok: true });
+        } catch (e) {
+            next(e);
+        }
+    },
+
+    deleteRow: async (req, res, next) => {
+        try {
+            const { token, section, rowId } = req.params;
+            if (!OnboardingDao.SECTION_MAP[section]) return res.status(400).json({ error: 'Invalid section' });
+            const onboarding = await OnboardingDao.findByToken(token);
+            if (!onboarding) return res.status(404).json({ error: 'Not found' });
+            await OnboardingDao.deleteRow(onboarding.id, section, parseInt(rowId, 10));
+            res.json({ ok: true });
+        } catch (e) {
+            next(e);
+        }
+    },
+
+    // ── Admin ──────────────────────────────────────────────────────────────────
+    adminList: async (req, res, next) => {
+        try {
+            const onboardings = await OnboardingDao.findAll();
+            res.render('onboarding/admin-list', {
+                title: 'Onboarding',
+                user: req.user,
+                onboardings,
+                baseUrl: `${req.protocol}://${req.get('host')}`,
+            });
+        } catch (e) {
+            next(e);
+        }
+    },
+
+    adminCreate: async (req, res, next) => {
+        try {
+            const { location_name } = req.body;
+            if (!location_name?.trim()) return res.status(400).json({ error: 'Location name is required' });
+            const token = randomUUID();
+            const id = await OnboardingDao.create(location_name.trim(), req.user.Person_id, token);
+            const url = `${req.protocol}://${req.get('host')}/onboard/${token}`;
+            res.json({ id, token, url });
+        } catch (e) {
+            next(e);
+        }
+    },
+
+    adminDetail: async (req, res, next) => {
+        try {
+            const onboarding = await OnboardingDao.findById(req.params.id);
+            if (!onboarding) return res.status(404).render('error', { message: 'Not found', error: {} });
+            const formData = await OnboardingDao.getAllData(onboarding.id);
+            formData.nozzles = formData.nozzles.map(n => ({
+                ...n,
+                next_stamping_date: formatDateForDisplay(n.next_stamping_date),
+            }));
+            res.render('onboarding/admin-detail', {
+                title: `Onboarding – ${onboarding.location_name}`,
+                user: req.user,
+                onboarding,
+                formData,
+                baseUrl: `${req.protocol}://${req.get('host')}`,
+            });
+        } catch (e) {
+            next(e);
+        }
+    },
+
+    adminUpdateStatus: async (req, res, next) => {
+        try {
+            const { status, notes } = req.body;
+            if (!['active', 'setup_done'].includes(status)) return res.status(400).json({ error: 'Invalid status' });
+            await OnboardingDao.updateStatus(req.params.id, status, notes);
+            res.json({ ok: true });
+        } catch (e) {
+            next(e);
+        }
+    },
+};

--- a/dao/onboarding-dao.js
+++ b/dao/onboarding-dao.js
@@ -1,0 +1,152 @@
+// dao/onboarding-dao.js
+const db = require('../db/db-connection');
+const { QueryTypes } = require('sequelize');
+
+const SECTION_MAP = {
+    'employees':        { table: 't_onboarding_employees',        fields: ['employee_name', 'designation'] },
+    'metered-products': { table: 't_onboarding_metered_products', fields: ['product_name', 'short_name'] },
+    'tanks':            { table: 't_onboarding_tanks',            fields: ['tank_name', 'tank_capacity', 'tank_short_name', 'product_short_name'] },
+    'nozzles':          { table: 't_onboarding_nozzles',          fields: ['nozzle_name', 'nozzle_product', 'du_make', 'tank_connected', 'next_stamping_date'] },
+    'lubes':            { table: 't_onboarding_lubes',            fields: ['product_name', 'unit', 'selling_price'] },
+    'banks':            { table: 't_onboarding_banks',            fields: ['bank_name', 'short_name', 'branch', 'account_name', 'account_last4', 'account_type'] },
+    'digital':          { table: 't_onboarding_digital',          fields: ['platform_name'] },
+    'customers':        { table: 't_onboarding_customers',        fields: ['customer_name', 'address', 'gstin', 'owner_name', 'owner_mobile', 'manager_name', 'manager_mobile', 'customer_type'] },
+    'suppliers':        { table: 't_onboarding_suppliers',        fields: ['supplier_name', 'short_name'] },
+};
+
+module.exports = {
+    SECTION_MAP,
+
+    findByToken: async (token) => {
+        const [row] = await db.sequelize.query(
+            'SELECT * FROM t_onboarding WHERE token = :token',
+            { replacements: { token }, type: QueryTypes.SELECT }
+        );
+        return row || null;
+    },
+
+    findById: async (id) => {
+        const [row] = await db.sequelize.query(
+            'SELECT * FROM t_onboarding WHERE id = :id',
+            { replacements: { id }, type: QueryTypes.SELECT }
+        );
+        return row || null;
+    },
+
+    findAll: async () => {
+        return db.sequelize.query(
+            'SELECT * FROM t_onboarding ORDER BY created_at DESC',
+            { type: QueryTypes.SELECT }
+        );
+    },
+
+    create: async (locationName, personId, token) => {
+        const [insertId] = await db.sequelize.query(
+            'INSERT INTO t_onboarding (token, location_name, created_by_person_id) VALUES (:token, :locationName, :personId)',
+            { replacements: { token, locationName, personId }, type: QueryTypes.INSERT }
+        );
+        return insertId;
+    },
+
+    updateStatus: async (id, status, notes) => {
+        await db.sequelize.query(
+            'UPDATE t_onboarding SET status = :status, notes = :notes WHERE id = :id',
+            { replacements: { id, status, notes: notes ?? null }, type: QueryTypes.UPDATE }
+        );
+    },
+
+    getRo: async (onboardingId) => {
+        const [row] = await db.sequelize.query(
+            'SELECT * FROM t_onboarding_ro WHERE onboarding_id = :onboardingId',
+            { replacements: { onboardingId }, type: QueryTypes.SELECT }
+        );
+        return row || {};
+    },
+
+    upsertRo: async (onboardingId, data) => {
+        const { ro_name, owner_contact, ro_brand, ro_address, location_link } = data;
+        await db.sequelize.query(`
+            INSERT INTO t_onboarding_ro (onboarding_id, ro_name, owner_contact, ro_brand, ro_address, location_link)
+            VALUES (:onboardingId, :ro_name, :owner_contact, :ro_brand, :ro_address, :location_link)
+            ON DUPLICATE KEY UPDATE
+                ro_name       = VALUES(ro_name),
+                owner_contact = VALUES(owner_contact),
+                ro_brand      = VALUES(ro_brand),
+                ro_address    = VALUES(ro_address),
+                location_link = VALUES(location_link)
+        `, {
+            replacements: {
+                onboardingId,
+                ro_name:       ro_name       || null,
+                owner_contact: owner_contact || null,
+                ro_brand:      ro_brand      || null,
+                ro_address:    ro_address    || null,
+                location_link: location_link || null,
+            },
+            type: QueryTypes.INSERT
+        });
+    },
+
+    getSection: async (onboardingId, section) => {
+        const { table } = SECTION_MAP[section];
+        return db.sequelize.query(
+            `SELECT * FROM ${table} WHERE onboarding_id = :onboardingId ORDER BY sort_order, id`,
+            { replacements: { onboardingId }, type: QueryTypes.SELECT }
+        );
+    },
+
+    addRow: async (onboardingId, section) => {
+        const { table } = SECTION_MAP[section];
+        const [maxRow] = await db.sequelize.query(
+            `SELECT COALESCE(MAX(sort_order), 0) + 1 AS next_order FROM ${table} WHERE onboarding_id = :onboardingId`,
+            { replacements: { onboardingId }, type: QueryTypes.SELECT }
+        );
+        const [insertId] = await db.sequelize.query(
+            `INSERT INTO ${table} (onboarding_id, sort_order) VALUES (:onboardingId, :nextOrder)`,
+            { replacements: { onboardingId, nextOrder: maxRow.next_order }, type: QueryTypes.INSERT }
+        );
+        return insertId;
+    },
+
+    updateRow: async (onboardingId, section, rowId, data) => {
+        const { table, fields } = SECTION_MAP[section];
+        const allowed = {};
+        for (const f of fields) {
+            if (f in data) {
+                allowed[f] = (data[f] === '' || data[f] === undefined) ? null : data[f];
+            }
+        }
+        if (Object.keys(allowed).length === 0) return;
+        const setClauses = Object.keys(allowed).map(f => `${f} = :${f}`).join(', ');
+        await db.sequelize.query(
+            `UPDATE ${table} SET ${setClauses} WHERE id = :rowId AND onboarding_id = :onboardingId`,
+            { replacements: { ...allowed, rowId, onboardingId }, type: QueryTypes.UPDATE }
+        );
+    },
+
+    deleteRow: async (onboardingId, section, rowId) => {
+        const { table } = SECTION_MAP[section];
+        await db.sequelize.query(
+            `DELETE FROM ${table} WHERE id = :rowId AND onboarding_id = :onboardingId`,
+            { replacements: { rowId, onboardingId }, type: QueryTypes.DELETE }
+        );
+    },
+
+    getAllData: async (onboardingId) => {
+        const dao = module.exports;
+        const [ro, employees, metered_products, tanks, nozzles, lubes, banks, digital, customers, suppliers] =
+            await Promise.all([
+                dao.getRo(onboardingId),
+                dao.getSection(onboardingId, 'employees'),
+                dao.getSection(onboardingId, 'metered-products'),
+                dao.getSection(onboardingId, 'tanks'),
+                dao.getSection(onboardingId, 'nozzles'),
+                dao.getSection(onboardingId, 'lubes'),
+                dao.getSection(onboardingId, 'banks'),
+                dao.getSection(onboardingId, 'digital'),
+                dao.getSection(onboardingId, 'customers'),
+                dao.getSection(onboardingId, 'suppliers'),
+            ]);
+        return { ro, employees, metered_products, tanks, nozzles, lubes, banks, digital, customers, suppliers };
+    },
+};

--- a/db/migrations/onboarding.sql
+++ b/db/migrations/onboarding.sql
@@ -1,0 +1,120 @@
+-- Web-based onboarding form tables
+
+CREATE TABLE IF NOT EXISTS t_onboarding (
+    id                   INT AUTO_INCREMENT PRIMARY KEY,
+    token                VARCHAR(36)  UNIQUE NOT NULL,
+    location_name        VARCHAR(200) NOT NULL,
+    status               ENUM('active', 'setup_done') DEFAULT 'active',
+    notes                TEXT,
+    created_by_person_id INT,
+    created_at           TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS t_onboarding_ro (
+    id            INT AUTO_INCREMENT PRIMARY KEY,
+    onboarding_id INT NOT NULL,
+    ro_name       VARCHAR(200),
+    owner_contact VARCHAR(100),
+    ro_brand      VARCHAR(50),
+    ro_address    TEXT,
+    location_link TEXT,
+    updated_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_ob_ro (onboarding_id),
+    CONSTRAINT fk_ob_ro FOREIGN KEY (onboarding_id) REFERENCES t_onboarding(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS t_onboarding_employees (
+    id            INT AUTO_INCREMENT PRIMARY KEY,
+    onboarding_id INT NOT NULL,
+    employee_name VARCHAR(200),
+    designation   VARCHAR(100),
+    sort_order    INT DEFAULT 0,
+    CONSTRAINT fk_ob_emp FOREIGN KEY (onboarding_id) REFERENCES t_onboarding(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS t_onboarding_metered_products (
+    id            INT AUTO_INCREMENT PRIMARY KEY,
+    onboarding_id INT NOT NULL,
+    product_name  VARCHAR(200),
+    short_name    VARCHAR(50),
+    sort_order    INT DEFAULT 0,
+    CONSTRAINT fk_ob_mprod FOREIGN KEY (onboarding_id) REFERENCES t_onboarding(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS t_onboarding_tanks (
+    id                 INT AUTO_INCREMENT PRIMARY KEY,
+    onboarding_id      INT NOT NULL,
+    tank_name          VARCHAR(200),
+    tank_capacity      INT,
+    tank_short_name    VARCHAR(50),
+    product_short_name VARCHAR(100),
+    sort_order         INT DEFAULT 0,
+    CONSTRAINT fk_ob_tank FOREIGN KEY (onboarding_id) REFERENCES t_onboarding(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS t_onboarding_nozzles (
+    id                 INT AUTO_INCREMENT PRIMARY KEY,
+    onboarding_id      INT NOT NULL,
+    nozzle_name        VARCHAR(200),
+    nozzle_product     VARCHAR(100),
+    du_make            VARCHAR(100),
+    tank_connected     VARCHAR(200),
+    next_stamping_date DATE,
+    sort_order         INT DEFAULT 0,
+    CONSTRAINT fk_ob_nozzle FOREIGN KEY (onboarding_id) REFERENCES t_onboarding(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS t_onboarding_lubes (
+    id            INT AUTO_INCREMENT PRIMARY KEY,
+    onboarding_id INT NOT NULL,
+    product_name  VARCHAR(200),
+    unit          VARCHAR(50),
+    selling_price DECIMAL(10, 2),
+    sort_order    INT DEFAULT 0,
+    CONSTRAINT fk_ob_lube FOREIGN KEY (onboarding_id) REFERENCES t_onboarding(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS t_onboarding_banks (
+    id            INT AUTO_INCREMENT PRIMARY KEY,
+    onboarding_id INT NOT NULL,
+    bank_name     VARCHAR(200),
+    short_name    VARCHAR(100),
+    branch        VARCHAR(200),
+    account_name  VARCHAR(200),
+    account_last4 VARCHAR(10),
+    account_type  VARCHAR(50),
+    sort_order    INT DEFAULT 0,
+    CONSTRAINT fk_ob_bank FOREIGN KEY (onboarding_id) REFERENCES t_onboarding(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS t_onboarding_digital (
+    id            INT AUTO_INCREMENT PRIMARY KEY,
+    onboarding_id INT NOT NULL,
+    platform_name VARCHAR(200),
+    sort_order    INT DEFAULT 0,
+    CONSTRAINT fk_ob_digital FOREIGN KEY (onboarding_id) REFERENCES t_onboarding(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS t_onboarding_customers (
+    id             INT AUTO_INCREMENT PRIMARY KEY,
+    onboarding_id  INT NOT NULL,
+    customer_name  VARCHAR(200),
+    address        TEXT,
+    gstin          VARCHAR(20),
+    owner_name     VARCHAR(200),
+    owner_mobile   VARCHAR(15),
+    manager_name   VARCHAR(200),
+    manager_mobile VARCHAR(15),
+    customer_type  VARCHAR(20),
+    sort_order     INT DEFAULT 0,
+    CONSTRAINT fk_ob_cust FOREIGN KEY (onboarding_id) REFERENCES t_onboarding(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS t_onboarding_suppliers (
+    id            INT AUTO_INCREMENT PRIMARY KEY,
+    onboarding_id INT NOT NULL,
+    supplier_name VARCHAR(200),
+    short_name    VARCHAR(100),
+    sort_order    INT DEFAULT 0,
+    CONSTRAINT fk_ob_supp FOREIGN KEY (onboarding_id) REFERENCES t_onboarding(id) ON DELETE CASCADE
+);

--- a/public/javascripts/onboarding-form.js
+++ b/public/javascripts/onboarding-form.js
@@ -1,0 +1,277 @@
+'use strict';
+
+// TOKEN injected by server in the Pug template
+const TOKEN = window.ONBOARD_TOKEN;
+
+// ── Save indicator ─────────────────────────────────────────────────────────────
+let _pendingSaves = 0;
+const _indicator = () => document.getElementById('save-indicator');
+
+function setSaving() {
+    _pendingSaves++;
+    const el = _indicator();
+    el.className = 'save-indicator saving';
+    el.textContent = 'Saving…';
+}
+
+function setSaved() {
+    _pendingSaves = Math.max(0, _pendingSaves - 1);
+    if (_pendingSaves === 0) {
+        const el = _indicator();
+        el.className = 'save-indicator saved';
+        el.textContent = 'All changes saved ✓';
+    }
+}
+
+function setSaveError() {
+    _pendingSaves = Math.max(0, _pendingSaves - 1);
+    const el = _indicator();
+    el.className = 'save-indicator error';
+    el.textContent = 'Save failed – check connection';
+}
+
+// ── RO save (debounced) ────────────────────────────────────────────────────────
+let _roTimer = null;
+
+function scheduleRoSave() {
+    clearTimeout(_roTimer);
+    _roTimer = setTimeout(saveRo, 800);
+}
+
+async function saveRo() {
+    const data = {};
+    document.querySelectorAll('#tab-ro [data-field]').forEach(el => {
+        data[el.dataset.field] = el.value;
+    });
+    setSaving();
+    try {
+        const r = await fetch(`/onboard/${TOKEN}/ro`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data),
+        });
+        if (!r.ok) throw new Error();
+        setSaved();
+    } catch {
+        setSaveError();
+    }
+}
+
+// ── Row save (debounced) ───────────────────────────────────────────────────────
+const _rowTimers = {};
+
+function scheduleRowSave(section, rowId) {
+    const key = `${section}:${rowId}`;
+    clearTimeout(_rowTimers[key]);
+    _rowTimers[key] = setTimeout(() => saveRow(section, rowId), 800);
+}
+
+async function saveRow(section, rowId) {
+    const tr = document.querySelector(`tr[data-section="${section}"][data-row-id="${rowId}"]`);
+    if (!tr) return;
+    const data = {};
+    tr.querySelectorAll('[data-field]').forEach(el => { data[el.dataset.field] = el.value; });
+    setSaving();
+    try {
+        const r = await fetch(`/onboard/${TOKEN}/${section}/${rowId}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data),
+        });
+        if (!r.ok) throw new Error();
+        setSaved();
+        if (section === 'metered-products') refreshProductDropdowns();
+        if (section === 'tanks') refreshTankDropdowns();
+    } catch {
+        setSaveError();
+    }
+}
+
+// ── Add row ────────────────────────────────────────────────────────────────────
+async function addRow(section) {
+    try {
+        const r = await fetch(`/onboard/${TOKEN}/${section}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({}),
+        });
+        if (!r.ok) throw new Error();
+        const { id } = await r.json();
+        const tbody = document.getElementById(`tbody-${section}`);
+        tbody.insertAdjacentHTML('beforeend', buildNewRow(section, id));
+        if (section === 'tanks') refreshProductDropdowns();
+        if (section === 'nozzles') refreshTankDropdowns();
+    } catch {
+        alert('Failed to add row. Please try again.');
+    }
+}
+
+// ── Delete row ─────────────────────────────────────────────────────────────────
+async function deleteRow(section, rowId, btn) {
+    if (!confirm('Remove this row?')) return;
+    try {
+        const r = await fetch(`/onboard/${TOKEN}/${section}/${rowId}`, { method: 'DELETE' });
+        if (!r.ok) throw new Error();
+        btn.closest('tr').remove();
+        if (section === 'metered-products') refreshProductDropdowns();
+        if (section === 'tanks') refreshTankDropdowns();
+    } catch {
+        alert('Failed to delete row. Please try again.');
+    }
+}
+
+// ── Cross-reference helpers ────────────────────────────────────────────────────
+function getProductOptions() {
+    const opts = [];
+    document.querySelectorAll('#tbody-metered-products tr').forEach(tr => {
+        const v = tr.querySelector('[data-field="short_name"]')?.value?.trim();
+        if (v) opts.push(v);
+    });
+    return opts;
+}
+
+function getTankOptions() {
+    const opts = [];
+    document.querySelectorAll('#tbody-tanks tr').forEach(tr => {
+        const v = tr.querySelector('[data-field="tank_name"]')?.value?.trim();
+        if (v) opts.push(v);
+    });
+    return opts;
+}
+
+function escHtml(s) {
+    return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function refreshProductDropdowns() {
+    const products = getProductOptions();
+    document.querySelectorAll('#tbody-tanks [data-field="product_short_name"]').forEach(sel => {
+        const cur = sel.value;
+        sel.innerHTML = '<option value="">-- Select --</option>' +
+            products.map(p => `<option value="${escHtml(p)}"${cur === p ? ' selected' : ''}>${escHtml(p)}</option>`).join('');
+    });
+}
+
+function refreshTankDropdowns() {
+    const tanks = getTankOptions();
+    document.querySelectorAll('#tbody-nozzles [data-field="tank_connected"]').forEach(sel => {
+        const cur = sel.value;
+        sel.innerHTML = '<option value="">-- Select --</option>' +
+            tanks.map(t => `<option value="${escHtml(t)}"${cur === t ? ' selected' : ''}>${escHtml(t)}</option>`).join('');
+    });
+}
+
+// ── Build HTML for a new empty row ────────────────────────────────────────────
+function buildNewRow(section, id) {
+    const del = `<button type="button" class="btn btn-outline-danger btn-sm" onclick="deleteRow('${section}',${id},this)">×</button>`;
+
+    const productOpts = () => '<option value="">-- Select --</option>' +
+        getProductOptions().map(p => `<option value="${escHtml(p)}">${escHtml(p)}</option>`).join('');
+
+    const tankOpts = () => '<option value="">-- Select --</option>' +
+        getTankOptions().map(t => `<option value="${escHtml(t)}">${escHtml(t)}</option>`).join('');
+
+    const attr = `data-section="${section}" data-row-id="${id}"`;
+
+    const rows = {
+        'employees': `<tr ${attr}>
+            <td><input class="form-control form-control-sm" type="text" data-field="employee_name" placeholder="Name with Initial"></td>
+            <td><select class="form-control form-control-sm" data-field="designation">
+                <option value="">-- Select --</option>
+                <option>Manager</option><option>Cashier</option><option>Attendant</option>
+                <option>DSM</option><option>DSW</option><option>Owner</option>
+            </select></td>
+            <td class="text-center align-middle">${del}</td></tr>`,
+
+        'metered-products': `<tr ${attr}>
+            <td><input class="form-control form-control-sm" type="text" data-field="product_name" placeholder="As per Invoice e.g. EBMS"></td>
+            <td><input class="form-control form-control-sm" type="text" data-field="short_name" placeholder="e.g. MS / HSD"></td>
+            <td class="text-center align-middle">${del}</td></tr>`,
+
+        'tanks': `<tr ${attr}>
+            <td><input class="form-control form-control-sm" type="text" data-field="tank_name" placeholder="Tank Name"></td>
+            <td><input class="form-control form-control-sm" type="number" data-field="tank_capacity" placeholder="15000"></td>
+            <td><input class="form-control form-control-sm" type="text" data-field="tank_short_name" placeholder="e.g. MS1"></td>
+            <td><select class="form-control form-control-sm" data-field="product_short_name">${productOpts()}</select></td>
+            <td class="text-center align-middle">${del}</td></tr>`,
+
+        'nozzles': `<tr ${attr}>
+            <td><input class="form-control form-control-sm" type="text" data-field="nozzle_name" placeholder="e.g. MS 1.1"></td>
+            <td><input class="form-control form-control-sm" type="text" data-field="nozzle_product" placeholder="Short Name"></td>
+            <td><input class="form-control form-control-sm" type="text" data-field="du_make" placeholder="Tokheim / Gilbarco"></td>
+            <td><select class="form-control form-control-sm" data-field="tank_connected">${tankOpts()}</select></td>
+            <td><input class="form-control form-control-sm" type="date" data-field="next_stamping_date"></td>
+            <td class="text-center align-middle">${del}</td></tr>`,
+
+        'lubes': `<tr ${attr}>
+            <td><input class="form-control form-control-sm" type="text" data-field="product_name" placeholder="e.g. Servo 10W-40 1L"></td>
+            <td><select class="form-control form-control-sm" data-field="unit">
+                <option value="">-- Select --</option>
+                <option>Litres</option><option>Nos</option><option>Kgs</option>
+            </select></td>
+            <td><input class="form-control form-control-sm" type="number" step="0.01" data-field="selling_price" placeholder="0.00"></td>
+            <td class="text-center align-middle">${del}</td></tr>`,
+
+        'banks': `<tr ${attr}>
+            <td><input class="form-control form-control-sm" type="text" data-field="bank_name" placeholder="Bank Name"></td>
+            <td><input class="form-control form-control-sm" type="text" data-field="short_name" placeholder="Short Name"></td>
+            <td><input class="form-control form-control-sm" type="text" data-field="branch" placeholder="Branch"></td>
+            <td><input class="form-control form-control-sm" type="text" data-field="account_name" placeholder="Account Name"></td>
+            <td><input class="form-control form-control-sm" type="text" data-field="account_last4" placeholder="Last 4" maxlength="4"></td>
+            <td><select class="form-control form-control-sm" data-field="account_type">
+                <option value="">-- Select --</option>
+                <option>Current</option><option>Savings</option><option>Cash Credit</option><option>EDFS</option>
+            </select></td>
+            <td class="text-center align-middle">${del}</td></tr>`,
+
+        'digital': `<tr ${attr}>
+            <td><input class="form-control form-control-sm" type="text" data-field="platform_name" placeholder="e.g. Paytm / PhonePe / XTRAREWARDS"></td>
+            <td class="text-center align-middle">${del}</td></tr>`,
+
+        'customers': `<tr ${attr}>
+            <td><input class="form-control form-control-sm" type="text" data-field="customer_name" placeholder="Trade Name"></td>
+            <td><input class="form-control form-control-sm" type="text" data-field="address" placeholder="Billing Address"></td>
+            <td><input class="form-control form-control-sm" type="text" data-field="gstin" placeholder="GSTIN" maxlength="15"></td>
+            <td><input class="form-control form-control-sm" type="text" data-field="owner_name" placeholder="Owner Name"></td>
+            <td><input class="form-control form-control-sm" type="tel" data-field="owner_mobile" placeholder="10-digit" maxlength="10"></td>
+            <td><input class="form-control form-control-sm" type="text" data-field="manager_name" placeholder="Manager Name"></td>
+            <td><input class="form-control form-control-sm" type="tel" data-field="manager_mobile" placeholder="10-digit" maxlength="10"></td>
+            <td><select class="form-control form-control-sm" data-field="customer_type">
+                <option value="">-- Select --</option>
+                <option>Credit</option><option>Cash</option>
+            </select></td>
+            <td class="text-center align-middle">${del}</td></tr>`,
+
+        'suppliers': `<tr ${attr}>
+            <td><input class="form-control form-control-sm" type="text" data-field="supplier_name" placeholder="As per Invoice"></td>
+            <td><input class="form-control form-control-sm" type="text" data-field="short_name" placeholder="Short Name"></td>
+            <td class="text-center align-middle">${del}</td></tr>`,
+    };
+    return rows[section] || '';
+}
+
+// ── Init ───────────────────────────────────────────────────────────────────────
+document.addEventListener('DOMContentLoaded', () => {
+    // Set initial save indicator
+    const el = _indicator();
+    if (el) { el.className = 'save-indicator saved'; el.textContent = 'All changes saved ✓'; }
+
+    // Init cross-ref dropdowns from server-rendered rows
+    refreshProductDropdowns();
+    refreshTankDropdowns();
+
+    // RO tab inputs
+    document.getElementById('tab-ro')?.addEventListener('input', scheduleRoSave);
+
+    // All section table inputs (event delegation on the whole page)
+    document.getElementById('onboarding-sections')?.addEventListener('input', e => {
+        const tr = e.target.closest('tr[data-row-id]');
+        if (!tr) return;
+        scheduleRowSave(tr.dataset.section, tr.dataset.rowId);
+    });
+
+    // Add-row buttons
+    document.querySelectorAll('[data-add-section]').forEach(btn => {
+        btn.addEventListener('click', () => addRow(btn.dataset.addSection));
+    });
+});

--- a/routes/onboarding-admin-routes.js
+++ b/routes/onboarding-admin-routes.js
@@ -1,0 +1,14 @@
+// routes/onboarding-admin-routes.js — requires login
+const express = require('express');
+const router = express.Router();
+const login = require('connect-ensure-login');
+const ctrl = require('../controllers/onboarding-controller');
+
+const isLoggedIn = login.ensureLoggedIn({});
+
+router.get('/',            isLoggedIn, ctrl.adminList);
+router.post('/',           isLoggedIn, ctrl.adminCreate);
+router.get('/:id',         isLoggedIn, ctrl.adminDetail);
+router.patch('/:id/status', isLoggedIn, ctrl.adminUpdateStatus);
+
+module.exports = router;

--- a/routes/onboarding-routes.js
+++ b/routes/onboarding-routes.js
@@ -1,0 +1,12 @@
+// routes/onboarding-routes.js — public (no auth required)
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../controllers/onboarding-controller');
+
+router.get('/:token',                  ctrl.getForm);
+router.patch('/:token/ro',             ctrl.upsertRo);
+router.post('/:token/:section',        ctrl.addRow);
+router.patch('/:token/:section/:rowId', ctrl.updateRow);
+router.delete('/:token/:section/:rowId', ctrl.deleteRow);
+
+module.exports = router;

--- a/views/onboarding/admin-detail.pug
+++ b/views/onboarding/admin-detail.pug
@@ -1,0 +1,278 @@
+extends ../layout
+include ../mixins/mixins
+
+mixin detailSection(colId, label, open)
+    .card.mb-1
+        .card-header.py-2
+            button.btn.btn-link.btn-sm.font-weight-bold.text-left.w-100(
+                type="button"
+                data-toggle="collapse"
+                data-target='#' + colId
+                aria-expanded=(open ? 'true' : 'false')
+            )= label
+        div.collapse(id=colId class=(open ? 'show' : '') data-parent="#accordionData")
+            .card-body.py-2
+                block
+
+block content
+    .container-fluid.py-4
+
+        //- Header
+        .d-flex.justify-content-between.align-items-center.mb-3
+            div
+                a.text-muted.small(href="/admin/onboarding") ← All Onboardings
+                h4.mb-0= onboarding.location_name
+            div
+                if onboarding.status === 'setup_done'
+                    span.badge.badge-success.mr-2 Setup Done
+                    button.btn.btn-sm.btn-outline-secondary#btnMarkActive(type="button") Mark Active
+                else
+                    span.badge.badge-warning.text-dark.mr-2 Active
+                    button.btn.btn-sm.btn-success#btnMarkDone(type="button") Mark Setup Done
+
+        //- URL card
+        .card.shadow-sm.mb-3
+            .card-body.py-2
+                .d-flex.align-items-center.flex-wrap
+                    span.text-muted.mr-2.small Onboarding URL:
+                    .input-group.input-group-sm
+                        input.form-control#detailUrl(type="text" readonly value=`${baseUrl}/onboard/${onboarding.token}` style="font-size:12px;")
+                        .input-group-append
+                            button.btn.btn-outline-secondary#btnCopyDetail(type="button") Copy URL
+                            a.btn.btn-outline-primary(href=`/onboard/${onboarding.token}` target="_blank") Open Form
+
+        //- Notes
+        .card.shadow-sm.mb-3
+            .card-body
+                label.font-weight-bold Notes
+                textarea#adminNotes.form-control(rows="2" placeholder="Internal notes…")= onboarding.notes || ''
+                button.btn.btn-sm.btn-outline-secondary.mt-2#btnSaveNotes(type="button") Save Notes
+
+        //- Data accordion
+        #accordionData.accordion
+
+            +detailSection("colRo", "RO Details", true)
+                table.table.table-sm.mb-0
+                    tbody
+                        tr
+                            th(width="160") RO Name
+                            td= formData.ro.ro_name || '—'
+                        tr
+                            th Owner Contact
+                            td= formData.ro.owner_contact || '—'
+                        tr
+                            th RO Brand
+                            td= formData.ro.ro_brand || '—'
+                        tr
+                            th Address
+                            td= formData.ro.ro_address || '—'
+                        tr
+                            th Google Maps Link
+                            td
+                                if formData.ro.location_link
+                                    a(href=formData.ro.location_link target="_blank" style="word-break:break-all;")= formData.ro.location_link
+                                else
+                                    | —
+
+            +detailSection("colEmployees", `Employees (${formData.employees.length})`)
+                if formData.employees.length
+                    table.table.table-sm.mb-0
+                        thead.thead-light
+                            tr
+                                th Employee Name
+                                th Designation
+                        tbody
+                            each e in formData.employees
+                                tr
+                                    td= e.employee_name || '—'
+                                    td= e.designation || '—'
+                else
+                    p.text-muted.mb-0 No entries
+
+            +detailSection("colProducts", `Metered Products (${formData.metered_products.length})`)
+                if formData.metered_products.length
+                    table.table.table-sm.mb-0
+                        thead.thead-light
+                            tr
+                                th Product Name
+                                th Short Name
+                        tbody
+                            each p in formData.metered_products
+                                tr
+                                    td= p.product_name || '—'
+                                    td= p.short_name || '—'
+                else
+                    p.text-muted.mb-0 No entries
+
+            +detailSection("colTanks", `Tanks (${formData.tanks.length})`)
+                if formData.tanks.length
+                    table.table.table-sm.mb-0
+                        thead.thead-light
+                            tr
+                                th Tank Name
+                                th Capacity (L)
+                                th Short Name
+                                th Product
+                        tbody
+                            each t in formData.tanks
+                                tr
+                                    td= t.tank_name || '—'
+                                    td= t.tank_capacity || '—'
+                                    td= t.tank_short_name || '—'
+                                    td= t.product_short_name || '—'
+                else
+                    p.text-muted.mb-0 No entries
+
+            +detailSection("colNozzles", `Nozzles (${formData.nozzles.length})`)
+                if formData.nozzles.length
+                    table.table.table-sm.mb-0
+                        thead.thead-light
+                            tr
+                                th Nozzle Name
+                                th Product
+                                th DU Make
+                                th Tank Connected
+                                th Next Stamping
+                        tbody
+                            each n in formData.nozzles
+                                tr
+                                    td= n.nozzle_name || '—'
+                                    td= n.nozzle_product || '—'
+                                    td= n.du_make || '—'
+                                    td= n.tank_connected || '—'
+                                    td= n.next_stamping_date || '—'
+                else
+                    p.text-muted.mb-0 No entries
+
+            +detailSection("colLubes", `Lubes & Other Products (${formData.lubes.length})`)
+                if formData.lubes.length
+                    table.table.table-sm.mb-0
+                        thead.thead-light
+                            tr
+                                th Product Name
+                                th Unit
+                                th Price (₹)
+                        tbody
+                            each l in formData.lubes
+                                tr
+                                    td= l.product_name || '—'
+                                    td= l.unit || '—'
+                                    td= l.selling_price || '—'
+                else
+                    p.text-muted.mb-0 No entries
+
+            +detailSection("colBanks", `Banks (${formData.banks.length})`)
+                if formData.banks.length
+                    .table-responsive
+                        table.table.table-sm.mb-0
+                            thead.thead-light
+                                tr
+                                    th Bank Name
+                                    th Short Name
+                                    th Branch
+                                    th Account Name
+                                    th Last 4
+                                    th Type
+                            tbody
+                                each b in formData.banks
+                                    tr
+                                        td= b.bank_name || '—'
+                                        td= b.short_name || '—'
+                                        td= b.branch || '—'
+                                        td= b.account_name || '—'
+                                        td= b.account_last4 || '—'
+                                        td= b.account_type || '—'
+                else
+                    p.text-muted.mb-0 No entries
+
+            +detailSection("colDigital", `Digital Platforms (${formData.digital.length})`)
+                if formData.digital.length
+                    table.table.table-sm.mb-0
+                        thead.thead-light
+                            tr
+                                th Platform Name
+                        tbody
+                            each d in formData.digital
+                                tr
+                                    td= d.platform_name || '—'
+                else
+                    p.text-muted.mb-0 No entries
+
+            +detailSection("colCustomers", `Customers (${formData.customers.length})`)
+                if formData.customers.length
+                    .table-responsive
+                        table.table.table-sm.mb-0
+                            thead.thead-light
+                                tr
+                                    th Name
+                                    th GSTIN
+                                    th Owner
+                                    th Owner Mobile
+                                    th Type
+                            tbody
+                                each c in formData.customers
+                                    tr
+                                        td= c.customer_name || '—'
+                                        td= c.gstin || '—'
+                                        td= c.owner_name || '—'
+                                        td= c.owner_mobile || '—'
+                                        td= c.customer_type || '—'
+                else
+                    p.text-muted.mb-0 No entries
+
+            +detailSection("colSuppliers", `Suppliers (${formData.suppliers.length})`)
+                if formData.suppliers.length
+                    table.table.table-sm.mb-0
+                        thead.thead-light
+                            tr
+                                th Supplier Name
+                                th Short Name
+                        tbody
+                            each s in formData.suppliers
+                                tr
+                                    td= s.supplier_name || '—'
+                                    td= s.short_name || '—'
+                else
+                    p.text-muted.mb-0 No entries
+
+    script.
+        var OB_ID = !{onboarding.id};
+        var OB_STATUS = '!{onboarding.status}';
+
+        document.getElementById('btnCopyDetail').addEventListener('click', function() {
+            navigator.clipboard.writeText(document.getElementById('detailUrl').value).then(() => {
+                this.textContent = 'Copied!';
+                setTimeout(() => this.textContent = 'Copy URL', 2000);
+            });
+        });
+
+        async function updateStatus(status) {
+            var notes = document.getElementById('adminNotes').value;
+            var r = await fetch('/admin/onboarding/' + OB_ID + '/status', {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ status: status, notes: notes })
+            });
+            if (r.ok) location.reload();
+            else alert('Failed to update status.');
+        }
+
+        var btnDone = document.getElementById('btnMarkDone');
+        var btnActive = document.getElementById('btnMarkActive');
+        if (btnDone) btnDone.addEventListener('click', function() { updateStatus('setup_done'); });
+        if (btnActive) btnActive.addEventListener('click', function() { updateStatus('active'); });
+
+        document.getElementById('btnSaveNotes').addEventListener('click', async function() {
+            var notes = document.getElementById('adminNotes').value;
+            var r = await fetch('/admin/onboarding/' + OB_ID + '/status', {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ status: OB_STATUS, notes: notes })
+            });
+            if (r.ok) {
+                this.textContent = 'Saved ✓';
+                setTimeout(() => this.textContent = 'Save Notes', 2000);
+            } else {
+                alert('Failed to save notes.');
+            }
+        });

--- a/views/onboarding/admin-list.pug
+++ b/views/onboarding/admin-list.pug
@@ -1,0 +1,127 @@
+extends ../layout
+include ../mixins/mixins
+
+block content
+    .container-fluid.py-4
+
+        .d-flex.justify-content-between.align-items-center.mb-4
+            h4.mb-0 Onboarding
+            button.btn.btn-primary(data-toggle="modal" data-target="#modalNewOnboarding") + New Onboarding
+
+        if onboardings.length === 0
+            .alert.alert-info No onboarding entries yet. Click "New Onboarding" to get started.
+        else
+            .card.shadow-sm
+                .table-responsive
+                    table.table.table-hover.mb-0
+                        thead.thead-light
+                            tr
+                                th Location Name
+                                th Status
+                                th Created
+                                th Onboarding URL
+                                th(width="100") Actions
+                        tbody
+                            each ob in onboardings
+                                tr
+                                    td
+                                        strong= ob.location_name
+                                    td
+                                        if ob.status === 'setup_done'
+                                            span.badge.badge-success Setup Done
+                                        else
+                                            span.badge.badge-warning.text-dark Active
+                                    td= ob.created_at ? new Date(ob.created_at).toLocaleDateString('en-IN') : ''
+                                    td
+                                        .input-group.input-group-sm
+                                            input.form-control.form-control-sm.onboard-url(
+                                                type="text"
+                                                readonly
+                                                value=`${baseUrl}/onboard/${ob.token}`
+                                                style="font-size:11px;"
+                                            )
+                                            .input-group-append
+                                                button.btn.btn-outline-secondary.btn-sm.btn-copy-url(
+                                                    type="button"
+                                                    data-token=ob.token
+                                                    title="Copy URL"
+                                                ) Copy
+                                    td
+                                        a.btn.btn-sm.btn-outline-primary(href=`/admin/onboarding/${ob.id}`) View
+
+    //- New Onboarding Modal
+    #modalNewOnboarding.modal.fade(tabindex="-1" role="dialog")
+        .modal-dialog(role="document")
+            .modal-content
+                .modal-header
+                    h5.modal-title New Onboarding
+                    button.close(type="button" data-dismiss="modal")
+                        span &times;
+                .modal-body
+                    .form-group
+                        label Location / Business Name
+                        input#newLocationName.form-control(type="text" placeholder="e.g. Joveni Enterprises" maxlength="200")
+                        small.form-text.text-muted This is just for your reference – the actual RO name will be filled in by the customer.
+                    #newOnboardResult.alert.alert-success.d-none
+                        p.mb-1 #[strong Onboarding URL created!]
+                        p.mb-1 Share this URL with the petrol bunk:
+                        .input-group
+                            input#newOnboardUrl.form-control(type="text" readonly)
+                            .input-group-append
+                                button.btn.btn-outline-secondary#btnCopyNewUrl(type="button") Copy
+                .modal-footer
+                    button.btn.btn-secondary(type="button" data-dismiss="modal") Close
+                    button.btn.btn-primary#btnCreateOnboarding(type="button") Create & Generate URL
+
+    script.
+        var BASE_URL = '!{baseUrl}';
+
+        document.getElementById('btnCreateOnboarding').addEventListener('click', async function() {
+            var name = document.getElementById('newLocationName').value.trim();
+            if (!name) { alert('Please enter a location name.'); return; }
+            this.disabled = true;
+            this.textContent = 'Creating…';
+            try {
+                var r = await fetch('/admin/onboarding', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ location_name: name })
+                });
+                var data = await r.json();
+                if (!r.ok) throw new Error(data.error || 'Failed');
+                document.getElementById('newOnboardUrl').value = data.url;
+                document.getElementById('newOnboardResult').classList.remove('d-none');
+                this.textContent = 'Created!';
+            } catch(e) {
+                alert('Error: ' + e.message);
+                this.disabled = false;
+                this.textContent = 'Create & Generate URL';
+            }
+        });
+
+        document.getElementById('btnCopyNewUrl').addEventListener('click', function() {
+            var input = document.getElementById('newOnboardUrl');
+            navigator.clipboard.writeText(input.value).then(() => {
+                this.textContent = 'Copied!';
+                setTimeout(() => this.textContent = 'Copy', 2000);
+            });
+        });
+
+        document.querySelectorAll('.btn-copy-url').forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                var url = BASE_URL + '/onboard/' + this.dataset.token;
+                navigator.clipboard.writeText(url).then(() => {
+                    this.textContent = 'Copied!';
+                    setTimeout(() => this.textContent = 'Copy', 2000);
+                });
+            });
+        });
+
+        // Reset modal on close
+        document.getElementById('modalNewOnboarding').addEventListener('hidden.bs.modal', function() {
+            document.getElementById('newLocationName').value = '';
+            document.getElementById('newOnboardResult').classList.add('d-none');
+            var btn = document.getElementById('btnCreateOnboarding');
+            btn.disabled = false;
+            btn.textContent = 'Create & Generate URL';
+        });

--- a/views/onboarding/form.pug
+++ b/views/onboarding/form.pug
@@ -1,0 +1,356 @@
+doctype html
+html(lang="en")
+    head
+        meta(charset="UTF-8")
+        meta(name="viewport" content="width=device-width, initial-scale=1.0")
+        title= title
+        link(rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css")
+        style.
+            body { background: #f4f6f9; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+            .top-bar { position: fixed; top: 0; left: 0; right: 0; z-index: 1030;
+                background: #fff; border-bottom: 2px solid #F4C430; padding: 10px 20px;
+                display: flex; align-items: center; justify-content: space-between; box-shadow: 0 2px 8px rgba(0,0,0,.08); }
+            .top-bar .brand { font-weight: 700; color: #1a1a1a; font-size: 16px; }
+            .top-bar .location { color: #555; font-size: 13px; }
+            .save-indicator { font-size: 12px; padding: 4px 14px; border-radius: 20px; font-weight: 500; }
+            .save-indicator.saved  { background: #d4edda; color: #155724; }
+            .save-indicator.saving { background: #cce5ff; color: #004085; }
+            .save-indicator.error  { background: #f8d7da; color: #721c24; }
+            .main-content { margin-top: 70px; padding: 20px; }
+            .nav-tabs .nav-link { font-size: 13px; padding: 8px 14px; color: #555; }
+            .nav-tabs .nav-link.active { font-weight: 600; color: #0d6efd; }
+            .tab-nav-wrap { overflow-x: auto; white-space: nowrap; -webkit-overflow-scrolling: touch; border-bottom: 1px solid #dee2e6; }
+            .tab-nav-wrap .nav-tabs { flex-wrap: nowrap; border-bottom: none; }
+            .section-card { background: #fff; border-radius: 6px; padding: 20px; box-shadow: 0 1px 4px rgba(0,0,0,.06); }
+            .section-hint { font-size: 12px; color: #6c757d; margin-bottom: 14px; }
+            .table th { font-size: 12px; font-weight: 600; background: #f8f9fa; white-space: nowrap; }
+            .table td { vertical-align: middle; }
+            .form-control-sm { font-size: 13px; }
+            .setup-done-banner { background: #d4edda; border: 1px solid #c3e6cb; border-radius: 6px; padding: 12px 16px; margin-bottom: 16px; color: #155724; font-size: 14px; }
+
+    body
+        //- Fixed top bar
+        .top-bar
+            div
+                span.brand PetroMath
+                span.text-muted.mx-2 |
+                span.location= onboarding.location_name
+            span#save-indicator.save-indicator.saved All changes saved ✓
+
+        .main-content.container-fluid
+            if onboarding.status === 'setup_done'
+                .setup-done-banner
+                    strong Setup in progress
+                    |  – Your information has been received. You can still update details below.
+
+            //- Tab navigation
+            .tab-nav-wrap
+                ul.nav.nav-tabs(role="tablist")
+                    li.nav-item: a.nav-link.active(href="#tab-ro" data-toggle="tab" role="tab") RO Details
+                    li.nav-item: a.nav-link(href="#tab-employees" data-toggle="tab" role="tab") Employees
+                    li.nav-item: a.nav-link(href="#tab-metered-products" data-toggle="tab" role="tab") Products
+                    li.nav-item: a.nav-link(href="#tab-tanks" data-toggle="tab" role="tab") Tanks
+                    li.nav-item: a.nav-link(href="#tab-nozzles" data-toggle="tab" role="tab") Nozzles
+                    li.nav-item: a.nav-link(href="#tab-lubes" data-toggle="tab" role="tab") Lubes / Other
+                    li.nav-item: a.nav-link(href="#tab-banks" data-toggle="tab" role="tab") Banks
+                    li.nav-item: a.nav-link(href="#tab-digital" data-toggle="tab" role="tab") Digital
+                    li.nav-item: a.nav-link(href="#tab-customers" data-toggle="tab" role="tab") Customers
+                    li.nav-item: a.nav-link(href="#tab-suppliers" data-toggle="tab" role="tab") Suppliers
+
+            //- Tab content
+            #onboarding-sections.tab-content.pt-3
+
+                //- ── RO Details ────────────────────────────────────────────────
+                #tab-ro.tab-pane.fade.show.active(role="tabpanel")
+                    .section-card
+                        p.section-hint This information is used to set up your business on PetroMath.
+                        .form-row
+                            .form-group.col-md-6
+                                label RO Name
+                                small.text-muted  (Trade name as per GST RC)
+                                input.form-control(type="text" data-field="ro_name" value=(formData.ro.ro_name||'') placeholder="e.g. Joveni Enterprises")
+                            .form-group.col-md-6
+                                label Owner Contact Number
+                                small.text-muted  (10-digit mobile)
+                                input.form-control(type="tel" data-field="owner_contact" value=(formData.ro.owner_contact||'') placeholder="9876543210")
+                        .form-row
+                            .form-group.col-md-4
+                                label RO Brand
+                                select.form-control(data-field="ro_brand")
+                                    option(value="" selected=!formData.ro.ro_brand) -- Select --
+                                    each b in ['IOCL','BPCL','HPCL','NAYARA','SHELL']
+                                        option(value=b selected=(formData.ro.ro_brand===b))= b
+                            .form-group.col-md-8
+                                label RO Address
+                                input.form-control(type="text" data-field="ro_address" value=(formData.ro.ro_address||'') placeholder="Full address")
+                        .form-group
+                            label Google Maps Link
+                            small.text-muted  (Copy & paste from Google Maps)
+                            input.form-control(type="url" data-field="location_link" value=(formData.ro.location_link||'') placeholder="https://maps.google.com/...")
+
+                //- ── Employees ─────────────────────────────────────────────────
+                #tab-employees.tab-pane.fade(role="tabpanel")
+                    .section-card
+                        .d-flex.justify-content-between.align-items-center.mb-2
+                            div
+                                h6.mb-0 Employees
+                                p.section-hint.mb-0 Access and usage rights will be based on details below.
+                            button.btn.btn-primary.btn-sm(type="button" data-add-section="employees") + Add Row
+                        .table-responsive
+                            table.table.table-sm.table-bordered
+                                thead
+                                    tr
+                                        th Employee Name
+                                        th Designation
+                                        th(width="50")
+                                tbody#tbody-employees
+                                    each row in formData.employees
+                                        tr(data-section="employees" data-row-id=row.id)
+                                            td: input.form-control.form-control-sm(type="text" data-field="employee_name" value=(row.employee_name||'') placeholder="Name with Initial")
+                                            td
+                                                select.form-control.form-control-sm(data-field="designation")
+                                                    option(value="" selected=!row.designation) -- Select --
+                                                    each d in ['Manager','Cashier','Attendant','DSM','DSW','Owner']
+                                                        option(value=d selected=(row.designation===d))= d
+                                            td.text-center.align-middle
+                                                button.btn.btn-outline-danger.btn-sm(type="button" onclick=`deleteRow('employees',${row.id},this)`) ×
+
+                //- ── Metered Products ──────────────────────────────────────────
+                #tab-metered-products.tab-pane.fade(role="tabpanel")
+                    .section-card
+                        .d-flex.justify-content-between.align-items-center.mb-2
+                            div
+                                h6.mb-0 Metered Products
+                                p.section-hint.mb-0 Products sold through Dispensing Units. Short Name is used across Tanks and Nozzles tabs.
+                            button.btn.btn-primary.btn-sm(type="button" data-add-section="metered-products") + Add Row
+                        .table-responsive
+                            table.table.table-sm.table-bordered
+                                thead
+                                    tr
+                                        th Product Name (as per Invoice)
+                                        th Short Name
+                                        th(width="50")
+                                tbody#tbody-metered-products
+                                    each row in formData.metered_products
+                                        tr(data-section="metered-products" data-row-id=row.id)
+                                            td: input.form-control.form-control-sm(type="text" data-field="product_name" value=(row.product_name||'') placeholder="e.g. EBMS, HSD")
+                                            td: input.form-control.form-control-sm(type="text" data-field="short_name" value=(row.short_name||'') placeholder="e.g. MS / HSD")
+                                            td.text-center.align-middle
+                                                button.btn.btn-outline-danger.btn-sm(type="button" onclick=`deleteRow('metered-products',${row.id},this)`) ×
+
+                //- ── Tanks ─────────────────────────────────────────────────────
+                #tab-tanks.tab-pane.fade(role="tabpanel")
+                    .section-card
+                        .d-flex.justify-content-between.align-items-center.mb-2
+                            div
+                                h6.mb-0 Tanks
+                                p.section-hint.mb-0 Present tank combination. Product dropdown is populated from the Metered Products tab.
+                            button.btn.btn-primary.btn-sm(type="button" data-add-section="tanks") + Add Row
+                        .table-responsive
+                            table.table.table-sm.table-bordered
+                                thead
+                                    tr
+                                        th Tank Name
+                                        th Capacity (L)
+                                        th Short Name
+                                        th Product
+                                        th(width="50")
+                                tbody#tbody-tanks
+                                    each row in formData.tanks
+                                        tr(data-section="tanks" data-row-id=row.id)
+                                            td: input.form-control.form-control-sm(type="text" data-field="tank_name" value=(row.tank_name||'') placeholder="Tank Name")
+                                            td: input.form-control.form-control-sm(type="number" data-field="tank_capacity" value=(row.tank_capacity||'') placeholder="15000")
+                                            td: input.form-control.form-control-sm(type="text" data-field="tank_short_name" value=(row.tank_short_name||'') placeholder="e.g. MS1")
+                                            td
+                                                select.form-control.form-control-sm(data-field="product_short_name")
+                                                    option(value="" selected=!row.product_short_name) -- Select --
+                                                    each p in formData.metered_products
+                                                        option(value=p.short_name selected=(row.product_short_name===p.short_name))= p.short_name
+                                            td.text-center.align-middle
+                                                button.btn.btn-outline-danger.btn-sm(type="button" onclick=`deleteRow('tanks',${row.id},this)`) ×
+
+                //- ── Nozzles ───────────────────────────────────────────────────
+                #tab-nozzles.tab-pane.fade(role="tabpanel")
+                    .section-card
+                        .d-flex.justify-content-between.align-items-center.mb-2
+                            div
+                                h6.mb-0 Nozzles / Dispensing Units
+                                p.section-hint.mb-0 Tank dropdown is populated from the Tanks tab. Opening Reading to be filled once nozzle-tank mapping is set up.
+                            button.btn.btn-primary.btn-sm(type="button" data-add-section="nozzles") + Add Row
+                        .table-responsive
+                            table.table.table-sm.table-bordered
+                                thead
+                                    tr
+                                        th Nozzle Name
+                                        th Product
+                                        th DU Make
+                                        th Tank Connected
+                                        th Next Stamping Date
+                                        th(width="50")
+                                tbody#tbody-nozzles
+                                    each row in formData.nozzles
+                                        tr(data-section="nozzles" data-row-id=row.id)
+                                            td: input.form-control.form-control-sm(type="text" data-field="nozzle_name" value=(row.nozzle_name||'') placeholder="e.g. MS 1.1")
+                                            td: input.form-control.form-control-sm(type="text" data-field="nozzle_product" value=(row.nozzle_product||'') placeholder="Short Name")
+                                            td: input.form-control.form-control-sm(type="text" data-field="du_make" value=(row.du_make||'') placeholder="Tokheim / Gilbarco")
+                                            td
+                                                select.form-control.form-control-sm(data-field="tank_connected")
+                                                    option(value="" selected=!row.tank_connected) -- Select --
+                                                    each t in formData.tanks
+                                                        option(value=t.tank_name selected=(row.tank_connected===t.tank_name))= t.tank_name
+                                            td: input.form-control.form-control-sm(type="date" data-field="next_stamping_date" value=(row.next_stamping_date||''))
+                                            td.text-center.align-middle
+                                                button.btn.btn-outline-danger.btn-sm(type="button" onclick=`deleteRow('nozzles',${row.id},this)`) ×
+
+                //- ── Lubes & Other Products ────────────────────────────────────
+                #tab-lubes.tab-pane.fade(role="tabpanel")
+                    .section-card
+                        .d-flex.justify-content-between.align-items-center.mb-2
+                            div
+                                h6.mb-0 Lubes & Other Products
+                                p.section-hint.mb-0 All products stocked in the RO except those sold through DU. Include SKU name with pack size.
+                            button.btn.btn-primary.btn-sm(type="button" data-add-section="lubes") + Add Row
+                        .table-responsive
+                            table.table.table-sm.table-bordered
+                                thead
+                                    tr
+                                        th Product Name (SKU + Pack Size)
+                                        th Unit
+                                        th Selling Price (₹)
+                                        th(width="50")
+                                tbody#tbody-lubes
+                                    each row in formData.lubes
+                                        tr(data-section="lubes" data-row-id=row.id)
+                                            td: input.form-control.form-control-sm(type="text" data-field="product_name" value=(row.product_name||'') placeholder="e.g. Servo 10W-40 1L")
+                                            td
+                                                select.form-control.form-control-sm(data-field="unit")
+                                                    option(value="" selected=!row.unit) -- Select --
+                                                    each u in ['Litres','Nos','Kgs']
+                                                        option(value=u selected=(row.unit===u))= u
+                                            td: input.form-control.form-control-sm(type="number" step="0.01" data-field="selling_price" value=(row.selling_price||'') placeholder="0.00")
+                                            td.text-center.align-middle
+                                                button.btn.btn-outline-danger.btn-sm(type="button" onclick=`deleteRow('lubes',${row.id},this)`) ×
+
+                //- ── Banks ─────────────────────────────────────────────────────
+                #tab-banks.tab-pane.fade(role="tabpanel")
+                    .section-card
+                        .d-flex.justify-content-between.align-items-center.mb-2
+                            div
+                                h6.mb-0 Bank Accounts
+                                p.section-hint.mb-0 All bank accounts used by the RO.
+                            button.btn.btn-primary.btn-sm(type="button" data-add-section="banks") + Add Row
+                        .table-responsive
+                            table.table.table-sm.table-bordered
+                                thead
+                                    tr
+                                        th Bank Name
+                                        th Short Name
+                                        th Branch
+                                        th Account Name
+                                        th Last 4 Digits
+                                        th Account Type
+                                        th(width="50")
+                                tbody#tbody-banks
+                                    each row in formData.banks
+                                        tr(data-section="banks" data-row-id=row.id)
+                                            td: input.form-control.form-control-sm(type="text" data-field="bank_name" value=(row.bank_name||'') placeholder="e.g. State Bank of India")
+                                            td: input.form-control.form-control-sm(type="text" data-field="short_name" value=(row.short_name||'') placeholder="e.g. SBI")
+                                            td: input.form-control.form-control-sm(type="text" data-field="branch" value=(row.branch||'') placeholder="Branch Name")
+                                            td: input.form-control.form-control-sm(type="text" data-field="account_name" value=(row.account_name||'') placeholder="Name as per bank")
+                                            td: input.form-control.form-control-sm(type="text" data-field="account_last4" value=(row.account_last4||'') placeholder="Last 4" maxlength="4")
+                                            td
+                                                select.form-control.form-control-sm(data-field="account_type")
+                                                    option(value="" selected=!row.account_type) -- Select --
+                                                    each at in ['Current','Savings','Cash Credit','EDFS']
+                                                        option(value=at selected=(row.account_type===at))= at
+                                            td.text-center.align-middle
+                                                button.btn.btn-outline-danger.btn-sm(type="button" onclick=`deleteRow('banks',${row.id},this)`) ×
+
+                //- ── Digital ───────────────────────────────────────────────────
+                #tab-digital.tab-pane.fade(role="tabpanel")
+                    .section-card
+                        .d-flex.justify-content-between.align-items-center.mb-2
+                            div
+                                h6.mb-0 Digital Payment Platforms
+                                p.section-hint.mb-0 Platforms used to receive customer payments (e.g. Paytm, PhonePe, XTRAREWARDS, ITPS).
+                            button.btn.btn-primary.btn-sm(type="button" data-add-section="digital") + Add Row
+                        .table-responsive
+                            table.table.table-sm.table-bordered
+                                thead
+                                    tr
+                                        th Platform / Company Name
+                                        th(width="50")
+                                tbody#tbody-digital
+                                    each row in formData.digital
+                                        tr(data-section="digital" data-row-id=row.id)
+                                            td: input.form-control.form-control-sm(type="text" data-field="platform_name" value=(row.platform_name||'') placeholder="e.g. Paytm / PhonePe / XTRAREWARDS")
+                                            td.text-center.align-middle
+                                                button.btn.btn-outline-danger.btn-sm(type="button" onclick=`deleteRow('digital',${row.id},this)`) ×
+
+                //- ── Customers ─────────────────────────────────────────────────
+                #tab-customers.tab-pane.fade(role="tabpanel")
+                    .section-card
+                        .d-flex.justify-content-between.align-items-center.mb-2
+                            div
+                                h6.mb-0 Customers
+                                p.section-hint.mb-0 Customers for whom you maintain a ledger. Obtain RC copy for accurate GSTIN details.
+                            button.btn.btn-primary.btn-sm(type="button" data-add-section="customers") + Add Row
+                        .table-responsive
+                            table.table.table-sm.table-bordered
+                                thead
+                                    tr
+                                        th Customer / Org Name
+                                        th Address
+                                        th GSTIN
+                                        th Owner Name
+                                        th Owner Mobile
+                                        th Manager Name
+                                        th Manager Mobile
+                                        th Type
+                                        th(width="50")
+                                tbody#tbody-customers
+                                    each row in formData.customers
+                                        tr(data-section="customers" data-row-id=row.id)
+                                            td: input.form-control.form-control-sm(type="text" data-field="customer_name" value=(row.customer_name||'') placeholder="Trade Name")
+                                            td: input.form-control.form-control-sm(type="text" data-field="address" value=(row.address||'') placeholder="Billing Address")
+                                            td: input.form-control.form-control-sm(type="text" data-field="gstin" value=(row.gstin||'') placeholder="GSTIN" maxlength="15")
+                                            td: input.form-control.form-control-sm(type="text" data-field="owner_name" value=(row.owner_name||'') placeholder="Owner Name")
+                                            td: input.form-control.form-control-sm(type="tel" data-field="owner_mobile" value=(row.owner_mobile||'') placeholder="10-digit" maxlength="10")
+                                            td: input.form-control.form-control-sm(type="text" data-field="manager_name" value=(row.manager_name||'') placeholder="Manager Name")
+                                            td: input.form-control.form-control-sm(type="tel" data-field="manager_mobile" value=(row.manager_mobile||'') placeholder="10-digit" maxlength="10")
+                                            td
+                                                select.form-control.form-control-sm(data-field="customer_type")
+                                                    option(value="" selected=!row.customer_type) -- Select --
+                                                    each ct in ['Credit','Cash']
+                                                        option(value=ct selected=(row.customer_type===ct))= ct
+                                            td.text-center.align-middle
+                                                button.btn.btn-outline-danger.btn-sm(type="button" onclick=`deleteRow('customers',${row.id},this)`) ×
+
+                //- ── Suppliers ─────────────────────────────────────────────────
+                #tab-suppliers.tab-pane.fade(role="tabpanel")
+                    .section-card
+                        .d-flex.justify-content-between.align-items-center.mb-2
+                            div
+                                h6.mb-0 Suppliers
+                                p.section-hint.mb-0 All suppliers from whom product purchases are made.
+                            button.btn.btn-primary.btn-sm(type="button" data-add-section="suppliers") + Add Row
+                        .table-responsive
+                            table.table.table-sm.table-bordered
+                                thead
+                                    tr
+                                        th Supplier Name (as per Invoice)
+                                        th Short Name
+                                        th(width="50")
+                                tbody#tbody-suppliers
+                                    each row in formData.suppliers
+                                        tr(data-section="suppliers" data-row-id=row.id)
+                                            td: input.form-control.form-control-sm(type="text" data-field="supplier_name" value=(row.supplier_name||'') placeholder="Full name as per invoice")
+                                            td: input.form-control.form-control-sm(type="text" data-field="short_name" value=(row.short_name||'') placeholder="Short Name")
+                                            td.text-center.align-middle
+                                                button.btn.btn-outline-danger.btn-sm(type="button" onclick=`deleteRow('suppliers',${row.id},this)`) ×
+
+        script(src="https://code.jquery.com/jquery-3.5.1.slim.min.js")
+        script(src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.bundle.min.js")
+        script.
+            window.ONBOARD_TOKEN = '!{token}';
+        script(src="/javascripts/onboarding-form.js")


### PR DESCRIPTION
## Summary
- New public form at `/onboard/:token` — no login required, served via unique UUID URL
- Auto-saves every field change (debounced 800ms) with live save indicator
- 10 tabs: RO Details, Employees, Metered Products, Tanks, Nozzles, Lubes, Banks, Digital, Customers, Suppliers
- Tank product dropdown cross-references Metered Products; Nozzle tank dropdown cross-references Tanks
- Admin panel at `/admin/onboarding` — create entries (generates UUID URL), view all submissions, mark setup done
- Separate DB tables per section (`t_onboarding_*`) for future migration to live PetroMath setup

## DB
Run `db/migrations/onboarding.sql` on dev DB (already done).
Menu insert: `ONBOARDING_ADMIN` → `/admin/onboarding`, ADMIN group, SuperUser only.

## Test plan
- [ ] Log in as SuperUser → verify Onboarding appears in ADMIN menu group
- [ ] Go to `/admin/onboarding` → create new entry → copy URL
- [ ] Open URL in incognito (no login) → fill in all 10 tabs → confirm auto-save indicator works
- [ ] Verify Tanks tab product dropdown updates when Products tab entries change
- [ ] Verify Nozzles tab tank dropdown updates when Tanks tab entries change
- [ ] Back in admin detail → confirm all data visible, notes save, mark Setup Done works

🤖 Generated with [Claude Code](https://claude.com/claude-code)