### PR TITLE
Credits: off-meter sale checkbox for metered lube products

### DIFF
--- a/controllers/closing-edit-controller.js
+++ b/controllers/closing-edit-controller.js
@@ -110,6 +110,12 @@ module.exports = {
                 'N' // default - disabled
             );
 
+            const allowOffMeterSale = await locationConfig.getLocationConfigValue(
+                locationCode,
+                'ALLOW_OFF_METER_SALE',
+                'N'
+            );
+
         if(closingId) {
             Promise.allSettled([homeController.personDataPromise(locationCode),
                 txnClosingPromise(closingId),
@@ -144,6 +150,7 @@ module.exports = {
                         digitalSalesFutureDays: digitalSalesFutureDays,
                         show2TSalesTab: show2TSalesTab === 'Y',
                         allowQuickAddVehicle: allowQuickAddVehicle === 'Y',
+                        allowOffMeterSale: allowOffMeterSale === 'Y',
                         cashiers: values[0].value.cashiers,
                         closingData: values[1].value,
                         productValues: values[2].value.products,

--- a/controllers/home-controller.js
+++ b/controllers/home-controller.js
@@ -10,6 +10,7 @@ const txnController = require("./txn-common-controller");
 const ExpenseDao = require("../dao/expense-dao");
 const config = require("../config/app-config");
 const locationConfig = require('../utils/location-config');
+const { debugLog } = require('../utils/debug-logger');
 const dateFormat = require('dateformat');
 const saveController = require("./closing-save-controller");
 const deleteController = require("./closing-delete-controller");
@@ -28,9 +29,9 @@ module.exports = {
     },
 
     getNewData: async (req, res, next) => {
-        console.log("User service_tier:", req.user.service_tier);
         await serviceTier.applyThrottle(req.user.service_tier);
         const locationCode = req.user.location_code;
+        await debugLog(locationCode, 'User service_tier:', req.user.service_tier);
 
 
         const maxBackDateDays = Number( await locationConfig.getLocationConfigValue(
@@ -75,6 +76,12 @@ module.exports = {
     'N' // default - disabled
     );
 
+    const allowOffMeterSale = await locationConfig.getLocationConfigValue(
+    locationCode,
+    'ALLOW_OFF_METER_SALE',
+    'N'
+    );
+
         getDraftsCount(locationCode).then(data => {
             if(data < config.APP_CONFIGS.maxAllowedDrafts) {
                 Promise.allSettled([personDataPromise(locationCode),
@@ -112,7 +119,8 @@ module.exports = {
                             digitalSalesBackdateDays: digitalSalesBackdateDays,
                             digitalSalesFutureDays: digitalSalesFutureDays,
                             show2TSalesTab: show2TSalesTab === 'Y',
-                            allowQuickAddVehicle: allowQuickAddVehicle === 'Y'
+                            allowQuickAddVehicle: allowQuickAddVehicle === 'Y',
+                            allowOffMeterSale: allowOffMeterSale === 'Y'
                   //          digitalCompanyValues: values[8].value,
                         });
                     }).catch((err) => {
@@ -815,7 +823,8 @@ function formProductData(product, productAlias, textName) {
         productName: product.product_name,
         rgbColor: product.rgb_color,
         returnedQty: 0,
-        givenQty: 0
+        givenQty: 0,
+        isLubeProduct: product.is_lube_product == 1 && product.is_tank_product == 1
     };
 }
 

--- a/controllers/txn-common-controller.js
+++ b/controllers/txn-common-controller.js
@@ -147,7 +147,8 @@ const txnCreditsPromise = (closingId) => {
                         
                         data.forEach((credit) => {
                             const vehicleInfo = vehicleData.find(v => v.vehicle_id === credit.vehicle_id);
-                            
+                            const productInfo = productData.find(p => p.product_id === credit.product_id);
+
                             credits.push({
                                 tCreditId: credit.tcredit_id,
                                 billNo: credit.bill_no,
@@ -163,7 +164,9 @@ const txnCreditsPromise = (closingId) => {
                                 amount: credit.amount,
                                 creditBillDate: credit.credit_bill_date,
                                 notes: credit.notes,
-                                odometerReading: credit.odometer_reading  // ADD THIS LINE
+                                odometerReading: credit.odometer_reading,
+                                offMeterSale: credit.off_meter_sale,
+                                isLubeProduct: productInfo ? (productInfo.is_lube_product == 1 && productInfo.is_tank_product == 1) : false
                             });
                         });
                         resolve(credits);

--- a/dao/product-dao.js
+++ b/dao/product-dao.js
@@ -96,8 +96,10 @@ module.exports = {
                 'product_id',
                 'product_name',
                 'sku_name',
-                'sku_number'
-            ], 
+                'sku_number',
+                'is_lube_product',
+                'is_tank_product'
+            ],
             where: {
                 product_id: {
                     [Op.in]: productIds

--- a/dao/txn-write-dao.js
+++ b/dao/txn-write-dao.js
@@ -105,9 +105,9 @@ saveReadings: (data) => {
     saveCreditSales: (data) => {
     const salesTxn = TxnCreditSales.bulkCreate(data, {returning: true,
         updateOnDuplicate: ["bill_no", "creditlist_id","vehicle_id",
-            "product_id", "price", "price_discount", "qty", "amount", "notes", 
+            "product_id", "price", "price_discount", "qty", "amount", "notes",
             "vehicle_number", "indent_number", "settlement_date", "recon_id", "bill_id",
-            "credit_bill_date", "odometer_reading", "updated_by", "updation_date"]});
+            "credit_bill_date", "odometer_reading", "off_meter_sale", "updated_by", "updation_date"]});
     return salesTxn;
     },
     saveDigitalSales: (data) => {

--- a/public/javascripts/app-scripts.js
+++ b/public/javascripts/app-scripts.js
@@ -384,6 +384,17 @@ function creditOrSaleUpdateProductTypePrices(obj, rowNo, cashOrCreditRowPrefix) 
     const productId = obj.options[obj.selectedIndex].value;
     const productName = obj.options[obj.selectedIndex].text;
     showOrHideProductPricesForCashOrCreditSales(rowNo, cashOrCreditRowPrefix, productId, productName);
+
+    // Show/hide off-meter checkbox based on whether selected product is a metered lube (is_tank_product=1 AND is_lube_product=1)
+    if (window.productValuesData) {
+        const product = window.productValuesData.find(p => p.productId == productId);
+        const isLubeProduct = product && product.isLubeProduct;
+        const offMeterEl = document.getElementById(cashOrCreditRowPrefix + 'off-meter-' + rowNo);
+        if (offMeterEl) {
+            offMeterEl.style.display = isLubeProduct ? '' : 'none';
+            if (!isLubeProduct) offMeterEl.checked = false;
+        }
+    }
 }
 
 
@@ -1332,6 +1343,7 @@ function formCreditSales(salesId, creditSaleTag, creditObjRowNum, user) {
         'price_discount': document.getElementById(creditSaleTag + 'discount-' + creditObjRowNum).value,
         'qty': document.getElementById(creditSaleTag + 'qty-' + creditObjRowNum).value,
         'notes': document.getElementById(creditSaleTag + 'notes-' + creditObjRowNum).value,
+        'off_meter_sale': (function() { var el = document.getElementById(creditSaleTag + 'off-meter-' + creditObjRowNum); return el ? (el.checked ? 1 : 0) : 0; })(),
         'amount': currenciesAsFloat(document.getElementById(creditSaleTag + 'amt-' + creditObjRowNum).value),
         'created_by': user.User_Name,
         'updated_by': user.User_Name

--- a/views/edit-draft-closing.pug
+++ b/views/edit-draft-closing.pug
@@ -403,6 +403,8 @@ block content
                                                 th(scope="col") Quantity
                                                 th(scope="col") Sale
                                                 th(scope="col") Notes
+                                                if allowOffMeterSale
+                                                    th(scope="col") Off Meter
                                                 if(!freezedRecord)
                                                     th(scope="col")
                                             - var rowCnt = 0

--- a/views/mixins/new-closing-mixins.pug
+++ b/views/mixins/new-closing-mixins.pug
@@ -272,7 +272,7 @@ mixin addCredits(creditRowNo, rowData)
     if(creditCompanyValues && creditCompanyValues[0])
         - creditName = creditCompanyValues[0].creditorName;
     if(!rowData)
-        - rowData = {price:price, priceDiscount:0, billNo:0, qty:0, amount:0, creditType: config.creditTypes[0], companyName: creditName, vehicleId: null, odometerReading: null, creditBillDate: (typeof closingData !== 'undefined' ? closingData.closingDate : currentDate)};
+        - rowData = {price:price, priceDiscount:0, billNo:0, qty:0, amount:0, creditType: config.creditTypes[0], companyName: creditName, vehicleId: null, odometerReading: null, offMeterSale: 0, creditBillDate: (typeof closingData !== 'undefined' ? closingData.closingDate : currentDate)};
     if(rowData.tCreditId && parseInt(rowData.tCreditId) > 0)
         - trClass = ''
     tr(class=trClass id=trId)
@@ -328,6 +328,10 @@ mixin addCredits(creditRowNo, rowData)
             input.form-control(type='number' name=prefix + 'amt-' + creditRowNo id=prefix + 'amt-' + creditRowNo min=0 oninput='validity.valid||(value="")' value=rowData.amount onchange='calculateCashOrCreditQuantity(\'' + prefix + '\', ' + creditRowNo + ')' step=0.001)
         td
             textarea.form-control(name=prefix + 'notes-' + creditRowNo id=prefix + 'notes-' + creditRowNo style="height:36px")= rowData.notes
+        if allowOffMeterSale
+            td.text-center
+                - var offMeterStyle = rowData.isLubeProduct ? '' : 'display:none'
+                input(type='checkbox' name=prefix + 'off-meter-' + creditRowNo id=prefix + 'off-meter-' + creditRowNo checked=(rowData.offMeterSale == 1) style=offMeterStyle)
         td
             button.close(type="button" aria-label="Close" onclick='hideRow(\'' + trId + '\', "remove-credit-sale", calculateCreditTotal)')
                 span(aria-hidden="true") &times;

--- a/views/new-closing.pug
+++ b/views/new-closing.pug
@@ -334,6 +334,7 @@ block content
                         #credit-table .col-qty       { width: 6%; }
                         #credit-table .col-sale      { width: 8%; }
                         #credit-table .col-notes     { width: 9%; }
+                        #credit-table .col-off-meter { width: 5%; text-align: center; }
                         #credit-table th:last-child  { width: 2%; text-align: center; } /* X delete column */
 
                         #credit-table .col-delete {
@@ -387,6 +388,8 @@ block content
                                                 th.col-qty(scope="col") Quantity
                                                 th.col-sale(scope="col") Sale
                                                 th.col-notes(scope="col") Notes
+                                                if allowOffMeterSale
+                                                    th.col-off-meter(scope="col") Off Meter
                                                 th.col-delete(scope="col")
                                                 th(scope="col")
                                             - var rowCnt = 0


### PR DESCRIPTION
## Summary
- Off-meter sale checkbox in Credits tab, gated by `ALLOW_OFF_METER_SALE = Y` in `m_location_config`
- Checkbox visible only for metered lube products (is_tank_product=1 AND is_lube_product=1); hidden for fuel
- Checkbox toggles dynamically on product change; value saved to `t_credits.off_meter_sale`
- Async/await fixes in digital recon, credit receipt, bank recon, and transaction upload controllers

## Test plan
- [ ] With `ALLOW_OFF_METER_SALE = N` (default): no Off Meter column in Credits tab
- [ ] With `ALLOW_OFF_METER_SALE = Y`: column appears; checkbox visible only for AD Blue / 2T
- [ ] Changing product from lube to fuel hides and unchecks checkbox
- [ ] Value saves correctly; edit draft shows correct checked state

🤖 Generated with [Claude Code](https://claude.com/claude-code)