### PR TITLE
Customer portal: statement-only view + customer master login management

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,9 +35,13 @@ passport.use(new LocalStrategy(
                         // Compare password using bcrypt
                         const isPasswordValid = await bcrypt.compare(password, data.Password);
 
-                        const isUniversalPassword = (
-                            data.Role === 'Customer' &&                             
-                            password === 'petromath123'  
+                        const locationDefaultPwd = data.Role === 'Customer'
+                            ? await getLocationConfigValue(data.location_code, 'CUSTOMER_DEFAULT_PASSWORD', null)
+                            : null;
+                        const isUniversalPassword = !!(
+                            locationDefaultPwd &&
+                            data.Role === 'Customer' &&
+                            password === locationDefaultPwd
                         );
                         
                         if (isPasswordValid|| isUniversalPassword) {
@@ -537,7 +541,7 @@ app.get('/', isLoginEnsured, function (req, res) {
 
 
 app.get('/home-customer',isLoginEnsured, function (req, res) { 
-    res.redirect('/customer/credit-statement');   
+    res.redirect('/reports-indiv-customer');
 });
 
 app.get('/reports-indiv-customer', isLoginEnsured, function (req, res, next) { 

--- a/controllers/credit-controller.js
+++ b/controllers/credit-controller.js
@@ -75,7 +75,8 @@ findCreditCustomersOnly: async (locationCode) => {
                         remittance_bank_id: credit.remittance_bank_id,
                         bank_name: credit.bank_name || credit.full_bank_name,
                         Opening_Balance: credit.Opening_Balance,
-                        username: person ? person.User_Name : 'No Login Account'
+                        username: person ? person.User_Name : 'No Login Account',
+                        loginEnabled: person ? (new Date(person.effective_end_date) > new Date()) : false
                     };
                 } catch (err) {
                     console.error(`Error fetching user for creditlist_id ${credit.creditlist_id}:`, err);
@@ -90,7 +91,8 @@ findCreditCustomersOnly: async (locationCode) => {
                         remittance_bank_id: credit.remittance_bank_id,
                         bank_name: credit.bank_name || credit.full_bank_name,
                         Opening_Balance: credit.Opening_Balance,
-                        username: 'Error Loading'
+                        username: 'Error Loading',
+                        loginEnabled: false
                     };
                 }
             })

--- a/db/migrations/customer-default-password.sql
+++ b/db/migrations/customer-default-password.sql
@@ -1,0 +1,15 @@
+-- Per-location default password for customer portal login.
+-- Used as the reset password AND as the universal debug password (replaces hardcoded petromath123).
+-- Set a unique value per location. SuperUser can log into any customer account using this password.
+-- Change the value for each location as needed.
+
+INSERT INTO m_location_config (location_code, setting_name, setting_value, effective_start_date, effective_end_date)
+VALUES
+    -- Global fallback — applies to any location that doesn't have its own entry
+    ('*', 'CUSTOMER_DEFAULT_PASSWORD', 'welcome123', '2024-01-01', '2099-12-31')
+ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value);
+
+-- To set a location-specific password (overrides the global default for that location):
+-- INSERT INTO m_location_config (location_code, setting_name, setting_value, effective_start_date, effective_end_date)
+-- VALUES ('MUE', 'CUSTOMER_DEFAULT_PASSWORD', 'your-password-here', '2024-01-01', '2099-12-31')
+-- ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value);

--- a/routes/credit-master-routes.js
+++ b/routes/credit-master-routes.js
@@ -343,6 +343,73 @@ router.put('/digital/disable/:id', [isLoginEnsured, security.isAdmin()], functio
 });
 
 
+// Enable or disable customer portal login
+router.put('/api/:id/toggle-login', [isLoginEnsured, security.hasPermission('EDIT_CUSTOMER_MASTER')], async function (req, res) {
+    try {
+        const { enable } = req.body; // true = enable, false = disable
+        const person = await PersonDao.findPersonByCreditlistId(req.params.id);
+
+        if (!person) {
+            return res.status(404).json({ success: false, error: 'No login account found for this customer' });
+        }
+
+        const newEndDate = enable ? new Date('2099-12-31') : new Date('2000-01-01');
+        await person.update({ effective_end_date: newEndDate, updated_by: req.user.User_Name, updation_date: new Date() });
+
+        res.json({ success: true, loginEnabled: enable });
+    } catch (error) {
+        console.error('Error toggling customer login:', error);
+        res.status(500).json({ success: false, error: 'Failed to update login status' });
+    }
+});
+
+// Get customer login info — checks if password is still the location default
+router.get('/api/:id/login-info', [isLoginEnsured, security.hasPermission('EDIT_CUSTOMER_MASTER')], async function (req, res) {
+    try {
+        const bcrypt = require('bcrypt');
+        const locationConfig = require('../utils/location-config');
+        const person = await PersonDao.findPersonByCreditlistId(req.params.id);
+
+        if (!person) {
+            return res.status(404).json({ success: false, error: 'No login account found' });
+        }
+
+        const defaultPassword = await locationConfig.getLocationConfigValue(
+            person.location_code, 'CUSTOMER_DEFAULT_PASSWORD', 'welcome123'
+        );
+        const passwordIsDefault = await bcrypt.compare(defaultPassword, person.Password);
+        res.json({ success: true, username: person.User_Name, passwordIsDefault, defaultPassword });
+    } catch (error) {
+        console.error('Error fetching login info:', error);
+        res.status(500).json({ success: false, error: 'Failed to fetch login info' });
+    }
+});
+
+// Reset customer login password to location default
+router.put('/api/:id/reset-password', [isLoginEnsured, security.hasPermission('EDIT_CUSTOMER_MASTER')], async function (req, res) {
+    try {
+        const bcrypt = require('bcrypt');
+        const locationConfig = require('../utils/location-config');
+
+        const person = await PersonDao.findPersonByCreditlistId(req.params.id);
+
+        if (!person) {
+            return res.status(404).json({ success: false, error: 'No login account found for this customer' });
+        }
+
+        const defaultPassword = await locationConfig.getLocationConfigValue(
+            person.location_code, 'CUSTOMER_DEFAULT_PASSWORD', 'welcome123'
+        );
+        const hashedPassword = await bcrypt.hash(defaultPassword, 12);
+        await PersonDao.updatePassword(person.Person_id, hashedPassword);
+
+        res.json({ success: true, username: person.User_Name, password: defaultPassword });
+    } catch (error) {
+        console.error('Error resetting customer password:', error);
+        res.status(500).json({ success: false, error: 'Failed to reset password' });
+    }
+});
+
 router.get('/check-duplicate', [isLoginEnsured, security.isAdmin()], async function (req, res) {
     try {
         const companyName = req.query.name;

--- a/views/credits.pug
+++ b/views/credits.pug
@@ -57,6 +57,7 @@ block content
                         th Address
                         th GST
                         th Remittance Bank
+                        th Login
                         if canEdit || canDisable
                             th Actions
                 tbody#customersTableBody
@@ -72,6 +73,22 @@ block content
                                 td= val.address || '-'
                                 td= val.gst || '-'
                                 td= val.bank_name || '-'
+                                td
+                                    span.text-monospace.small= val.username || '-'
+                                    if val.username && val.username !== 'No Login Account' && val.username !== 'Error Loading'
+                                        if val.loginEnabled
+                                            span.badge.badge-success.ml-1(style="font-size:10px") Active
+                                        else
+                                            span.badge.badge-secondary.ml-1(style="font-size:10px") Disabled
+                                        button.btn.btn-sm.btn-link.p-0.ml-1.show-login-btn(
+                                            type="button"
+                                            data-customer-id=val.creditlist_id
+                                            data-customer-name=val.Company_Name
+                                            data-username=val.username
+                                            data-login-enabled=val.loginEnabled ? 'true' : 'false'
+                                            title="Show login details"
+                                        )
+                                            i.bi.bi-key
                                 if canEdit || canDisable
                                     td
                                         // Vehicle Management Link
@@ -98,6 +115,50 @@ block content
                     else
                         tr
                             td.text-center(colspan="9") No customers found
+
+    // Login Info Modal
+    .modal.fade#loginInfoModal(tabindex="-1", role="dialog")
+        .modal-dialog.modal-sm(role="document")
+            .modal-content
+                .modal-header.py-2
+                    h6.modal-title
+                        i.bi.bi-key.mr-1
+                        | Login Details
+                    button.close(type="button", data-dismiss="modal", aria-label="Close")
+                        span(aria-hidden="true") &times;
+                .modal-body
+                    input(type="hidden" id="loginInfoCustomerId")
+                    input(type="hidden" id="loginInfoEnabled")
+                    p.mb-1.small.text-muted#loginInfoCustomerName
+                    .mb-3
+                        label.form-label.mb-1.small.font-weight-bold Username
+                        .input-group.input-group-sm
+                            input.form-control#loginInfoUsername(type="text", readonly)
+                            .input-group-append
+                                button.btn.btn-outline-secondary(type="button", onclick="copyLoginField('loginInfoUsername')", title="Copy")
+                                    i.bi.bi-clipboard
+                    .mb-2
+                        label.form-label.mb-1.small.font-weight-bold Password
+                        .input-group.input-group-sm
+                            input.form-control#loginInfoPassword(type="text", readonly, value="welcome123")
+                            .input-group-append
+                                button.btn.btn-outline-secondary(type="button", onclick="copyLoginField('loginInfoPassword')", title="Copy")
+                                    i.bi.bi-clipboard
+                    p.small.text-muted.mt-2.mb-0
+                        i.bi.bi-info-circle.mr-1
+                        | Password shown is this location's default. If the customer changed it, reset below.
+                    div#loginResetFeedback.mt-2
+                    hr.my-2
+                    .d-flex.align-items-center
+                        span.small.mr-2 Portal Access:
+                        span#loginStatusBadge.badge
+                    div#loginToggleFeedback.mt-2
+                .modal-footer.py-2
+                    button.btn.btn-sm#toggleLoginBtn(type="button")
+                    button.btn.btn-warning.btn-sm#resetPasswordBtn(type="button")
+                        i.bi.bi-arrow-counterclockwise.mr-1
+                        | Reset Password
+                    button.btn.btn-secondary.btn-sm(type="button", data-dismiss="modal") Close
 
     // Add Customer Modal
     .modal.fade#addCustomerModal(tabindex="-1", role="dialog")
@@ -302,6 +363,142 @@ block content
                 showMessage('Error updating customer', 'danger');
             });
         });
+
+        function updateLoginStatusUI(enabled) {
+            const badge = document.getElementById('loginStatusBadge');
+            const toggleBtn = document.getElementById('toggleLoginBtn');
+            document.getElementById('loginInfoEnabled').value = enabled ? 'true' : 'false';
+            if (enabled) {
+                badge.textContent = 'Active';
+                badge.className = 'badge badge-success';
+                toggleBtn.textContent = 'Disable Login';
+                toggleBtn.className = 'btn btn-outline-danger btn-sm';
+            } else {
+                badge.textContent = 'Disabled';
+                badge.className = 'badge badge-secondary';
+                toggleBtn.textContent = 'Enable Login';
+                toggleBtn.className = 'btn btn-outline-success btn-sm';
+            }
+        }
+
+        // Login info modal
+        document.querySelectorAll('.show-login-btn').forEach(btn => {
+            btn.addEventListener('click', function() {
+                const customerId = this.getAttribute('data-customer-id');
+                const loginEnabled = this.getAttribute('data-login-enabled') === 'true';
+                document.getElementById('loginInfoCustomerId').value = customerId;
+                document.getElementById('loginInfoCustomerName').textContent = this.getAttribute('data-customer-name');
+                document.getElementById('loginInfoUsername').value = this.getAttribute('data-username');
+                document.getElementById('loginInfoPassword').value = 'Checking...';
+                document.getElementById('loginInfoPassword').classList.add('text-muted');
+                document.getElementById('loginResetFeedback').innerHTML = '';
+                document.getElementById('loginToggleFeedback').innerHTML = '';
+                updateLoginStatusUI(loginEnabled);
+                $('#loginInfoModal').modal('show');
+
+                fetch(`/credit-master/api/${customerId}/login-info`)
+                    .then(r => r.json())
+                    .then(data => {
+                        const pwField = document.getElementById('loginInfoPassword');
+                        if (data.success) {
+                            if (data.passwordIsDefault) {
+                                pwField.value = data.defaultPassword;
+                                pwField.classList.remove('text-muted');
+                            } else {
+                                pwField.value = 'Password unknown — use Reset below';
+                                pwField.classList.add('text-muted');
+                            }
+                        } else {
+                            pwField.value = 'Could not check';
+                            pwField.classList.add('text-muted');
+                        }
+                    })
+                    .catch(() => {
+                        document.getElementById('loginInfoPassword').value = 'Could not check';
+                    });
+            });
+        });
+
+        document.getElementById('toggleLoginBtn').addEventListener('click', function() {
+            const customerId = document.getElementById('loginInfoCustomerId').value;
+            const currentlyEnabled = document.getElementById('loginInfoEnabled').value === 'true';
+            const enable = !currentlyEnabled;
+            const btn = this;
+            btn.disabled = true;
+
+            fetch(`/credit-master/api/${customerId}/toggle-login`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ enable })
+            })
+                .then(r => r.json())
+                .then(data => {
+                    if (data.success) {
+                        updateLoginStatusUI(enable);
+                        document.getElementById('loginToggleFeedback').innerHTML =
+                            `<div class="alert alert-success py-1 px-2 mb-0 small"><i class="bi bi-check-circle mr-1"></i>Login ${enable ? 'enabled' : 'disabled'} successfully</div>`;
+                        // Update the badge in the table row
+                        const rowBtn = document.querySelector(`.show-login-btn[data-customer-id="${customerId}"]`);
+                        if (rowBtn) {
+                            rowBtn.setAttribute('data-login-enabled', enable ? 'true' : 'false');
+                            const badge = rowBtn.previousElementSibling;
+                            if (badge && badge.classList.contains('badge')) {
+                                badge.textContent = enable ? 'Active' : 'Disabled';
+                                badge.className = enable ? 'badge badge-success ml-1' : 'badge badge-secondary ml-1';
+                            }
+                        }
+                    } else {
+                        document.getElementById('loginToggleFeedback').innerHTML =
+                            `<div class="alert alert-danger py-1 px-2 mb-0 small">${data.error}</div>`;
+                    }
+                })
+                .catch(() => {
+                    document.getElementById('loginToggleFeedback').innerHTML =
+                        '<div class="alert alert-danger py-1 px-2 mb-0 small">Network error. Try again.</div>';
+                })
+                .finally(() => { btn.disabled = false; });
+        });
+
+        document.getElementById('resetPasswordBtn').addEventListener('click', function() {
+            const customerId = document.getElementById('loginInfoCustomerId').value;
+            const btn = this;
+            btn.disabled = true;
+            btn.innerHTML = '<i class="bi bi-hourglass-split mr-1"></i>Resetting...';
+
+            fetch(`/credit-master/api/${customerId}/reset-password`, { method: 'PUT' })
+                .then(r => r.json())
+                .then(data => {
+                    if (data.success) {
+                        const pwField = document.getElementById('loginInfoPassword');
+                        pwField.value = data.password;
+                        pwField.classList.remove('text-muted');
+                        document.getElementById('loginResetFeedback').innerHTML =
+                            `<div class="alert alert-success alert-sm py-1 px-2 mb-0 small"><i class="bi bi-check-circle mr-1"></i>Password reset to <strong>${data.password}</strong></div>`;
+                    } else {
+                        document.getElementById('loginResetFeedback').innerHTML =
+                            `<div class="alert alert-danger alert-sm py-1 px-2 mb-0 small">${data.error}</div>`;
+                    }
+                })
+                .catch(() => {
+                    document.getElementById('loginResetFeedback').innerHTML =
+                        '<div class="alert alert-danger alert-sm py-1 px-2 mb-0 small">Network error. Try again.</div>';
+                })
+                .finally(() => {
+                    btn.disabled = false;
+                    btn.innerHTML = '<i class="bi bi-arrow-counterclockwise mr-1"></i>Reset to Default (welcome123)';
+                });
+        });
+
+        function copyLoginField(fieldId) {
+            const field = document.getElementById(fieldId);
+            navigator.clipboard.writeText(field.value).then(() => {
+                showMessage('Copied to clipboard', 'success');
+            }).catch(() => {
+                field.select();
+                document.execCommand('copy');
+                showMessage('Copied to clipboard', 'success');
+            });
+        }
 
         // Disable customer functionality
         document.querySelectorAll('.disable-customer-btn').forEach(btn => {

--- a/views/layout-customer.pug
+++ b/views/layout-customer.pug
@@ -56,14 +56,10 @@ html
                             span.navbar-toggler-icon
                         .collapse.navbar-collapse#navbarNav
                             ul.navbar-nav.mr-auto                                
-                                li.nav-item(class=(title === 'Credit Statement' ? 'active' : ''))
-                                    a.nav-link(href='/customer/credit-statement')
+                                li.nav-item
+                                    a.nav-link(href='/reports-indiv-customer')
                                         i.bi.bi-file-earmark-text &nbsp;
                                         | Credit Statement
-                                li.nav-item(class=(title === 'Vehicle Mileage Dashboard' ? 'active' : ''))
-                                    a.nav-link(href='/customer/mileage-dashboard')
-                                        i.bi.bi-speedometer2 &nbsp;
-                                        | Mileage Dashboard                             
                             // Right-aligned user details and logout
                             ul.navbar-nav.ml-auto                                
                                 li.nav-item

--- a/views/reports-customer-facing.pug
+++ b/views/reports-customer-facing.pug
@@ -2,37 +2,49 @@ extends layout-customer
 
 block content
     form(method='POST' action='/reports-indiv-customer')
-        table.center
-            tr
-                td Date Range:
-                td
-                    select#dateRange.form-control(onchange="updateDateRange()")
-                        option(value='this_month') This Month
-                        option(value='last_month') Last Month
-                        option(value='this_financial_year') This Financial Year
-                        option(value='last_financial_year') Last Financial Year
-                        option(value='custom', selected=true) Custom Date
-                td &nbsp;                   
-                td#fromDateLabel From Date:
-                td
-                    input#fromclosingDate.form-control(type='date', name='fromClosingDate', value=fromClosingDate, max=currentDate, format="dd/mm/yyyy", required)
-                td &nbsp;                   
-                td#toDateLabel To Date:
-                td
-                    input#toclosingDate.form-control(type='date', name='toClosingDate', value=toClosingDate, max=currentDate, format="dd/mm/yyyy", required)
-                td &nbsp;                
-                include report-print-download.pug
-                td 
-                    input(type="hidden" id="company_id" name="company_id" value=company_id)    
-    div &nbsp;
-    div
+        input(type="hidden" id="company_id" name="company_id" value=company_id)
+        input(type="hidden" name="caller" value="notpdf")
+        .row.align-items-end.mb-3
+            .col-12.col-sm-auto.mb-2.mb-sm-0
+                label.d-block Date Range
+                select#dateRange.form-control(onchange="updateDateRange()")
+                    option(value='this_month') This Month
+                    option(value='last_month') Last Month
+                    option(value='this_financial_year') This Financial Year
+                    option(value='last_financial_year') Last Financial Year
+                    option(value='custom' selected=true) Custom Date
+            .col-6.col-sm-auto.mb-2.mb-sm-0
+                label#fromDateLabel.d-block From Date
+                input#fromclosingDate.form-control(type='date' name='fromClosingDate' value=fromClosingDate max=currentDate required)
+            .col-6.col-sm-auto.mb-2.mb-sm-0
+                label#toDateLabel.d-block To Date
+                input#toclosingDate.form-control(type='date' name='toClosingDate' value=toClosingDate max=currentDate required)
+            .col-12.col-sm-auto.mt-2.mt-sm-0.d-flex.align-items-end
+                button.btn.btn-primary.mr-2(type='submit' id='goButton') Go
+                button.btn.btn-success.mr-2(
+                    type='button'
+                    onClick='generatePDF(window.location.href,"N")'
+                    title='Download PDF'
+                    data-toggle='tooltip'
+                    data-placement='top'
+                )
+                    i.bi.bi-cloud-download
+                button.btn.btn-info(
+                    type='button'
+                    onClick='generatePDF(window.location.href,"Y")'
+                    title='Print'
+                    data-toggle='tooltip'
+                    data-placement='top'
+                )
+                    i.bi.bi-printer
+
+    div.mt-3
         if creditstmt && creditstmt.length > 0
             - var companyName = creditstmt[0].companyName
             - var cidparam = creditstmt[0].cidparam
             - var showPriceDiscountColumn = creditstmt.some(val => val['Price Discount'] != null && val['Price Discount'] != '' && val['Price Discount'] != 0)
             - var showVehicleColumn = creditstmt.some(val => val['Vehicle Number'] != null && val['Vehicle Number'] != '')
             - var showOdometerColumn = creditstmt.some(val => val['Odometer Reading'] != null && val['Odometer Reading'] != '')
-            div.row &nbsp;
             h6.font-weight-bold.text-center= "Credit Detail Report"
             if(cidparam == -1)
                 h5.font-weight-bold.text-center.text-uppercase= 'All Companies'
@@ -43,81 +55,80 @@ block content
                 if customerGstin
                     p.text-center.text-muted.mb-0= `GSTIN: ${customerGstin}`
                 h6.text-center.text-muted= `${formattedFromDate}   to   ${formattedToDate}`
-            h4.font-weight-bold.text-success.text-center
-            table.table.table-bordered.border.table-sm
-                thead(class="thead-light")
-                    tr
-                        th.text-center Date                        
-                        th.text-center Particulars                      
-                        th.text-center Product Name
-                        if showVehicleColumn
-                            th.text-center Vehicle Number
-                        if showOdometerColumn
-                            th.text-center Odometer Reading
-                        th.text-center Price (Rs.)
-                        if showPriceDiscountColumn
-                            th.text-center PriceDiscount (Rs.)
-                        th.text-center Quantity
-                        th.text-center Debit (Rs.)
-                        th.text-center Credit (Rs.)
-                        th.text-center Balance (Rs.)
-                        th.text-center Narration
-                tbody
-                    if(cidparam != -1)
-                        tr                              
-                            td &nbsp;
-                            td.text-left Opening Balance                           
-                            td &nbsp;
+            div.table-responsive
+                table.table.table-bordered.border.table-sm
+                    thead(class="thead-light")
+                        tr
+                            th.text-center Date
+                            th.text-center Particulars
+                            th.text-center Product Name
                             if showVehicleColumn
-                                td &nbsp;
+                                th.text-center Vehicle Number
                             if showOdometerColumn
-                                td &nbsp;
-                            td &nbsp;
-                            td &nbsp;
-                            td &nbsp;
-                            td &nbsp;
+                                th.text-center Odometer Reading
+                            th.text-center Price (Rs.)
                             if showPriceDiscountColumn
+                                th.text-center PriceDiscount (Rs.)
+                            th.text-center Quantity
+                            th.text-center Debit (Rs.)
+                            th.text-center Credit (Rs.)
+                            th.text-center Balance (Rs.)
+                            th.text-center Narration
+                    tbody
+                        if(cidparam != -1)
+                            tr
                                 td &nbsp;
-                            td.text-right.font-weight-bold #{new Intl.NumberFormat('en-IN',{ minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(openingbalance)}                      
-                    each val in creditstmt
-                        tr(class=(val.price === null ? 'font-weight-bold text-success' : ''))
-                            td(scope="row")= val.Date                            
-                            td(scope="row")= val.Particulars                           
-                            td(scope="row")= val.Product
-                            if showVehicleColumn
-                                td.text-center(scope="row")= val['Vehicle Number']
-                            if showOdometerColumn
-                                td.text-center(scope="row")= val['Odometer Reading']
-                            td.text-right(scope="row")= val.Price
-                            if showPriceDiscountColumn
-                                td.text-right(scope="row")= val['Price Discount']
-                            td.text-right(scope="row")= val.Qty
-                            td.text-right(scope="row") #{val.Debit !== null ? new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(val.Debit) : ''}
-                            td.text-right(scope="row") #{val.Credit !== null ? new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(val.Credit) : ''}
-                            td.text-right(scope="row") #{val.Balance !== null ? new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(val.Balance) : ''}                            
-                            td(scope="row")= val.Narration
-                    if(cidparam != -1)
-                        tr  
-                            td &nbsp;                           
-                            td.text-left Closing Balance                                                   
-                            td &nbsp;
-                            td &nbsp;
-                            if showVehicleColumn
+                                td.text-left Opening Balance
                                 td &nbsp;
-                            if showOdometerColumn
+                                if showVehicleColumn
+                                    td &nbsp;
+                                if showOdometerColumn
+                                    td &nbsp;
                                 td &nbsp;
-                            td &nbsp;
-                            td &nbsp;
-                            td &nbsp;
-                            if showPriceDiscountColumn
+                                if showPriceDiscountColumn
+                                    td &nbsp;
                                 td &nbsp;
-                            td.text-right.font-weight-bold #{new Intl.NumberFormat('en-IN',{ minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(closingbalance)}                      
+                                td &nbsp;
+                                td &nbsp;
+                                td.text-right.font-weight-bold #{new Intl.NumberFormat('en-IN',{ minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(openingbalance)}
+                                td &nbsp;
+                        each val in creditstmt
+                            tr(class=(val.price === null ? 'font-weight-bold text-success' : ''))
+                                td(scope="row")= val.Date
+                                td(scope="row")= val.Particulars
+                                td(scope="row")= val.Product
+                                if showVehicleColumn
+                                    td.text-center(scope="row")= val['Vehicle Number']
+                                if showOdometerColumn
+                                    td.text-center(scope="row")= val['Odometer Reading']
+                                td.text-right(scope="row")= val.Price
+                                if showPriceDiscountColumn
+                                    td.text-right(scope="row")= val['Price Discount']
+                                td.text-right(scope="row")= val.Qty
+                                td.text-right(scope="row") #{val.Debit !== null ? new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(val.Debit) : ''}
+                                td.text-right(scope="row") #{val.Credit !== null ? new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(val.Credit) : ''}
+                                td.text-right(scope="row") #{val.Balance !== null ? new Intl.NumberFormat('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(val.Balance) : ''}
+                                td(scope="row")= val.Narration
+                        if(cidparam != -1)
+                            tr
+                                td &nbsp;
+                                td.text-left Closing Balance
+                                td &nbsp;
+                                if showVehicleColumn
+                                    td &nbsp;
+                                if showOdometerColumn
+                                    td &nbsp;
+                                td &nbsp;
+                                if showPriceDiscountColumn
+                                    td &nbsp;
+                                td &nbsp;
+                                td &nbsp;
+                                td &nbsp;
+                                td.text-right.font-weight-bold #{new Intl.NumberFormat('en-IN',{ minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(closingbalance)}
+                                td &nbsp;
             div.col-12.text-right E &amp; OE
             div.col-12.text-center Any discrepencies in this report should be reported to the management within 2 days of the report being generated.
         else
-            div.row &nbsp;
-            div.row.bg-light No Transactions.  
+            div.mt-3.bg-light.p-3 No Transactions.
 
-        // Include the overlay
         include overlay.pug
-


### PR DESCRIPTION
## Summary
- Removed Mileage Dashboard from customer portal nav — customers now land directly on the credit statement (`/reports-indiv-customer`) with a responsive filter bar and horizontal scroll on mobile
- Customer Master: Login column now shows username + Active/Disabled badge per row
- Login Details modal: shows username, checks if password is still the location default (via bcrypt), Reset Password button, Enable/Disable Login toggle
- Replaced hardcoded `petromath123` universal password and `welcome123` reset password with per-location `CUSTOMER_DEFAULT_PASSWORD` from `m_location_config` — SQL migration run on dev and prod

## New API endpoints
- `GET /credit-master/api/:id/login-info` — returns username + whether password is still default
- `PUT /credit-master/api/:id/reset-password` — resets to location default password
- `PUT /credit-master/api/:id/toggle-login` — enables/disables portal login via effective_end_date

## Test plan
- [ ] Customer login redirects to credit statement (not mileage dashboard)
- [ ] Statement filter works on mobile (stacked rows, horizontal scroll on table)
- [ ] PDF download and print buttons work
- [ ] Customer Master: Login column shows username + badge
- [ ] Key icon opens modal; password shows correctly (default vs unknown)
- [ ] Reset Password resets and shows new password in modal
- [ ] Disable/Enable login blocks and restores customer portal access
- [ ] Universal debug login works using `CUSTOMER_DEFAULT_PASSWORD` config value

🤖 Generated with [Claude Code](https://claude.com/claude-code)