### PR TITLE
Home: testing quantity columns (SHOW_TESTING_SUMMARY)

### DIFF
--- a/controllers/home-controller.js
+++ b/controllers/home-controller.js
@@ -497,6 +497,12 @@ const getHomeData = async (req, res, next) => {
             'N' // default value if not configured
         );
 
+        const showTestingSummary = await locationConfig.getLocationConfigValue(
+            locationCode,
+            'SHOW_TESTING_SUMMARY',
+            'N'
+        );
+
         Promise.allSettled([
             getClosingData(locationCode, closingQueryFromDate, closingQueryToDate),
             getDraftsCount(locationCode),
@@ -522,6 +528,7 @@ const getHomeData = async (req, res, next) => {
                 canCreateShiftClosing: canCreateShiftClosing,
                 showDayCloseGrouping: showDayCloseGrouping,
                 allowShiftReopen: allowShiftReopen,
+                showTestingSummary: showTestingSummary,
                 devBackupInfo: devBackupInfo,
             });
         }).catch(error => {

--- a/dao/txn-read-dao.js
+++ b/dao/txn-read-dao.js
@@ -71,14 +71,16 @@ getClosingDetailsByDate: async (locationCode, fromDate, toDate) => {
         // Build dynamic product columns
         let fuelSalesColumns = [];
         let finalProductColumns = [];
-        
+
         if (pumpProducts.length > 0) {
             pumpProducts.forEach(product => {
                 fuelSalesColumns.push(`SUM(CASE WHEN mp.product_code = '${product.product_code}' THEN COALESCE((r.closing_reading - r.opening_reading - r.testing), 0) ELSE 0 END) as \`${product.product_code}\``);
+                fuelSalesColumns.push(`SUM(CASE WHEN mp.product_code = '${product.product_code}' THEN COALESCE(r.testing, 0) ELSE 0 END) as \`test_${product.product_code}\``);
                 finalProductColumns.push(`COALESCE(fs.\`${product.product_code}\`, 0) as \`${product.product_code}\``);
+                finalProductColumns.push(`COALESCE(fs.\`test_${product.product_code}\`, 0) as \`test_${product.product_code}\``);
             });
         }
-        
+
         const dynamicFuelColumns = fuelSalesColumns.length > 0 ? ',\n        ' + fuelSalesColumns.join(',\n        ') : '';
         const dynamicFinalColumns = finalProductColumns.length > 0 ? ',\n    ' + finalProductColumns.join(',\n    ') : '';
 

--- a/db/migrations/home-testing-summary.sql
+++ b/db/migrations/home-testing-summary.sql
@@ -1,0 +1,12 @@
+-- Migration: SHOW_TESTING_SUMMARY config key
+-- Purpose: When enabled, the home page product sale columns also show
+--          the per-product testing quantity (small secondary line below sale qty).
+-- Default: N (disabled). Enable per location.
+-- Run on: locations that request the testing summary display.
+
+-- Enable for a specific location (replace 'LOC' with the actual location code):
+INSERT INTO m_location_config
+    (location_code, setting_name, setting_value, effective_start_date, effective_end_date, created_by, updated_by, creation_date, updation_date)
+VALUES
+    ('LOC', 'SHOW_TESTING_SUMMARY', 'Y', CURDATE(), '9999-12-31', 'MIGRATION', 'MIGRATION', NOW(), NOW())
+ON DUPLICATE KEY UPDATE setting_value = 'Y', updated_by = 'MIGRATION', updation_date = NOW();

--- a/views/home.pug
+++ b/views/home.pug
@@ -137,6 +137,8 @@ block content
                             if productColumns && productColumns.length > 0
                                 each column in productColumns
                                     th= column.label
+                                    if showTestingSummary === 'Y' && column.type === 'pump'
+                                        th= column.label + ' (T)'
                             else
                                 th MS
                                 th HSD
@@ -174,6 +176,9 @@ block content
                                     each column in productColumns
                                         td
                                             span= parseFloat(val[column.key] || 0).toFixed(2)
+                                        if showTestingSummary === 'Y' && column.type === 'pump'
+                                            td
+                                                span= parseFloat(val['test_' + column.key] || 0).toFixed(2)
                                 else
                                     td
                                         span= val.msData || '0.00'
@@ -230,6 +235,12 @@ block content
                                             each val in closingValues
                                                 - total += parseFloat(val[column.key] || 0)
                                             strong= total.toFixed(2)
+                                        if showTestingSummary === 'Y' && column.type === 'pump'
+                                            td
+                                                - var testTotal = 0
+                                                each val in closingValues
+                                                    - testTotal += parseFloat(val['test_' + column.key] || 0)
+                                                strong= testTotal.toFixed(2)
                                 else
                                     td
                                         - var msTotal = 0
@@ -282,6 +293,13 @@ block content
                                         .card-label= column.label
                                         .card-value
                                             span.product-value= productValue.toFixed(2)
+                                if showTestingSummary === 'Y' && column.type === 'pump'
+                                    - var testValue = parseFloat(val['test_' + column.key] || 0)
+                                    if testValue > 0
+                                        .card-row
+                                            .card-label= column.label + ' (T)'
+                                            .card-value
+                                                span.product-value= testValue.toFixed(2)
                         else
                             - var msVal = parseFloat(val.msData || 0)
                             if msVal > 0


### PR DESCRIPTION
## Summary
- Adds per-product **testing quantity** columns on the home page shift list, shown as separate `MS (T)`, `HSD (T)` etc. columns next to each pump product
- Gated by `SHOW_TESTING_SUMMARY = Y` in `m_location_config` (default off)
- Migration script included: `db/migrations/home-testing-summary.sql`

## Changes
- `dao/txn-read-dao.js` — `getClosingDetailsByDate` now fetches `test_<product>` columns (SUM of `r.testing` per product per closing)
- `controllers/home-controller.js` — reads `SHOW_TESTING_SUMMARY` config, passes `showTestingSummary` to view
- `views/home.pug` — renders separate `(T)` column after each pump product column (desktop table + totals row + mobile cards)
- `db/migrations/home-testing-summary.sql` — INSERT to enable for a specific location

## Test plan
- [ ] With `SHOW_TESTING_SUMMARY = N` (default): home page looks unchanged
- [ ] With `SHOW_TESTING_SUMMARY = Y`: each pump product column has an adjacent `(T)` column showing testing qty
- [ ] Totals row shows correct testing totals
- [ ] Mobile cards show `MS (T)` rows only when testing value > 0
- [ ] Live search still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)