### PR TITLE
Customer portal: fix mobile table hidden by admin CSS

### DIFF
--- a/views/layout-customer.pug
+++ b/views/layout-customer.pug
@@ -31,6 +31,11 @@ html
         //-         return formattedInteger + '.' + decimal;
         //-     }
         style.
+            /* Customer portal: undo global mobile CSS rules that were scoped to admin pages */
+            @media (max-width: 768px) {
+                .table-responsive { display: block !important; }
+                .table tbody tr { display: table-row !important; }
+            }
             @media print {
             table.table-bordered {
                 border-collapse: collapse !important;


### PR DESCRIPTION
## Root cause
`style.css` has two `@media (max-width: 768px)` rules intended for specific admin pages but with no class scoping:
- `.table-responsive { display: none !important }` — hides ALL responsive table wrappers on mobile (was meant for bills create page)
- `.table tbody tr:nth-child(n+6) { display: none !important }` — hides all rows after row 5 (was meant for edit-draft-closing performance)

Both rules killed the credit statement table on mobile.

## Fix
Override both in `layout-customer.pug` (used only by customer portal pages) — admin pages are unaffected. `style.css` not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)