### PR TITLE
Customer statement mobile: fix table showing + Dr/Cr balance labels

### DIFF
--- a/views/layout-customer.pug
+++ b/views/layout-customer.pug
@@ -31,11 +31,6 @@ html
         //-         return formattedInteger + '.' + decimal;
         //-     }
         style.
-            /* Customer portal: undo global mobile CSS rules that were scoped to admin pages */
-            @media (max-width: 768px) {
-                .table-responsive { display: block !important; }
-                .table tbody tr { display: table-row !important; }
-            }
             @media print {
             table.table-bordered {
                 border-collapse: collapse !important;

--- a/views/reports-customer-facing.pug
+++ b/views/reports-customer-facing.pug
@@ -137,7 +137,8 @@ block content
                 if cidparam != -1
                     .d-flex.justify-content-between.align-items-center.py-2.px-1.mb-2.border-bottom
                         span.text-muted.small Opening Balance
-                        span.font-weight-bold= fmt(openingbalance)
+                        span.font-weight-bold(class=openingbalance >= 0 ? 'text-danger' : 'text-success')
+                            = fmt(Math.abs(openingbalance)) + (openingbalance >= 0 ? ' Dr' : ' Cr')
 
                 each val in creditstmt
                     - var isPayment = (val.price === null)
@@ -167,7 +168,8 @@ block content
                 if cidparam != -1
                     .d-flex.justify-content-between.align-items-center.py-2.px-1.mt-1.border-top
                         span.font-weight-bold Closing Balance
-                        span.font-weight-bold= fmt(closingbalance)
+                        span.font-weight-bold(class=closingbalance >= 0 ? 'text-danger' : 'text-success')
+                            = fmt(Math.abs(closingbalance)) + (closingbalance >= 0 ? ' Dr' : ' Cr')
 
             div.text-right.small.text-muted.mt-2 E &amp; OE
             div.text-center.small.text-muted Any discrepancies in this report should be reported to the management within 2 days.


### PR DESCRIPTION
## Fixes
- **Table still showing on mobile**: removed `.table-responsive { display: block !important }` override from layout-customer.pug — it was overriding Bootstrap's `d-none` class, so the desktop table was visible on mobile despite `d-none d-md-block`
- **Opening/closing balance confusing**: now displayed as `₹X Dr` (red) when customer owes, `₹X Cr` (green) when station owes customer

🤖 Generated with [Claude Code](https://claude.com/claude-code)