### PR TITLE
Onboarding: fix m_location_config insert, credit list type, no-space codes, full audit columns

### DIFF
--- a/controllers/onboarding-controller.js
+++ b/controllers/onboarding-controller.js
@@ -166,8 +166,8 @@ module.exports = {
                     { replacements: { loc, name }, type: QueryTypes.DELETE }
                 );
                 await db.sequelize.query(
-                    `INSERT INTO m_location_config (location_code, setting_name, setting_value, effective_start_date, effective_end_date, created_by)
-                     VALUES (:loc, :name, :value, CURDATE(), '9999-12-31', 'onboarding')`,
+                    `INSERT INTO m_location_config (location_code, setting_name, setting_value, effective_start_date, effective_end_date, created_by, updated_by, creation_date, updation_date)
+                     VALUES (:loc, :name, :value, CURDATE(), '9999-12-31', 'onboarding', 'onboarding', NOW(), NOW())`,
                     { replacements: { loc, name, value }, type: QueryTypes.INSERT }
                 );
             }

--- a/controllers/onboarding-migrate-controller.js
+++ b/controllers/onboarding-migrate-controller.js
@@ -60,7 +60,8 @@ module.exports = {
             const results = [];
 
             // Helper: uppercase a string value safely
-            const up = (v) => (typeof v === 'string' && v.trim() ? v.trim().toUpperCase() : (v || null));
+            const up   = (v) => (typeof v === 'string' && v.trim() ? v.trim().toUpperCase() : (v || null));
+            const code = (v) => up(v) ? up(v).replace(/\s+/g, '') : null;
 
             // ── Step 1: Create Location ──────────────────────────────────────────
             {
@@ -72,8 +73,8 @@ module.exports = {
                 } else {
                     try {
                         await insertRow(
-                            `INSERT INTO m_location (location_code, location_name, address, company_name, phone, gst_number, start_date, effective_end_date, created_by)
-                             VALUES (:loc, :name, :address, :company, :phone, :gst, CURDATE(), '9999-12-31', 'onboarding')`,
+                            `INSERT INTO m_location (location_code, location_name, address, company_name, phone, gst_number, start_date, effective_end_date, created_by, updated_by, creation_date)
+                             VALUES (:loc, :name, :address, :company, :phone, :gst, CURDATE(), '9999-12-31', 'onboarding', 'onboarding', NOW())`,
                             {
                                 loc,
                                 name:    up(ro.ro_name    || onboarding.location_name),
@@ -101,8 +102,8 @@ module.exports = {
                 );
                 if (exists) return 'skipped';
                 await insertRow(
-                    `INSERT INTO m_supplier (supplier_name, supplier_short_name, location_code, effective_start_date, effective_end_date, created_by)
-                     VALUES (:name, :short, :loc, CURDATE(), '9999-12-31', 'onboarding')`,
+                    `INSERT INTO m_supplier (supplier_name, supplier_short_name, location_code, effective_start_date, effective_end_date, created_by, updated_by)
+                     VALUES (:name, :short, :loc, CURDATE(), '9999-12-31', 'onboarding', 'onboarding')`,
                     { name: up(s.supplier_name), short: up(s.short_name || s.supplier_name), loc }
                 );
             }));
@@ -117,8 +118,8 @@ module.exports = {
                 if (exists) return 'skipped';
                 const rgb = PRODUCT_RGB[(p.short_name || '').toUpperCase()] || '200,200,200';
                 await insertRow(
-                    `INSERT INTO m_product (product_name, location_code, qty, unit, is_tank_product, rgb_color, hsn_code, cgst_percent, sgst_percent, created_by)
-                     VALUES (:name, :loc, 1, 'Litres', 1, :rgb, :hsn, :cgst, :sgst, 'onboarding')`,
+                    `INSERT INTO m_product (product_name, location_code, qty, unit, is_tank_product, rgb_color, hsn_code, cgst_percent, sgst_percent, created_by, updated_by)
+                     VALUES (:name, :loc, 1, 'Litres', 1, :rgb, :hsn, :cgst, :sgst, 'onboarding', 'onboarding')`,
                     { name: up(p.product_name), loc, rgb, hsn: up(p.hsn_code) || null, cgst: p.cgst_percent ?? null, sgst: p.sgst_percent ?? null }
                 );
             }));
@@ -132,8 +133,8 @@ module.exports = {
                 );
                 if (exists) return 'skipped';
                 await insertRow(
-                    `INSERT INTO m_product (product_name, location_code, qty, unit, price, is_lube_product, hsn_code, cgst_percent, sgst_percent, created_by)
-                     VALUES (:name, :loc, 1, :unit, :price, 1, :hsn, :cgst, :sgst, 'onboarding')`,
+                    `INSERT INTO m_product (product_name, location_code, qty, unit, price, is_lube_product, hsn_code, cgst_percent, sgst_percent, created_by, updated_by)
+                     VALUES (:name, :loc, 1, :unit, :price, 1, :hsn, :cgst, :sgst, 'onboarding', 'onboarding')`,
                     { name: up(l.product_name), loc, unit: l.unit || 'Nos', price: l.selling_price || null, hsn: up(l.hsn_code) || null, cgst: l.cgst_percent ?? null, sgst: l.sgst_percent ?? null }
                 );
             }));
@@ -143,13 +144,13 @@ module.exports = {
                 if (!t.tank_name) return 'skipped';
                 const exists = await selectOne(
                     'SELECT tank_id FROM m_tank WHERE tank_code = :code AND location_code = :loc',
-                    { code: up(t.tank_name), loc }
+                    { code: code(t.tank_name), loc }
                 );
                 if (exists) return 'skipped';
                 await insertRow(
-                    `INSERT INTO m_tank (tank_code, product_code, location_code, tank_orig_capacity, tank_opening_stock, effective_start_date, effective_end_date, created_by)
-                     VALUES (:code, :product, :loc, :capacity, 0, CURDATE(), '9999-12-31', 'onboarding')`,
-                    { code: up(t.tank_name), product: up(t.product_short_name) || '', loc, capacity: t.tank_capacity || 0 }
+                    `INSERT INTO m_tank (tank_code, product_code, location_code, tank_orig_capacity, tank_opening_stock, effective_start_date, effective_end_date, created_by, updated_by, creation_date)
+                     VALUES (:code, :product, :loc, :capacity, 0, CURDATE(), '9999-12-31', 'onboarding', 'onboarding', NOW())`,
+                    { code: code(t.tank_name), product: up(t.product_short_name) || '', loc, capacity: t.tank_capacity || 0 }
                 );
             }));
 
@@ -158,7 +159,7 @@ module.exports = {
                 if (!n.nozzle_name) return 'skipped';
                 const exists = await selectOne(
                     'SELECT pump_id FROM m_pump WHERE pump_code = :code AND location_code = :loc',
-                    { code: up(n.nozzle_name), loc }
+                    { code: code(n.nozzle_name), loc }
                 );
                 if (exists) return 'skipped';
                 const stampingDue = n.next_stamping_date
@@ -166,19 +167,19 @@ module.exports = {
                     : '0000-00-00 00:00:00';
                 const pump_id = await insertRow(
                     `INSERT INTO m_pump (pump_code, pump_make, product_code, opening_reading, location_code,
-                        effective_start_date, effective_end_date, current_stamping_date, Stamping_due, created_by)
-                     VALUES (:code, :make, :product, 0, :loc, CURDATE(), '9999-12-31', '0000-00-00 00:00:00', :stamping, 'onboarding')`,
-                    { code: up(n.nozzle_name), make: up(n.du_make) || 'UNKNOWN', product: up(n.nozzle_product) || '', loc, stamping: stampingDue }
+                        effective_start_date, effective_end_date, current_stamping_date, Stamping_due, created_by, updated_by)
+                     VALUES (:code, :make, :product, 0, :loc, CURDATE(), '9999-12-31', '0000-00-00 00:00:00', :stamping, 'onboarding', 'onboarding')`,
+                    { code: code(n.nozzle_name), make: up(n.du_make) || 'UNKNOWN', product: up(n.nozzle_product) || '', loc, stamping: stampingDue }
                 );
                 if (n.tank_connected) {
                     const tank = await selectOne(
                         'SELECT tank_id FROM m_tank WHERE tank_code = :code AND location_code = :loc',
-                        { code: up(n.tank_connected), loc }
+                        { code: code(n.tank_connected), loc }
                     );
                     if (tank) {
                         await insertRow(
-                            `INSERT INTO m_pump_tank (pump_id, tank_id, location_code, effective_start_date, effective_end_date, created_by)
-                             VALUES (:pump_id, :tank_id, :loc, CURDATE(), '9999-12-31', 'onboarding')`,
+                            `INSERT INTO m_pump_tank (pump_id, tank_id, location_code, effective_start_date, effective_end_date, created_by, updated_by)
+                             VALUES (:pump_id, :tank_id, :loc, CURDATE(), '9999-12-31', 'onboarding', 'onboarding')`,
                             { pump_id, tank_id: tank.tank_id, loc }
                         );
                     }
@@ -196,8 +197,8 @@ module.exports = {
                 );
                 if (exists) return 'skipped';
                 await insertRow(
-                    `INSERT INTO m_bank (bank_name, bank_branch, account_number, ifsc_code, location_code, type, account_nickname, internal_flag, created_by)
-                     VALUES (:name, :branch, :accnum, :ifsc, :loc, :type, :nickname, 'Y', 'onboarding')`,
+                    `INSERT INTO m_bank (bank_name, bank_branch, account_number, ifsc_code, location_code, type, account_nickname, internal_flag, created_by, updated_by)
+                     VALUES (:name, :branch, :accnum, :ifsc, :loc, :type, :nickname, 'Y', 'onboarding', 'onboarding')`,
                     {
                         name:     up(b.bank_name),
                         branch:   up(b.branch) || '',
@@ -219,8 +220,8 @@ module.exports = {
                 );
                 if (exists) return 'skipped';
                 await insertRow(
-                    `INSERT INTO m_credit_list (Company_Name, location_code, card_flag, Opening_Balance, type, creation_date, created_by)
-                     VALUES (:name, :loc, 'Y', 0, 'Digital', NOW(), 'onboarding')`,
+                    `INSERT INTO m_credit_list (Company_Name, location_code, card_flag, Opening_Balance, type, effective_start_date, effective_end_date, creation_date, created_by, updated_by)
+                     VALUES (:name, :loc, 'Y', 0, 'Credit', CURDATE(), '9999-12-31', NOW(), 'onboarding', 'onboarding')`,
                     { name: up(d.platform_name), loc }
                 );
             }));
@@ -242,8 +243,8 @@ module.exports = {
                     if (rb) remitBankId = rb.bank_id;
                 }
                 await insertRow(
-                    `INSERT INTO m_credit_list (Company_Name, location_code, card_flag, Opening_Balance, gst, address, type, remittance_bank_id, creation_date, created_by)
-                     VALUES (:name, :loc, 'N', 0, :gst, :address, :type, :remitBankId, NOW(), 'onboarding')`,
+                    `INSERT INTO m_credit_list (Company_Name, location_code, card_flag, Opening_Balance, gst, address, type, remittance_bank_id, effective_start_date, effective_end_date, creation_date, created_by, updated_by)
+                     VALUES (:name, :loc, 'N', 0, :gst, :address, :type, :remitBankId, CURDATE(), '9999-12-31', NOW(), 'onboarding', 'onboarding')`,
                     { name: up(c.customer_name), loc, gst: up(c.gstin) || null, address: up(c.address) || null, type: c.customer_type || null, remitBankId }
                 );
             }));

--- a/public/javascripts/onboarding-form.js
+++ b/public/javascripts/onboarding-form.js
@@ -205,14 +205,14 @@ function buildNewRow(section, id) {
             <td class="text-center align-middle">${del}</td></tr>`,
 
         'tanks': `<tr ${a}>
-            <td data-label="Tank Name"><input class="form-control form-control-sm" type="text" data-field="tank_name" placeholder="Tank Name"></td>
+            <td data-label="Tank Name"><input class="form-control form-control-sm" type="text" data-field="tank_name" data-no-space="true" placeholder="No spaces e.g. TANK1"></td>
             <td data-label="Capacity (L)"><input class="form-control form-control-sm" type="number" data-field="tank_capacity" placeholder="15000"></td>
             <td data-label="Short Name"><input class="form-control form-control-sm" type="text" data-field="tank_short_name" placeholder="e.g. MS1"></td>
             <td data-label="Product"><select class="form-control form-control-sm" data-field="product_short_name">${productOpts()}</select></td>
             <td class="text-center align-middle">${del}</td></tr>`,
 
         'nozzles': `<tr ${a}>
-            <td data-label="Nozzle Name"><input class="form-control form-control-sm" type="text" data-field="nozzle_name" placeholder="e.g. MS 1.1"></td>
+            <td data-label="Nozzle Name"><input class="form-control form-control-sm" type="text" data-field="nozzle_name" data-no-space="true" placeholder="No spaces e.g. MS1.1"></td>
             <td data-label="Product"><input class="form-control form-control-sm" type="text" data-field="nozzle_product" placeholder="Short Name"></td>
             <td data-label="DU Make"><input class="form-control form-control-sm" type="text" data-field="du_make" placeholder="Tokheim / Gilbarco"></td>
             <td data-label="Tank"><select class="form-control form-control-sm" data-field="tank_connected">${tankOpts()}</select></td>
@@ -273,11 +273,12 @@ function enforceUppercase(el) {
     if (!el || el.tagName !== 'INPUT') return;
     const t = (el.type || '').toLowerCase();
     if (t === 'url' || t === 'date' || t === 'number' || t === 'email' || t === 'tel') return;
-    const upper = el.value.toUpperCase();
-    if (el.value !== upper) {
+    let val = el.value.toUpperCase();
+    if (el.dataset.noSpace) val = val.replace(/\s+/g, '');
+    if (el.value !== val) {
         const start = el.selectionStart;
         const end   = el.selectionEnd;
-        el.value = upper;
+        el.value = val;
         try { el.setSelectionRange(start, end); } catch (_) {}
     }
 }

--- a/views/onboarding/form.pug
+++ b/views/onboarding/form.pug
@@ -214,7 +214,7 @@ html(lang="en")
                                 tbody#tbody-tanks
                                     each row in formData.tanks
                                         tr(data-section="tanks" data-row-id=row.id)
-                                            td(data-label="Tank Name"): input.form-control.form-control-sm(type="text" data-field="tank_name" value=(row.tank_name||'') placeholder="Tank Name")
+                                            td(data-label="Tank Name"): input.form-control.form-control-sm(type="text" data-field="tank_name" data-no-space="true" value=(row.tank_name||'') placeholder="No spaces e.g. TANK1")
                                             td(data-label="Capacity (L)"): input.form-control.form-control-sm(type="number" data-field="tank_capacity" value=(row.tank_capacity||'') placeholder="15000")
                                             td(data-label="Short Name"): input.form-control.form-control-sm(type="text" data-field="tank_short_name" value=(row.tank_short_name||'') placeholder="e.g. MS1")
                                             td(data-label="Product")
@@ -246,7 +246,7 @@ html(lang="en")
                                 tbody#tbody-nozzles
                                     each row in formData.nozzles
                                         tr(data-section="nozzles" data-row-id=row.id)
-                                            td(data-label="Nozzle Name"): input.form-control.form-control-sm(type="text" data-field="nozzle_name" value=(row.nozzle_name||'') placeholder="e.g. MS 1.1")
+                                            td(data-label="Nozzle Name"): input.form-control.form-control-sm(type="text" data-field="nozzle_name" data-no-space="true" value=(row.nozzle_name||'') placeholder="No spaces e.g. MS1.1")
                                             td(data-label="Product"): input.form-control.form-control-sm(type="text" data-field="nozzle_product" value=(row.nozzle_product||'') placeholder="Short Name")
                                             td(data-label="DU Make"): input.form-control.form-control-sm(type="text" data-field="du_make" value=(row.du_make||'') placeholder="Tokheim / Gilbarco")
                                             td(data-label="Tank")


### PR DESCRIPTION
## Summary
- **applyConfig** was silently failing — INSERT into `m_location_config` was missing `updated_by`, `creation_date`, `updation_date` required columns
- Digital platforms migrated with `type = 'Credit'` (was incorrectly `'Digital'`); both credit list inserts now include `effective_start_date` / `effective_end_date`
- Added `code()` helper in migration controller to strip spaces from `tank_code` and `pump_code` (spaces cause issues in master lookups)
- Full audit column due diligence against MUE reference: `updated_by = 'onboarding'` added to all 8 table INSERTs; `creation_date = NOW()` added to `m_location` and `m_tank`
- Form: `data-no-space="true"` on tank name and nozzle name inputs — spaces stripped in real-time via JS

## Test plan
- [ ] Open onboarding admin detail → Migrate modal → fill Location Config checklist → click Apply Config → confirm ✓ saved message and rows appear in m_location_config
- [ ] Run migration → verify Digital Platforms appear in m_credit_list with type = 'Credit' and card_flag = 'Y'
- [ ] Enter tank name with a space (e.g. "TANK 1") → confirm space is stripped to "TANK1" immediately
- [ ] Verify all migrated rows have non-null updated_by = 'onboarding' and valid creation_date

🤖 Generated with [Claude Code](https://claude.com/claude-code)