### PR TITLE
Credit Statement: show customer address & GSTIN (gated by config)

### DIFF
--- a/controllers/reports-controller.js
+++ b/controllers/reports-controller.js
@@ -88,6 +88,9 @@ module.exports = {
 
               const data1 = await ReportDao.getCreditStmt(locationCode, fromDate,toDate,cid);
 
+              const customerAddress = data1.length > 0 ? (data1[0].address || null) : null;
+              const customerGstin   = data1.length > 0 ? (data1[0].gstin   || null) : null;
+
               if (reportType == 'Creditledger') {
                 let runningBalance = Number(OpeningBal); // Ensure it's a number                
               
@@ -200,6 +203,7 @@ module.exports = {
                         const showStatementNumber = await locationConfig.getLocationConfigValue(locationCode, 'CREDIT_STMT_SHOW_STATEMENT_NUMBER', 'N');
                         const balanceCrDrFormat = await locationConfig.getLocationConfigValue(locationCode, 'CREDIT_STMT_BALANCE_CRDR_FORMAT', 'N');
                         const showBalanceCol = await locationConfig.getLocationConfigValue(locationCode, 'CREDIT_STMT_SHOW_BALANCE', 'Y');
+                        const showCustomerInfo = await locationConfig.getLocationConfigValue(locationCode, 'CREDIT_STMT_SHOW_CUSTOMER_INFO', 'N');
                         let statementNumber = null;
                         if (showStatementNumber === 'Y' && cid && cid != -1) {
                             try {
@@ -235,6 +239,8 @@ module.exports = {
                         balanceCrDr: balanceCrDrFormat === 'Y',
                         showBalance: showBalanceCol === 'Y',
                         enableCreditExcelDownload: (await locationConfig.getLocationConfigValue(locationCode, 'ENABLE_CREDIT_REPORT_EXCEL_DOWNLOAD', 'N')) === 'Y',
+                        customerAddress: showCustomerInfo === 'Y' ? customerAddress : null,
+                        customerGstin: showCustomerInfo === 'Y' ? customerGstin : null,
                       }
 
                     if(caller=='notpdf') {

--- a/dao/report-dao.js
+++ b/dao/report-dao.js
@@ -129,7 +129,7 @@ module.exports = {
 // Updated getCreditStmt function in dao/report-dao.js with transaction_type
 getCreditStmt: (locationCode, closingQueryFromDate, closingQueryToDate, creditId) => {
     return db.sequelize.query(
-        `SELECT 
+        `SELECT
             COALESCE(tc.credit_bill_date, DATE(tcl.closing_date)) AS tran_date,
             tcl.location_code,
             CONCAT('To Bill No: ', tc.bill_no) AS bill_no,
@@ -143,7 +143,9 @@ getCreditStmt: (locationCode, closingQueryFromDate, closingQueryToDate, creditId
             mcl.creditlist_id,
             tc.odometer_reading,
             mcv.vehicle_number,
-            'SALE' AS transaction_type
+            'SALE' AS transaction_type,
+            mcl.address,
+            mcl.gst AS gstin
         FROM t_credits tc
         JOIN m_product mp ON tc.product_id = mp.product_id
         JOIN m_credit_list mcl ON tc.creditlist_id = mcl.creditlist_id
@@ -156,7 +158,7 @@ getCreditStmt: (locationCode, closingQueryFromDate, closingQueryToDate, creditId
 
         UNION ALL
 
-        SELECT 
+        SELECT
             tr.receipt_date AS tran_date,
             tr.location_code,
             CONCAT('By Receipt No: ', tr.receipt_no) AS bill_no,
@@ -170,7 +172,9 @@ getCreditStmt: (locationCode, closingQueryFromDate, closingQueryToDate, creditId
             mcl.creditlist_id,
             NULL AS odometer_reading,
             NULL AS vehicle_number,
-            'RECEIPT' AS transaction_type
+            'RECEIPT' AS transaction_type,
+            mcl.address,
+            mcl.gst AS gstin
         FROM t_receipts tr
         JOIN m_credit_list mcl ON tr.creditlist_id = mcl.creditlist_id
         WHERE mcl.creditlist_id = :creditId
@@ -180,7 +184,7 @@ getCreditStmt: (locationCode, closingQueryFromDate, closingQueryToDate, creditId
         UNION ALL
 
         -- NEW: Include adjustments with explicit transaction types
-        SELECT 
+        SELECT
             ta.adjustment_date AS tran_date,
             ta.location_code,
             CONCAT('Adjustment: ', COALESCE(ta.reference_no, ta.adjustment_id)) AS bill_no,
@@ -194,11 +198,13 @@ getCreditStmt: (locationCode, closingQueryFromDate, closingQueryToDate, creditId
             mcl.creditlist_id,
             NULL AS odometer_reading,
             NULL AS vehicle_number,
-            CASE 
+            CASE
                 WHEN ta.debit_amount > 0 THEN 'ADJUSTMENT_DEBIT'
                 WHEN ta.credit_amount > 0 THEN 'ADJUSTMENT_CREDIT'
                 ELSE 'ADJUSTMENT'
-            END AS transaction_type
+            END AS transaction_type,
+            mcl.address,
+            mcl.gst AS gstin
         FROM t_adjustments ta
         JOIN m_credit_list mcl ON ta.external_id = mcl.creditlist_id
         WHERE ta.external_source IN ('CUSTOMER', 'DIGITAL_VENDOR')  -- Changed from 'CREDIT'
@@ -224,7 +230,9 @@ getCreditStmt: (locationCode, closingQueryFromDate, closingQueryToDate, creditId
             mcl.creditlist_id,
             NULL                                                      AS odometer_reading,
             mcv.vehicle_number                                        AS vehicle_number,
-            'BOWSER_SALE'                                             AS transaction_type
+            'BOWSER_SALE'                                             AS transaction_type,
+            mcl.address,
+            mcl.gst AS gstin
         FROM t_bowser_credits bc
         JOIN t_bowser_closing       bcl ON bcl.bowser_closing_id = bc.bowser_closing_id
         JOIN m_credit_list          mcl ON mcl.creditlist_id     = bc.creditlist_id

--- a/utils/app-pdf-generator.js
+++ b/utils/app-pdf-generator.js
@@ -350,8 +350,8 @@ module.exports = {
                 <span style="font-size: 12px;">Page <span class="pageNumber"></span> of <span class="totalPages"></span></span>
             </div>`,
             margin: {
-                top: '140px',    // Increased to accommodate dealer line + GSTIN/TIN in header
-                bottom: '90px',  // Increased from 60px to give more space for footer
+                top: '170px',    // Extra room for long addresses that wrap to 2 lines
+                bottom: '90px',
                 left: '20px',
                 right: '20px'
             }

--- a/views/reports-customer-facing.pug
+++ b/views/reports-customer-facing.pug
@@ -37,8 +37,12 @@ block content
             if(cidparam == -1)
                 h5.font-weight-bold.text-center.text-uppercase= 'All Companies'
             else
-                h5.font-weight-bold.text-center.text-uppercase= companyName                 
-                h6.text-center.text-muted= `${formattedFromDate}   to   ${formattedToDate}`      
+                h5.font-weight-bold.text-center.text-uppercase= companyName
+                if customerAddress
+                    p.text-center.text-muted.mb-0= customerAddress
+                if customerGstin
+                    p.text-center.text-muted.mb-0= `GSTIN: ${customerGstin}`
+                h6.text-center.text-muted= `${formattedFromDate}   to   ${formattedToDate}`
             h4.font-weight-bold.text-success.text-center
             table.table.table-bordered.border.table-sm
                 thead(class="thead-light")

--- a/views/reports.pug
+++ b/views/reports.pug
@@ -71,7 +71,11 @@ block content
             if(cidparam == -1)
                 h5.font-weight-bold.text-center.text-uppercase= 'All Companies'
             else
-                h5.font-weight-bold.text-center.text-uppercase= companyName                 
+                h5.font-weight-bold.text-center.text-uppercase= companyName
+                if customerAddress
+                    p.text-center.text-muted.mb-0= customerAddress
+                if customerGstin
+                    p.text-center.text-muted.mb-0= `GSTIN: ${customerGstin}`
                 h6.text-center.text-muted= `${formattedFromDate}   to   ${formattedToDate}`
             h4.font-weight-bold.text-success.text-center
             if statementNumber


### PR DESCRIPTION
## Summary
- Customer address and GSTIN now shown below the company name in the credit statement (both staff and customer-facing views)
- Gated by `CREDIT_STMT_SHOW_CUSTOMER_INFO = Y` in `m_location_config` — defaults to `N`, no change for other locations
- PDF margin increased (140px → 170px) to fix table overlap on page 2+ for locations with long addresses

## Enabling for a location
```sql
INSERT INTO m_location_config
  (location_code, setting_name, setting_value, effective_start_date, effective_end_date)
VALUES
  ('SFS', 'CREDIT_STMT_SHOW_CUSTOMER_INFO', 'Y', '2020-01-01', '2099-12-31');
```

## Test plan
- [ ] Credit statement with config OFF — address/GSTIN not shown (no regression)
- [ ] Credit statement with config ON — address and GSTIN appear below company name if filled in `m_credit_list`
- [ ] Customer with no address/GSTIN — nothing extra rendered
- [ ] Multi-page PDF — table does not overlap page header on page 2+

🤖 Generated with [Claude Code](https://claude.com/claude-code)