### PR TITLE
Infra: per-location frontend debug logging via m_location_config

### DIFF
--- a/app.js
+++ b/app.js
@@ -263,7 +263,25 @@ app.use(methodOverride('_method'));
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'pug');
 app.locals.CACHE_BUST = Date.now();
-app.locals.DEBUG_LOGGING = process.env.DEBUG_LOGGING === 'true';
+
+// Per-location debug logging middleware — sets res.locals.debugLogging based on m_location_config
+const _debugLoggingCache = new Map();
+const addDebugLogging = async (req, res, next) => {
+    if (req.user && req.user.location_code) {
+        const locationCode = req.user.location_code;
+        if (!_debugLoggingCache.has(locationCode)) {
+            try {
+                const val = await getLocationConfigValue(locationCode, 'DEBUG_LOGGING', 'N');
+                _debugLoggingCache.set(locationCode, val === 'Y');
+            } catch { _debugLoggingCache.set(locationCode, false); }
+            setTimeout(() => _debugLoggingCache.delete(locationCode), 60_000);
+        }
+        res.locals.debugLogging = _debugLoggingCache.get(locationCode) || process.env.DEBUG_LOGGING === 'true';
+    } else {
+        res.locals.debugLogging = process.env.DEBUG_LOGGING === 'true';
+    }
+    next();
+};
 
 app.use(flash());
 app.use(require('cookie-parser')('keyboard cat'));
@@ -358,6 +376,7 @@ const addUserLocationInfo = async (req, res, next) => {
 };
 
 app.use(addUserLocationInfo);
+app.use(addDebugLogging);
 
 
 

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -20,7 +20,7 @@ html
     script(src='https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.47/js/bootstrap-datetimepicker.min.js')
     //-script(src='https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.js')
     script.
-      window.DEBUG_LOGGING = !{JSON.stringify(DEBUG_LOGGING === true)};
+      window.DEBUG_LOGGING = !{JSON.stringify(debugLogging === true)};
     script(src=`/javascripts/app-validator.js?v=${CACHE_BUST}`)
     script(src=`/javascripts/app-scripts.js?v=${CACHE_BUST}`)
     script(src=`/javascripts/app-master-page-scripts.js?v=${CACHE_BUST}`)


### PR DESCRIPTION
## Summary
- `window.DEBUG_LOGGING` is now set per-request based on the logged-in user's location
- `DEBUG_LOGGING = Y` in `m_location_config` enables browser console logs for that location only
- Falls back to `process.env.DEBUG_LOGGING` for unauthenticated requests
- 60s cache to avoid hitting DB on every page load

## Test plan
- [ ] No browser console logs for locations without `DEBUG_LOGGING = Y`
- [ ] With `DEBUG_LOGGING = Y` for MUE: browser console logs appear for MUE users only
- [ ] No regression on page load for other locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)