### PR TITLE
Onboarding: editable config hints + Apply Config to m_location_config

### DIFF
--- a/controllers/onboarding-controller.js
+++ b/controllers/onboarding-controller.js
@@ -151,6 +151,32 @@ module.exports = {
         }
     },
 
+    applyConfig: async (req, res, next) => {
+        try {
+            const { location_code, settings } = req.body;
+            if (!location_code?.trim()) return res.status(400).json({ error: 'location_code is required' });
+            if (!settings || typeof settings !== 'object') return res.status(400).json({ error: 'settings object is required' });
+            const loc = location_code.trim().toUpperCase();
+            const entries = Object.entries(settings).filter(([, v]) => v !== null && v !== '');
+            if (!entries.length) return res.json({ inserted: 0 });
+            for (const [name, value] of entries) {
+                // Remove any existing open-ended row for this location+setting, then insert fresh
+                await db.sequelize.query(
+                    `DELETE FROM m_location_config WHERE location_code = :loc AND setting_name = :name AND effective_end_date = '9999-12-31'`,
+                    { replacements: { loc, name }, type: QueryTypes.DELETE }
+                );
+                await db.sequelize.query(
+                    `INSERT INTO m_location_config (location_code, setting_name, setting_value, effective_start_date, effective_end_date, created_by)
+                     VALUES (:loc, :name, :value, CURDATE(), '9999-12-31', 'onboarding')`,
+                    { replacements: { loc, name, value }, type: QueryTypes.INSERT }
+                );
+            }
+            res.json({ inserted: entries.length });
+        } catch (e) {
+            next(e);
+        }
+    },
+
     hsnSuggestions: async (req, res, next) => {
         try {
             const q = (req.query.q || '').trim();

--- a/routes/onboarding-admin-routes.js
+++ b/routes/onboarding-admin-routes.js
@@ -11,8 +11,9 @@ router.get('/',              isLoggedIn, ctrl.adminList);
 router.post('/',             isLoggedIn, ctrl.adminCreate);
 router.get('/config-hints',   isLoggedIn, ctrl.adminConfigHints);   // must be before /:id
 router.get('/hsn-suggestions', isLoggedIn, ctrl.hsnSuggestions);    // must be before /:id
-router.get('/:id',           isLoggedIn, ctrl.adminDetail);
-router.patch('/:id/status',  isLoggedIn, ctrl.adminUpdateStatus);
-router.post('/:id/migrate',  isLoggedIn, migrateCtrl.migrate);
+router.get('/:id',              isLoggedIn, ctrl.adminDetail);
+router.patch('/:id/status',     isLoggedIn, ctrl.adminUpdateStatus);
+router.post('/:id/migrate',     isLoggedIn, migrateCtrl.migrate);
+router.post('/:id/apply-config', isLoggedIn, ctrl.applyConfig);
 
 module.exports = router;

--- a/views/onboarding/admin-detail.pug
+++ b/views/onboarding/admin-detail.pug
@@ -417,14 +417,59 @@ block content
                     .then(function(hints) {
                         var el = document.getElementById('configHintTable');
                         if (!hints.length) { el.innerHTML = '<p class="text-muted small mb-0">No location configs found for MUE / SFS / AACBE.</p>'; return; }
-                        var h = '<div class="table-responsive mt-1"><table class="table table-sm table-bordered table-striped mb-0" style="font-size:12px">';
-                        h += '<thead class="thead-light"><tr><th>Setting</th><th>MUE<br><small class="font-weight-normal text-muted">IOCL</small></th><th>SFS<br><small class="font-weight-normal text-muted">BPCL</small></th><th>AACBE</th></tr></thead><tbody>';
+                        // Pre-fill new-location column from brand template (IOCL→MUE, BPCL→SFS)
+                        var tmplCol = OB_RO_BRAND === 'IOCL' ? 'MUE' : (OB_RO_BRAND === 'BPCL' ? 'SFS' : null);
+                        var h = '<div class="table-responsive mt-1"><table class="table table-sm table-bordered mb-0" style="font-size:12px" id="configHintsTable">';
+                        h += '<thead class="thead-light"><tr><th>Setting</th><th>MUE<br><small class="font-weight-normal text-muted">IOCL</small></th><th>SFS<br><small class="font-weight-normal text-muted">BPCL</small></th><th>AACBE</th><th style="min-width:110px">New Location</th></tr></thead><tbody>';
                         hints.forEach(function(row) {
-                            h += '<tr><td>' + row.name + '</td><td>' + (row.MUE || '<span class="text-muted">—</span>') + '</td><td>' + (row.SFS || '<span class="text-muted">—</span>') + '</td><td>' + (row.AACBE || '<span class="text-muted">—</span>') + '</td></tr>';
+                            var prefill = tmplCol ? (row[tmplCol] || '') : '';
+                            h += '<tr>';
+                            h += '<td>' + row.name + '</td>';
+                            h += '<td>' + (row.MUE || '<span class="text-muted">—</span>') + '</td>';
+                            h += '<td>' + (row.SFS || '<span class="text-muted">—</span>') + '</td>';
+                            h += '<td>' + (row.AACBE || '<span class="text-muted">—</span>') + '</td>';
+                            h += '<td><input type="text" class="form-control form-control-sm config-new-val" data-setting="' + row.name + '" value="' + prefill + '" style="min-width:90px"></td>';
+                            h += '</tr>';
                         });
                         h += '</tbody></table></div>';
-                        h += '<p class="text-muted mt-1 mb-0" style="font-size:11px">These settings are not migrated automatically. Insert into m_location_config for the new location after reviewing the values above.</p>';
+                        h += '<div class="d-flex align-items-center mt-2">';
+                        h += '<button type="button" class="btn btn-sm btn-outline-primary mr-2" id="btnApplyConfig">Apply Config to Location</button>';
+                        h += '<span id="applyConfigStatus" class="small text-muted"></span>';
+                        h += '</div>';
+                        h += '<p class="text-muted mt-1 mb-0" style="font-size:11px">Filled values will be inserted into m_location_config for the new location. Blank rows are skipped.</p>';
                         el.innerHTML = h;
+
+                        document.getElementById('btnApplyConfig').addEventListener('click', async function() {
+                            var locCode = document.getElementById('migrateLocCode').value.trim();
+                            if (!locCode) { alert('Enter the Location Code first (in the fields above).'); return; }
+                            var settings = {};
+                            document.querySelectorAll('#configHintsTable .config-new-val').forEach(function(inp) {
+                                var v = inp.value.trim();
+                                if (v) settings[inp.dataset.setting] = v;
+                            });
+                            if (!Object.keys(settings).length) { alert('No values to apply — fill in the New Location column first.'); return; }
+                            this.disabled = true;
+                            document.getElementById('applyConfigStatus').textContent = 'Saving…';
+                            try {
+                                var r = await fetch('/admin/onboarding/' + OB_ID + '/apply-config', {
+                                    method: 'POST',
+                                    headers: { 'Content-Type': 'application/json' },
+                                    body: JSON.stringify({ location_code: locCode, settings: settings })
+                                });
+                                var data = await r.json();
+                                if (r.ok) {
+                                    document.getElementById('applyConfigStatus').textContent = '✓ ' + data.inserted + ' settings saved to m_location_config.';
+                                    document.getElementById('applyConfigStatus').className = 'small text-success';
+                                } else {
+                                    throw new Error(data.error || 'Failed');
+                                }
+                            } catch(e) {
+                                document.getElementById('applyConfigStatus').textContent = 'Error: ' + e.message;
+                                document.getElementById('applyConfigStatus').className = 'small text-danger';
+                            } finally {
+                                this.disabled = false;
+                            }
+                        });
                     })
                     .catch(function(e) {
                         document.getElementById('configHintTable').innerHTML = '<p class="text-danger small mb-0">Failed to load config hints: ' + (e.message || 'unknown error') + '</p>';


### PR DESCRIPTION
## Summary
- Config hints table in migration modal now has an editable "New Location" column
- Values pre-filled from brand template (IOCL→MUE, BPCL→SFS)
- "Apply Config to Location" button inserts filled settings into m_location_config with proper effective dates
- Idempotent: deletes existing open-ended row before re-inserting

## Test plan
- [ ] Open migration modal → expand Location Config Checklist
- [ ] Verify New Location column appears pre-filled from brand template
- [ ] Edit a value, click Apply Config — confirm "✓ N settings saved" appears
- [ ] Check m_location_config in DB for the new location

🤖 Generated with [Claude Code](https://claude.com/claude-code)