### PR TITLE
Onboarding: CAPS, pre-flight, GST%/HSN, remittance bank, supplier skip

### DIFF
--- a/controllers/onboarding-controller.js
+++ b/controllers/onboarding-controller.js
@@ -151,12 +151,34 @@ module.exports = {
         }
     },
 
+    hsnSuggestions: async (req, res, next) => {
+        try {
+            const q = (req.query.q || '').trim();
+            // Return distinct HSN codes; filter by product name if q provided
+            const rows = await db.sequelize.query(
+                `SELECT DISTINCT hsn_code,
+                        GROUP_CONCAT(DISTINCT product_name ORDER BY product_name SEPARATOR ', ') AS sample_products,
+                        COUNT(*) AS cnt
+                 FROM m_product
+                 WHERE hsn_code IS NOT NULL AND hsn_code != ''
+                   ${q ? 'AND product_name LIKE :pattern' : ''}
+                 GROUP BY hsn_code
+                 ORDER BY cnt DESC
+                 LIMIT 30`,
+                { replacements: { pattern: `%${q}%` }, type: QueryTypes.SELECT }
+            );
+            res.json(rows);
+        } catch (e) {
+            next(e);
+        }
+    },
+
     adminConfigHints: async (req, res, next) => {
         try {
             const rows = await db.sequelize.query(
                 `SELECT location_code, setting_name, setting_value
                  FROM m_location_config
-                 WHERE location_code IN (:locs) AND effective_end_date >= CURDATE()
+                 WHERE location_code IN (:locs)
                  ORDER BY setting_name, location_code`,
                 { replacements: { locs: CONFIG_HINT_LOCATIONS }, type: QueryTypes.SELECT }
             );

--- a/controllers/onboarding-migrate-controller.js
+++ b/controllers/onboarding-migrate-controller.js
@@ -48,15 +48,19 @@ module.exports = {
             const onboarding = await OnboardingDao.findById(req.params.id);
             if (!onboarding) return res.status(404).json({ error: 'Not found' });
 
-            const { location_code, template_location } = req.body;
+            const { location_code, template_location, skip_supplier_ids } = req.body;
             if (!location_code?.trim()) return res.status(400).json({ error: 'location_code is required' });
             if (!template_location?.trim()) return res.status(400).json({ error: 'template_location is required' });
             const loc = location_code.trim();
             const tmpl = template_location.trim();
+            const skipSupplierIds = new Set((skip_supplier_ids || []).map(Number));
 
             const data = await OnboardingDao.getAllData(onboarding.id);
             const ro = data.ro;
             const results = [];
+
+            // Helper: uppercase a string value safely
+            const up = (v) => (typeof v === 'string' && v.trim() ? v.trim().toUpperCase() : (v || null));
 
             // ── Step 1: Create Location ──────────────────────────────────────────
             {
@@ -72,11 +76,11 @@ module.exports = {
                              VALUES (:loc, :name, :address, :company, :phone, :gst, CURDATE(), '9999-12-31', 'onboarding')`,
                             {
                                 loc,
-                                name:    ro.ro_name    || onboarding.location_name,
-                                address: ro.ro_address || '',
-                                company: ro.ro_brand   || null,
-                                phone:   ro.owner_contact || null,
-                                gst:     ro.gst_number || null,
+                                name:    up(ro.ro_name    || onboarding.location_name),
+                                address: up(ro.ro_address) || '',
+                                company: up(ro.ro_brand)   || null,
+                                phone:   ro.owner_contact  || null,
+                                gst:     up(ro.gst_number) || null,
                             }
                         );
                         // Trigger auto-seeds: expenses, CashFlow lookups, oil company supplier + SAP bank
@@ -90,15 +94,16 @@ module.exports = {
             // ── Step 2: Suppliers ────────────────────────────────────────────────
             results.push(await runSection('Suppliers', data.suppliers, async (s) => {
                 if (!s.supplier_name) return 'skipped';
+                if (skipSupplierIds.has(s.id)) return 'skipped';
                 const exists = await selectOne(
                     'SELECT supplier_id FROM m_supplier WHERE supplier_name = :name AND location_code = :loc',
-                    { name: s.supplier_name, loc }
+                    { name: up(s.supplier_name), loc }
                 );
                 if (exists) return 'skipped';
                 await insertRow(
                     `INSERT INTO m_supplier (supplier_name, supplier_short_name, location_code, effective_start_date, effective_end_date, created_by)
                      VALUES (:name, :short, :loc, CURDATE(), '9999-12-31', 'onboarding')`,
-                    { name: s.supplier_name, short: s.short_name || s.supplier_name, loc }
+                    { name: up(s.supplier_name), short: up(s.short_name || s.supplier_name), loc }
                 );
             }));
 
@@ -107,14 +112,14 @@ module.exports = {
                 if (!p.product_name) return 'skipped';
                 const exists = await selectOne(
                     'SELECT product_id FROM m_product WHERE product_name = :name AND location_code = :loc AND is_tank_product = 1',
-                    { name: p.product_name, loc }
+                    { name: up(p.product_name), loc }
                 );
                 if (exists) return 'skipped';
                 const rgb = PRODUCT_RGB[(p.short_name || '').toUpperCase()] || '200,200,200';
                 await insertRow(
-                    `INSERT INTO m_product (product_name, location_code, qty, unit, is_tank_product, rgb_color, created_by)
-                     VALUES (:name, :loc, 1, 'Litres', 1, :rgb, 'onboarding')`,
-                    { name: p.product_name, loc, rgb }
+                    `INSERT INTO m_product (product_name, location_code, qty, unit, is_tank_product, rgb_color, hsn_code, cgst_percent, sgst_percent, created_by)
+                     VALUES (:name, :loc, 1, 'Litres', 1, :rgb, :hsn, :cgst, :sgst, 'onboarding')`,
+                    { name: up(p.product_name), loc, rgb, hsn: up(p.hsn_code) || null, cgst: p.cgst_percent ?? null, sgst: p.sgst_percent ?? null }
                 );
             }));
 
@@ -123,13 +128,13 @@ module.exports = {
                 if (!l.product_name) return 'skipped';
                 const exists = await selectOne(
                     'SELECT product_id FROM m_product WHERE product_name = :name AND location_code = :loc AND is_lube_product = 1',
-                    { name: l.product_name, loc }
+                    { name: up(l.product_name), loc }
                 );
                 if (exists) return 'skipped';
                 await insertRow(
-                    `INSERT INTO m_product (product_name, location_code, qty, unit, price, is_lube_product, created_by)
-                     VALUES (:name, :loc, 1, :unit, :price, 1, 'onboarding')`,
-                    { name: l.product_name, loc, unit: l.unit || 'Nos', price: l.selling_price || null }
+                    `INSERT INTO m_product (product_name, location_code, qty, unit, price, is_lube_product, hsn_code, cgst_percent, sgst_percent, created_by)
+                     VALUES (:name, :loc, 1, :unit, :price, 1, :hsn, :cgst, :sgst, 'onboarding')`,
+                    { name: up(l.product_name), loc, unit: l.unit || 'Nos', price: l.selling_price || null, hsn: up(l.hsn_code) || null, cgst: l.cgst_percent ?? null, sgst: l.sgst_percent ?? null }
                 );
             }));
 
@@ -138,13 +143,13 @@ module.exports = {
                 if (!t.tank_name) return 'skipped';
                 const exists = await selectOne(
                     'SELECT tank_id FROM m_tank WHERE tank_code = :code AND location_code = :loc',
-                    { code: t.tank_name, loc }
+                    { code: up(t.tank_name), loc }
                 );
                 if (exists) return 'skipped';
                 await insertRow(
                     `INSERT INTO m_tank (tank_code, product_code, location_code, tank_orig_capacity, tank_opening_stock, effective_start_date, effective_end_date, created_by)
                      VALUES (:code, :product, :loc, :capacity, 0, CURDATE(), '9999-12-31', 'onboarding')`,
-                    { code: t.tank_name, product: t.product_short_name || '', loc, capacity: t.tank_capacity || 0 }
+                    { code: up(t.tank_name), product: up(t.product_short_name) || '', loc, capacity: t.tank_capacity || 0 }
                 );
             }));
 
@@ -153,7 +158,7 @@ module.exports = {
                 if (!n.nozzle_name) return 'skipped';
                 const exists = await selectOne(
                     'SELECT pump_id FROM m_pump WHERE pump_code = :code AND location_code = :loc',
-                    { code: n.nozzle_name, loc }
+                    { code: up(n.nozzle_name), loc }
                 );
                 if (exists) return 'skipped';
                 const stampingDue = n.next_stamping_date
@@ -163,12 +168,12 @@ module.exports = {
                     `INSERT INTO m_pump (pump_code, pump_make, product_code, opening_reading, location_code,
                         effective_start_date, effective_end_date, current_stamping_date, Stamping_due, created_by)
                      VALUES (:code, :make, :product, 0, :loc, CURDATE(), '9999-12-31', '0000-00-00 00:00:00', :stamping, 'onboarding')`,
-                    { code: n.nozzle_name, make: n.du_make || 'Unknown', product: n.nozzle_product || '', loc, stamping: stampingDue }
+                    { code: up(n.nozzle_name), make: up(n.du_make) || 'UNKNOWN', product: up(n.nozzle_product) || '', loc, stamping: stampingDue }
                 );
                 if (n.tank_connected) {
                     const tank = await selectOne(
                         'SELECT tank_id FROM m_tank WHERE tank_code = :code AND location_code = :loc',
-                        { code: n.tank_connected, loc }
+                        { code: up(n.tank_connected), loc }
                     );
                     if (tank) {
                         await insertRow(
@@ -187,20 +192,20 @@ module.exports = {
                 if (!b.account_number || !b.ifsc_code) return 'skipped';
                 const exists = await selectOne(
                     'SELECT bank_id FROM m_bank WHERE bank_name = :name AND location_code = :loc',
-                    { name: b.bank_name, loc }
+                    { name: up(b.bank_name), loc }
                 );
                 if (exists) return 'skipped';
                 await insertRow(
                     `INSERT INTO m_bank (bank_name, bank_branch, account_number, ifsc_code, location_code, type, account_nickname, internal_flag, created_by)
                      VALUES (:name, :branch, :accnum, :ifsc, :loc, :type, :nickname, 'Y', 'onboarding')`,
                     {
-                        name:     b.bank_name,
-                        branch:   b.branch || '',
+                        name:     up(b.bank_name),
+                        branch:   up(b.branch) || '',
                         accnum:   b.account_number,
-                        ifsc:     b.ifsc_code,
+                        ifsc:     up(b.ifsc_code),
                         loc,
                         type:     b.account_type || null,
-                        nickname: b.short_name || null,
+                        nickname: up(b.short_name || b.bank_name),
                     }
                 );
             }));
@@ -210,13 +215,13 @@ module.exports = {
                 if (!d.platform_name) return 'skipped';
                 const exists = await selectOne(
                     'SELECT creditlist_id FROM m_credit_list WHERE Company_Name = :name AND location_code = :loc',
-                    { name: d.platform_name, loc }
+                    { name: up(d.platform_name), loc }
                 );
                 if (exists) return 'skipped';
                 await insertRow(
                     `INSERT INTO m_credit_list (Company_Name, location_code, card_flag, Opening_Balance, type, creation_date, created_by)
                      VALUES (:name, :loc, 'Y', 0, 'Digital', NOW(), 'onboarding')`,
-                    { name: d.platform_name, loc }
+                    { name: up(d.platform_name), loc }
                 );
             }));
 
@@ -225,13 +230,21 @@ module.exports = {
                 if (!c.customer_name) return 'skipped';
                 const exists = await selectOne(
                     'SELECT creditlist_id FROM m_credit_list WHERE Company_Name = :name AND location_code = :loc',
-                    { name: c.customer_name, loc }
+                    { name: up(c.customer_name), loc }
                 );
                 if (exists) return 'skipped';
+                let remitBankId = null;
+                if (c.remittance_bank) {
+                    const rb = await selectOne(
+                        `SELECT bank_id FROM m_bank WHERE location_code = :loc AND (account_nickname = :name OR bank_name = :name) LIMIT 1`,
+                        { loc, name: up(c.remittance_bank) }
+                    );
+                    if (rb) remitBankId = rb.bank_id;
+                }
                 await insertRow(
-                    `INSERT INTO m_credit_list (Company_Name, location_code, card_flag, Opening_Balance, gst, address, phoneno, type, creation_date, created_by)
-                     VALUES (:name, :loc, 'N', 0, :gst, :address, :phone, :type, NOW(), 'onboarding')`,
-                    { name: c.customer_name, loc, gst: c.gstin || null, address: c.address || null, phone: c.owner_mobile || null, type: c.customer_type || null }
+                    `INSERT INTO m_credit_list (Company_Name, location_code, card_flag, Opening_Balance, gst, address, type, remittance_bank_id, creation_date, created_by)
+                     VALUES (:name, :loc, 'N', 0, :gst, :address, :type, :remitBankId, NOW(), 'onboarding')`,
+                    { name: up(c.customer_name), loc, gst: up(c.gstin) || null, address: up(c.address) || null, type: c.customer_type || null, remitBankId }
                 );
             }));
 

--- a/dao/onboarding-dao.js
+++ b/dao/onboarding-dao.js
@@ -4,13 +4,13 @@ const { QueryTypes } = require('sequelize');
 
 const SECTION_MAP = {
     'employees':        { table: 't_onboarding_employees',        fields: ['employee_name', 'designation'] },
-    'metered-products': { table: 't_onboarding_metered_products', fields: ['product_name', 'short_name'] },
+    'metered-products': { table: 't_onboarding_metered_products', fields: ['product_name', 'short_name', 'hsn_code', 'cgst_percent', 'sgst_percent'] },
     'tanks':            { table: 't_onboarding_tanks',            fields: ['tank_name', 'tank_capacity', 'tank_short_name', 'product_short_name'] },
     'nozzles':          { table: 't_onboarding_nozzles',          fields: ['nozzle_name', 'nozzle_product', 'du_make', 'tank_connected', 'next_stamping_date'] },
-    'lubes':            { table: 't_onboarding_lubes',            fields: ['product_name', 'unit', 'selling_price'] },
+    'lubes':            { table: 't_onboarding_lubes',            fields: ['product_name', 'unit', 'selling_price', 'hsn_code', 'cgst_percent', 'sgst_percent'] },
     'banks':            { table: 't_onboarding_banks',            fields: ['bank_name', 'short_name', 'branch', 'account_name', 'account_last4', 'ifsc_code', 'account_number', 'account_type'] },
     'digital':          { table: 't_onboarding_digital',          fields: ['platform_name'] },
-    'customers':        { table: 't_onboarding_customers',        fields: ['customer_name', 'address', 'gstin', 'owner_name', 'owner_mobile', 'manager_name', 'manager_mobile', 'customer_type'] },
+    'customers':        { table: 't_onboarding_customers',        fields: ['customer_name', 'address', 'gstin', 'remittance_bank', 'customer_type'] },
     'suppliers':        { table: 't_onboarding_suppliers',        fields: ['supplier_name', 'short_name'] },
 };
 

--- a/db/migrations/onboarding-customer-remit-bank.sql
+++ b/db/migrations/onboarding-customer-remit-bank.sql
@@ -1,0 +1,4 @@
+-- Add remittance_bank column to onboarding customers
+-- (contact detail columns kept in DB for historical data; removed from form)
+ALTER TABLE t_onboarding_customers
+    ADD COLUMN remittance_bank VARCHAR(200) NULL AFTER gstin;

--- a/db/migrations/onboarding-product-gst-hsn.sql
+++ b/db/migrations/onboarding-product-gst-hsn.sql
@@ -1,0 +1,10 @@
+-- Add HSN code and GST% columns to onboarding product tables
+ALTER TABLE t_onboarding_metered_products
+    ADD COLUMN hsn_code     VARCHAR(20)  NULL AFTER short_name,
+    ADD COLUMN cgst_percent DECIMAL(5,2) NULL AFTER hsn_code,
+    ADD COLUMN sgst_percent DECIMAL(5,2) NULL AFTER cgst_percent;
+
+ALTER TABLE t_onboarding_lubes
+    ADD COLUMN hsn_code     VARCHAR(20)  NULL AFTER selling_price,
+    ADD COLUMN cgst_percent DECIMAL(5,2) NULL AFTER hsn_code,
+    ADD COLUMN sgst_percent DECIMAL(5,2) NULL AFTER cgst_percent;

--- a/public/javascripts/onboarding-form.js
+++ b/public/javascripts/onboarding-form.js
@@ -81,6 +81,7 @@ async function saveRow(section, rowId) {
         setSaved();
         if (section === 'metered-products') refreshProductDropdowns();
         if (section === 'tanks') refreshTankDropdowns();
+        if (section === 'banks') refreshBankDatalist();
     } catch {
         setSaveError();
     }
@@ -100,6 +101,7 @@ async function addRow(section) {
         tbody.insertAdjacentHTML('beforeend', buildNewRow(section, id));
         if (section === 'tanks') refreshProductDropdowns();
         if (section === 'nozzles') refreshTankDropdowns();
+        if (section === 'banks') refreshBankDatalist();
     } catch {
         alert('Failed to add row. Please try again.');
     }
@@ -114,6 +116,7 @@ async function deleteRow(section, rowId, btn) {
         btn.closest('tr').remove();
         if (section === 'metered-products') refreshProductDropdowns();
         if (section === 'tanks') refreshTankDropdowns();
+        if (section === 'banks') refreshBankDatalist();
     } catch {
         alert('Failed to delete row. Please try again.');
     }
@@ -160,6 +163,19 @@ function refreshTankDropdowns() {
     });
 }
 
+function refreshBankDatalist() {
+    const dl = document.getElementById('bank-datalist');
+    if (!dl) return;
+    const banks = [];
+    document.querySelectorAll('#tbody-banks tr').forEach(tr => {
+        const sn = tr.querySelector('[data-field="short_name"]')?.value?.trim();
+        const bn = tr.querySelector('[data-field="bank_name"]')?.value?.trim();
+        const val = sn || bn;
+        if (val) banks.push(val);
+    });
+    dl.innerHTML = banks.map(b => `<option value="${escHtml(b)}">`).join('');
+}
+
 // ── Build HTML for a new empty row ────────────────────────────────────────────
 function buildNewRow(section, id) {
     const del = `<button type="button" class="btn btn-outline-danger btn-sm" onclick="deleteRow('${section}',${id},this)">×</button>`;
@@ -183,6 +199,9 @@ function buildNewRow(section, id) {
         'metered-products': `<tr ${a}>
             <td data-label="Product Name"><input class="form-control form-control-sm" type="text" data-field="product_name" placeholder="As per Invoice e.g. EBMS"></td>
             <td data-label="Short Name"><input class="form-control form-control-sm" type="text" data-field="short_name" placeholder="e.g. MS / HSD"></td>
+            <td data-label="HSN Code"><input class="form-control form-control-sm" type="text" data-field="hsn_code" placeholder="e.g. 27101290" maxlength="20"></td>
+            <td data-label="CGST %"><input class="form-control form-control-sm" type="number" step="0.01" min="0" max="50" data-field="cgst_percent" placeholder="e.g. 9"></td>
+            <td data-label="SGST %"><input class="form-control form-control-sm" type="number" step="0.01" min="0" max="50" data-field="sgst_percent" placeholder="e.g. 9"></td>
             <td class="text-center align-middle">${del}</td></tr>`,
 
         'tanks': `<tr ${a}>
@@ -207,6 +226,9 @@ function buildNewRow(section, id) {
                 <option>Litres</option><option>Nos</option><option>Kgs</option>
             </select></td>
             <td data-label="Price (₹)"><input class="form-control form-control-sm" type="number" step="0.01" data-field="selling_price" placeholder="0.00"></td>
+            <td data-label="HSN Code"><input class="form-control form-control-sm" type="text" data-field="hsn_code" placeholder="e.g. 27101290" maxlength="20"></td>
+            <td data-label="CGST %"><input class="form-control form-control-sm" type="number" step="0.01" min="0" max="50" data-field="cgst_percent" placeholder="e.g. 9"></td>
+            <td data-label="SGST %"><input class="form-control form-control-sm" type="number" step="0.01" min="0" max="50" data-field="sgst_percent" placeholder="e.g. 9"></td>
             <td class="text-center align-middle">${del}</td></tr>`,
 
         'banks': `<tr ${a}>
@@ -231,10 +253,7 @@ function buildNewRow(section, id) {
             <td data-label="Customer Name"><input class="form-control form-control-sm" type="text" data-field="customer_name" placeholder="Trade Name"></td>
             <td data-label="Address"><input class="form-control form-control-sm" type="text" data-field="address" placeholder="Billing Address"></td>
             <td data-label="GSTIN"><input class="form-control form-control-sm" type="text" data-field="gstin" placeholder="GSTIN" maxlength="15"></td>
-            <td data-label="Owner Name"><input class="form-control form-control-sm" type="text" data-field="owner_name" placeholder="Owner Name"></td>
-            <td data-label="Owner Mobile"><input class="form-control form-control-sm" type="tel" data-field="owner_mobile" placeholder="10-digit" maxlength="10"></td>
-            <td data-label="Manager"><input class="form-control form-control-sm" type="text" data-field="manager_name" placeholder="Manager Name"></td>
-            <td data-label="Mgr Mobile"><input class="form-control form-control-sm" type="tel" data-field="manager_mobile" placeholder="10-digit" maxlength="10"></td>
+            <td data-label="Remittance Bank"><input class="form-control form-control-sm" type="text" list="bank-datalist" data-field="remittance_bank" placeholder="Bank short name"></td>
             <td data-label="Type"><select class="form-control form-control-sm" data-field="customer_type">
                 <option value="">-- Select --</option>
                 <option>Credit</option><option>Cash</option>
@@ -249,6 +268,20 @@ function buildNewRow(section, id) {
     return rows[section] || '';
 }
 
+// ── CAPS enforcement ──────────────────────────────────────────────────────────
+function enforceUppercase(el) {
+    if (!el || el.tagName !== 'INPUT') return;
+    const t = (el.type || '').toLowerCase();
+    if (t === 'url' || t === 'date' || t === 'number' || t === 'email' || t === 'tel') return;
+    const upper = el.value.toUpperCase();
+    if (el.value !== upper) {
+        const start = el.selectionStart;
+        const end   = el.selectionEnd;
+        el.value = upper;
+        try { el.setSelectionRange(start, end); } catch (_) {}
+    }
+}
+
 // ── Init ───────────────────────────────────────────────────────────────────────
 document.addEventListener('DOMContentLoaded', () => {
     const el = _indicator();
@@ -256,6 +289,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     refreshProductDropdowns();
     refreshTankDropdowns();
+    refreshBankDatalist();
+
+    // CAPS: run before save listeners so saved value is already uppercased
+    ['tab-ro', 'onboarding-sections'].forEach(id => {
+        document.getElementById(id)?.addEventListener('input', e => enforceUppercase(e.target), true);
+    });
 
     document.getElementById('tab-ro')?.addEventListener('input', scheduleRoSave);
 

--- a/routes/onboarding-admin-routes.js
+++ b/routes/onboarding-admin-routes.js
@@ -9,7 +9,8 @@ const isLoggedIn = login.ensureLoggedIn({});
 
 router.get('/',              isLoggedIn, ctrl.adminList);
 router.post('/',             isLoggedIn, ctrl.adminCreate);
-router.get('/config-hints',  isLoggedIn, ctrl.adminConfigHints);  // must be before /:id
+router.get('/config-hints',   isLoggedIn, ctrl.adminConfigHints);   // must be before /:id
+router.get('/hsn-suggestions', isLoggedIn, ctrl.hsnSuggestions);    // must be before /:id
 router.get('/:id',           isLoggedIn, ctrl.adminDetail);
 router.patch('/:id/status',  isLoggedIn, ctrl.adminUpdateStatus);
 router.post('/:id/migrate',  isLoggedIn, migrateCtrl.migrate);

--- a/views/onboarding/admin-detail.pug
+++ b/views/onboarding/admin-detail.pug
@@ -243,6 +243,44 @@ block content
                 else
                     p.text-muted.mb-0 No entries
 
+            +detailSection("colProductTax", `Product Tax — HSN & GST% (${formData.metered_products.length + formData.lubes.length} products)`)
+                p.small.text-muted.mb-2 Edit HSN codes and GST% before migration. HSN suggestions are drawn from existing products across all locations.
+                if formData.metered_products.length || formData.lubes.length
+                    .table-responsive
+                        table.table.table-sm.table-bordered.mb-0#taxEditTable
+                            thead.thead-light
+                                tr
+                                    th Type
+                                    th Product Name
+                                    th Short Name / Unit
+                                    th HSN Code
+                                    th CGST %
+                                    th SGST %
+                                    th(width="80")
+                            tbody
+                                each p in formData.metered_products
+                                    tr(data-tax-section="metered-products" data-tax-id=p.id)
+                                        td.small.text-muted Metered
+                                        td.small= p.product_name || '—'
+                                        td.small= p.short_name || '—'
+                                        td: input.form-control.form-control-sm(type="text" list="hsnDatalist" class="tax-hsn" value=(p.hsn_code||'') placeholder="e.g. 27101290")
+                                        td: input.form-control.form-control-sm(type="number" step="0.01" min="0" max="50" class="tax-cgst" value=(p.cgst_percent!=null?p.cgst_percent:'') placeholder="e.g. 9")
+                                        td: input.form-control.form-control-sm(type="number" step="0.01" min="0" max="50" class="tax-sgst" value=(p.sgst_percent!=null?p.sgst_percent:'') placeholder="e.g. 9")
+                                        td: button.btn.btn-outline-secondary.btn-sm(type="button" onclick=`saveTaxRow(this)`) Save
+                                each l in formData.lubes
+                                    tr(data-tax-section="lubes" data-tax-id=l.id)
+                                        td.small.text-muted Lube
+                                        td.small= l.product_name || '—'
+                                        td.small= l.unit || '—'
+                                        td: input.form-control.form-control-sm(type="text" list="hsnDatalist" class="tax-hsn" value=(l.hsn_code||'') placeholder="e.g. 27101290")
+                                        td: input.form-control.form-control-sm(type="number" step="0.01" min="0" max="50" class="tax-cgst" value=(l.cgst_percent!=null?l.cgst_percent:'') placeholder="e.g. 9")
+                                        td: input.form-control.form-control-sm(type="number" step="0.01" min="0" max="50" class="tax-sgst" value=(l.sgst_percent!=null?l.sgst_percent:'') placeholder="e.g. 9")
+                                        td: button.btn.btn-outline-secondary.btn-sm(type="button" onclick=`saveTaxRow(this)`) Save
+                    datalist#hsnDatalist
+                    p.text-muted.mt-1.mb-0(style="font-size:11px") HSN suggestions load from historical data when you click an HSN field.
+                else
+                    p.text-muted.mb-0 No products to edit
+
     //- ── Migrate to PetroMath Modal ────────────────────────────────────────────
     #migrateModal.modal.fade(tabindex="-1" role="dialog" aria-labelledby="migrateModalLabel" aria-hidden="true")
         .modal-dialog.modal-lg(role="document")
@@ -252,6 +290,12 @@ block content
                     button.close(type="button" data-dismiss="modal" aria-label="Close")
                         span(aria-hidden="true") ×
                 .modal-body
+                    //- Pre-flight validation
+                    #preflightCheck.mb-3
+                        p.small.font-weight-bold.text-secondary.mb-1 Pre-flight Validation
+                        #preflightBody
+                            p.text-muted.small.mb-0 Loading…
+                    hr.my-3
                     p.text-muted.small.mb-3
                         | Creates the location and inserts all masters into PetroMath. Safe to re-run — existing records are detected and skipped.
                     .form-row
@@ -263,6 +307,14 @@ block content
                             label.font-weight-bold(for="migrateTemplateLocCode") Template Location
                             input.form-control#migrateTemplateLocCode(type="text" placeholder="e.g. MUE or SFS" autocomplete="off")
                             small.form-text.text-muted Used for Account Heads & Ledger Rules. Auto-suggested from RO brand.
+                    if formData.suppliers.length
+                        .form-group.mb-2
+                            label.font-weight-bold.small Suppliers to Migrate
+                            p.text-muted(style="font-size:12px;margin-bottom:4px;") Uncheck suppliers that will be auto-created by the location trigger (e.g. oil company vendors).
+                            each s in formData.suppliers
+                                .form-check.form-check-inline
+                                    input.form-check-input(type="checkbox" id=`chkSupp${s.id}` value=s.id checked)
+                                    label.form-check-label.small(for=`chkSupp${s.id}`)= s.supplier_name || `Row ${s.id}`
                     .alert.alert-warning.py-2.small
                         strong Note:
                         |  Banks with missing Account Number or IFSC Code will be skipped — fill those fields in the onboarding form first.
@@ -281,12 +333,76 @@ block content
     script.
         var OB_ID = !{onboarding.id};
         var OB_STATUS = '!{onboarding.status}';
+        var OB_TOKEN = '!{onboarding.token}';
         var OB_RO_BRAND = '!{formData.ro ? (formData.ro.ro_brand || "") : ""}';
+        var OB_FORM_DATA = !{JSON.stringify(formData)};
+
+        function runPreflightCheck() {
+            var fd = OB_FORM_DATA;
+            var issues = [], warnings = [];
+
+            // Build lookup sets (case-insensitive)
+            var productSN = new Set();
+            (fd.metered_products || []).forEach(function(p) {
+                var sn = (p.short_name || '').trim().toUpperCase();
+                if (sn) productSN.add(sn);
+                if (!p.product_name || !p.product_name.trim()) issues.push('Metered product row with empty name');
+                else if (!sn) warnings.push('Product "' + p.product_name + '" has no Short Name — name will be used as product_code in tanks/nozzles');
+            });
+
+            var tankNames = new Set();
+            (fd.tanks || []).forEach(function(t) {
+                var tn = (t.tank_name || '').trim().toUpperCase();
+                if (tn) tankNames.add(tn);
+                if (!tn) { issues.push('Tank row with empty name'); return; }
+                var pn = (t.product_short_name || '').trim().toUpperCase();
+                if (!pn) warnings.push('Tank "' + t.tank_name + '" has no product assigned');
+                else if (!productSN.has(pn)) issues.push('Tank "' + t.tank_name + '" → product "' + t.product_short_name + '" not found in Metered Products');
+            });
+
+            (fd.nozzles || []).forEach(function(n) {
+                var nn = (n.nozzle_name || '').trim();
+                if (!nn) { issues.push('Nozzle row with empty name'); return; }
+                var tc = (n.tank_connected || '').trim().toUpperCase();
+                if (!tc) warnings.push('Nozzle "' + nn + '" not connected to any tank');
+                else if (!tankNames.has(tc)) issues.push('Nozzle "' + nn + '" → tank "' + n.tank_connected + '" not found in Tanks');
+                var np = (n.nozzle_product || '').trim().toUpperCase();
+                if (!np) warnings.push('Nozzle "' + nn + '" has no product set');
+                else if (!productSN.has(np)) warnings.push('Nozzle "' + nn + '" → product "' + n.nozzle_product + '" not in Metered Products (short name mismatch?)');
+            });
+
+            (fd.banks || []).forEach(function(b) {
+                if (!b.bank_name) return;
+                var missing = [];
+                if (!b.account_number) missing.push('Account Number');
+                if (!b.ifsc_code) missing.push('IFSC Code');
+                if (missing.length) warnings.push('Bank "' + b.bank_name + '" missing ' + missing.join(' & ') + ' — will be skipped during migration');
+            });
+
+            var el = document.getElementById('preflightBody');
+            var html = '';
+            if (!issues.length && !warnings.length) {
+                html = '<div class="alert alert-success py-2 mb-0 small"><strong>✓ All checks passed.</strong> Data looks good to migrate.</div>';
+            } else {
+                if (issues.length) {
+                    html += '<div class="alert alert-danger py-2 mb-2 small"><strong>Issues (' + issues.length + ') — fix before migrating:</strong><ul class="mb-0 pl-3 mt-1">';
+                    issues.forEach(function(i) { html += '<li>' + i + '</li>'; });
+                    html += '</ul></div>';
+                }
+                if (warnings.length) {
+                    html += '<div class="alert alert-warning py-2 mb-0 small"><strong>Warnings (' + warnings.length + '):</strong><ul class="mb-0 pl-3 mt-1">';
+                    warnings.forEach(function(w) { html += '<li>' + w + '</li>'; });
+                    html += '</ul></div>';
+                }
+            }
+            el.innerHTML = html;
+        }
 
         // Auto-suggest template location + load config hints when modal opens
         var TEMPLATE_SUGGESTIONS = { 'IOCL': 'MUE', 'BPCL': 'SFS' };
         var configHintsLoaded = false;
-        document.getElementById('migrateModal').addEventListener('show.bs.modal', function() {
+        $('#migrateModal').on('show.bs.modal', function() {
+            runPreflightCheck();
             var templateInput = document.getElementById('migrateTemplateLocCode');
             if (!templateInput.value && TEMPLATE_SUGGESTIONS[OB_RO_BRAND]) {
                 templateInput.value = TEMPLATE_SUGGESTIONS[OB_RO_BRAND];
@@ -294,10 +410,13 @@ block content
             if (!configHintsLoaded) {
                 configHintsLoaded = true;
                 fetch('/admin/onboarding/config-hints')
-                    .then(function(r) { return r.json(); })
+                    .then(function(r) {
+                        if (!r.ok) throw new Error('HTTP ' + r.status);
+                        return r.json();
+                    })
                     .then(function(hints) {
                         var el = document.getElementById('configHintTable');
-                        if (!hints.length) { el.innerHTML = '<p class="text-muted small mb-0">No location configs found.</p>'; return; }
+                        if (!hints.length) { el.innerHTML = '<p class="text-muted small mb-0">No location configs found for MUE / SFS / AACBE.</p>'; return; }
                         var h = '<div class="table-responsive mt-1"><table class="table table-sm table-bordered table-striped mb-0" style="font-size:12px">';
                         h += '<thead class="thead-light"><tr><th>Setting</th><th>MUE<br><small class="font-weight-normal text-muted">IOCL</small></th><th>SFS<br><small class="font-weight-normal text-muted">BPCL</small></th><th>AACBE</th></tr></thead><tbody>';
                         hints.forEach(function(row) {
@@ -307,8 +426,8 @@ block content
                         h += '<p class="text-muted mt-1 mb-0" style="font-size:11px">These settings are not migrated automatically. Insert into m_location_config for the new location after reviewing the values above.</p>';
                         el.innerHTML = h;
                     })
-                    .catch(function() {
-                        document.getElementById('configHintTable').innerHTML = '<p class="text-danger small mb-0">Failed to load config hints.</p>';
+                    .catch(function(e) {
+                        document.getElementById('configHintTable').innerHTML = '<p class="text-danger small mb-0">Failed to load config hints: ' + (e.message || 'unknown error') + '</p>';
                     });
             }
         });
@@ -351,11 +470,56 @@ block content
             }
         });
 
+        // ── HSN suggestions ─────────────────────────────────────────────────────
+        var hsnLoaded = false;
+        document.getElementById('taxEditTable')?.addEventListener('focus', function(e) {
+            if (!hsnLoaded && e.target.classList.contains('tax-hsn')) {
+                hsnLoaded = true;
+                fetch('/admin/onboarding/hsn-suggestions')
+                    .then(function(r) { return r.json(); })
+                    .then(function(rows) {
+                        var dl = document.getElementById('hsnDatalist');
+                        if (dl) dl.innerHTML = rows.map(function(r) {
+                            return '<option value="' + r.hsn_code + '">' + r.sample_products + '</option>';
+                        }).join('');
+                    })
+                    .catch(function() {});
+            }
+        }, true);
+
+        async function saveTaxRow(btn) {
+            var tr = btn.closest('tr');
+            var section = tr.dataset.taxSection;
+            var rowId   = tr.dataset.taxId;
+            var hsn  = tr.querySelector('.tax-hsn').value.trim().toUpperCase() || null;
+            var cgst = tr.querySelector('.tax-cgst').value || null;
+            var sgst = tr.querySelector('.tax-sgst').value || null;
+            btn.textContent = 'Saving…';
+            btn.disabled = true;
+            try {
+                var r = await fetch('/onboard/' + OB_TOKEN + '/' + section + '/' + rowId, {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ hsn_code: hsn, cgst_percent: cgst, sgst_percent: sgst })
+                });
+                btn.textContent = r.ok ? 'Saved ✓' : 'Error';
+                setTimeout(function() { btn.textContent = 'Save'; btn.disabled = false; }, 2000);
+            } catch(e) {
+                btn.textContent = 'Error';
+                btn.disabled = false;
+            }
+        }
+
         document.getElementById('btnRunMigrate').addEventListener('click', async function() {
             var locCode = document.getElementById('migrateLocCode').value.trim();
             var templateLoc = document.getElementById('migrateTemplateLocCode').value.trim();
             if (!locCode) { alert('Enter the PetroMath location code.'); return; }
             if (!templateLoc) { alert('Enter the template location code (used for Account Heads & Ledger Rules).'); return; }
+            // Collect unchecked supplier IDs to skip
+            var skipSupplierIds = [];
+            document.querySelectorAll('#migrateModal input[type=checkbox]').forEach(function(cb) {
+                if (!cb.checked) skipSupplierIds.push(parseInt(cb.value, 10));
+            });
             this.disabled = true;
             this.textContent = 'Running…';
             document.getElementById('migrateResults').style.display = 'none';
@@ -363,7 +527,7 @@ block content
                 var r = await fetch('/admin/onboarding/' + OB_ID + '/migrate', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ location_code: locCode, template_location: templateLoc })
+                    body: JSON.stringify({ location_code: locCode, template_location: templateLoc, skip_supplier_ids: skipSupplierIds })
                 });
                 var data = await r.json();
                 var resultsEl = document.getElementById('migrateResults');

--- a/views/onboarding/form.pug
+++ b/views/onboarding/form.pug
@@ -27,6 +27,8 @@ html(lang="en")
             .ob-table th { font-size: 12px; font-weight: 600; background: #f8f9fa; white-space: nowrap; }
             .ob-table td { vertical-align: middle; }
             .form-control-sm { font-size: 13px; }
+            input[type="text"].form-control,
+            input[type="text"].form-control-sm { text-transform: uppercase; }
             .setup-done-banner { background: #d4edda; border: 1px solid #c3e6cb; border-radius: 6px; padding: 12px 16px; margin-bottom: 16px; color: #155724; font-size: 14px; }
 
             /* ── Mobile responsive tables ───────────────────────────────────── */
@@ -169,7 +171,7 @@ html(lang="en")
                         .d-flex.justify-content-between.align-items-center.mb-2.section-row
                             div
                                 h6.mb-0 Metered Products
-                                p.section-hint.mb-0 Products sold through Dispensing Units. Short Name is used across Tanks and Nozzles tabs.
+                                p.section-hint.mb-0 Products sold through Dispensing Units. Short Name is used across Tanks and Nozzles tabs. HSN &amp; GST% will be verified by PetroMath admin before import.
                             button.btn.btn-primary.btn-sm(type="button" data-add-section="metered-products") + Add Row
                         .table-responsive
                             table.table.table-sm.table-bordered.ob-table
@@ -177,12 +179,18 @@ html(lang="en")
                                     tr
                                         th Product Name (as per Invoice)
                                         th Short Name
+                                        th HSN Code
+                                        th CGST %
+                                        th SGST %
                                         th(width="50")
                                 tbody#tbody-metered-products
                                     each row in formData.metered_products
                                         tr(data-section="metered-products" data-row-id=row.id)
                                             td(data-label="Product Name"): input.form-control.form-control-sm(type="text" data-field="product_name" value=(row.product_name||'') placeholder="e.g. EBMS, HSD")
                                             td(data-label="Short Name"): input.form-control.form-control-sm(type="text" data-field="short_name" value=(row.short_name||'') placeholder="e.g. MS / HSD")
+                                            td(data-label="HSN Code"): input.form-control.form-control-sm(type="text" data-field="hsn_code" value=(row.hsn_code||'') placeholder="e.g. 27101290" maxlength="20")
+                                            td(data-label="CGST %"): input.form-control.form-control-sm(type="number" step="0.01" min="0" max="50" data-field="cgst_percent" value=(row.cgst_percent!=null?row.cgst_percent:'') placeholder="e.g. 9")
+                                            td(data-label="SGST %"): input.form-control.form-control-sm(type="number" step="0.01" min="0" max="50" data-field="sgst_percent" value=(row.sgst_percent!=null?row.sgst_percent:'') placeholder="e.g. 9")
                                             td.text-center.align-middle
                                                 button.btn.btn-outline-danger.btn-sm(type="button" onclick=`deleteRow('metered-products',${row.id},this)`) ×
 
@@ -256,7 +264,7 @@ html(lang="en")
                         .d-flex.justify-content-between.align-items-center.mb-2.section-row
                             div
                                 h6.mb-0 Lubes & Other Products
-                                p.section-hint.mb-0 All products stocked in the RO except those sold through DU. Include SKU name with pack size.
+                                p.section-hint.mb-0 All products stocked in the RO except those sold through DU. Include SKU name with pack size. HSN &amp; GST% will be verified by admin.
                             button.btn.btn-primary.btn-sm(type="button" data-add-section="lubes") + Add Row
                         .table-responsive
                             table.table.table-sm.table-bordered.ob-table
@@ -265,6 +273,9 @@ html(lang="en")
                                         th Product Name (SKU + Pack Size)
                                         th Unit
                                         th Selling Price (₹)
+                                        th HSN Code
+                                        th CGST %
+                                        th SGST %
                                         th(width="50")
                                 tbody#tbody-lubes
                                     each row in formData.lubes
@@ -276,6 +287,9 @@ html(lang="en")
                                                     each u in ['Litres','Nos','Kgs']
                                                         option(value=u selected=(row.unit===u))= u
                                             td(data-label="Price (₹)"): input.form-control.form-control-sm(type="number" step="0.01" data-field="selling_price" value=(row.selling_price||'') placeholder="0.00")
+                                            td(data-label="HSN Code"): input.form-control.form-control-sm(type="text" data-field="hsn_code" value=(row.hsn_code||'') placeholder="e.g. 27101290" maxlength="20")
+                                            td(data-label="CGST %"): input.form-control.form-control-sm(type="number" step="0.01" min="0" max="50" data-field="cgst_percent" value=(row.cgst_percent!=null?row.cgst_percent:'') placeholder="e.g. 9")
+                                            td(data-label="SGST %"): input.form-control.form-control-sm(type="number" step="0.01" min="0" max="50" data-field="sgst_percent" value=(row.sgst_percent!=null?row.sgst_percent:'') placeholder="e.g. 9")
                                             td.text-center.align-middle
                                                 button.btn.btn-outline-danger.btn-sm(type="button" onclick=`deleteRow('lubes',${row.id},this)`) ×
 
@@ -345,8 +359,11 @@ html(lang="en")
                         .d-flex.justify-content-between.align-items-center.mb-2.section-row
                             div
                                 h6.mb-0 Customers
-                                p.section-hint.mb-0 Customers for whom you maintain a ledger. Obtain RC copy for accurate GSTIN details.
+                                p.section-hint.mb-0 Customers for whom you maintain a ledger. Remittance Bank is which bank they pay through — select from the Banks tab.
                             button.btn.btn-primary.btn-sm(type="button" data-add-section="customers") + Add Row
+                        datalist#bank-datalist
+                            each b in formData.banks
+                                option(value=(b.short_name || b.bank_name || ''))
                         .table-responsive
                             table.table.table-sm.table-bordered.ob-table
                                 thead
@@ -354,10 +371,7 @@ html(lang="en")
                                         th Customer / Org Name
                                         th Address
                                         th GSTIN
-                                        th Owner Name
-                                        th Owner Mobile
-                                        th Manager Name
-                                        th Manager Mobile
+                                        th Remittance Bank
                                         th Type
                                         th(width="50")
                                 tbody#tbody-customers
@@ -366,10 +380,7 @@ html(lang="en")
                                             td(data-label="Customer Name"): input.form-control.form-control-sm(type="text" data-field="customer_name" value=(row.customer_name||'') placeholder="Trade Name")
                                             td(data-label="Address"): input.form-control.form-control-sm(type="text" data-field="address" value=(row.address||'') placeholder="Billing Address")
                                             td(data-label="GSTIN"): input.form-control.form-control-sm(type="text" data-field="gstin" value=(row.gstin||'') placeholder="GSTIN" maxlength="15")
-                                            td(data-label="Owner Name"): input.form-control.form-control-sm(type="text" data-field="owner_name" value=(row.owner_name||'') placeholder="Owner Name")
-                                            td(data-label="Owner Mobile"): input.form-control.form-control-sm(type="tel" data-field="owner_mobile" value=(row.owner_mobile||'') placeholder="10-digit" maxlength="10")
-                                            td(data-label="Manager"): input.form-control.form-control-sm(type="text" data-field="manager_name" value=(row.manager_name||'') placeholder="Manager Name")
-                                            td(data-label="Mgr Mobile"): input.form-control.form-control-sm(type="tel" data-field="manager_mobile" value=(row.manager_mobile||'') placeholder="10-digit" maxlength="10")
+                                            td(data-label="Remittance Bank"): input.form-control.form-control-sm(type="text" list="bank-datalist" data-field="remittance_bank" value=(row.remittance_bank||'') placeholder="Bank short name")
                                             td(data-label="Type")
                                                 select.form-control.form-control-sm(data-field="customer_type")
                                                     option(value="" selected=!row.customer_type) -- Select --


### PR DESCRIPTION
## Summary
- CAPS enforcement on all text inputs (form JS + CSS + server-side before INSERT)
- Pre-flight validation in migration modal — checks product→tank→nozzle cross-references before running
- Bootstrap modal event fix: `show.bs.modal` now uses jQuery `.on()` so config hints actually load
- GST% + HSN fields added to metered products and lubes (form, DAO, migration to `m_product`)
- Customer remittance bank: replaced contact fields (owner/manager) with `remittance_bank` dropdown; resolves to `m_bank.bank_id` on migrate
- Supplier skip: checkboxes in migration modal; oil company suppliers (auto-created by trigger) can be unchecked
- Admin-detail Product Tax panel: admin can edit HSN/GST% per product with historical HSN suggestions from `m_product`
- DB migrations run on dev and prod: `onboarding-product-gst-hsn.sql`, `onboarding-customer-remit-bank.sql`

## Test plan
- [ ] Open onboarding form — verify text inputs auto-uppercase as you type
- [ ] Check customers tab — contact fields gone, remittance bank datalist shows banks from Banks tab
- [ ] Check metered products + lubes — HSN Code, CGST%, SGST% columns present
- [ ] Open admin-detail → Migrate modal — verify pre-flight shows green/warnings correctly
- [ ] Verify config hints load (no longer stuck on "Loading…")
- [ ] Check supplier checkboxes in modal; uncheck one and confirm it's skipped in results
- [ ] Open Product Tax accordion section — edit HSN, click an HSN field to load suggestions, save a row
- [ ] Run full migration and verify GST%/HSN lands in m_product, remittance_bank_id set in m_credit_list

🤖 Generated with [Claude Code](https://claude.com/claude-code)