### PR TITLE
Tank dip: remove datalist, grey out input, max 2 decimal places

### DIFF
--- a/public/javascripts/tank-dip.js
+++ b/public/javascripts/tank-dip.js
@@ -71,6 +71,8 @@ $(document).ready(function() {
 function updateTankInfo(tankId) {
     if (!tankId) {
         $('#tankInfo, #connectedPumpsSection, #noPumpsMessage').hide();
+        $('#dip_reading').val('').prop('disabled', true);
+        $('#dip_volume_display').text('--');
         return;
     }
 
@@ -93,18 +95,18 @@ function updateTankInfo(tankId) {
             if (cm > maxDip) maxDip = cm;
         });
 
-        // Populate datalist with integer chart values
-        const datalist = $('#dip_chart_datalist');
-        datalist.empty();
-        for (let cm = 1; cm <= maxDip; cm++) {
-            datalist.append(`<option value="${cm}">${cm} cm — ${dipVolumeMap[cm].toLocaleString('en-IN', {maximumFractionDigits: 2})} L</option>`);
-        }
-
         const dipInput = $('#dip_reading');
-        dipInput.val('');
+        dipInput.val('').prop('disabled', false);
         $('#dip_volume_display').text('--');
 
-        dipInput.off('input change').on('input change', function() {
+        dipInput.off('input').on('input', function() {
+            // Restrict to max 2 decimal places
+            const val = $(this).val();
+            const dotPos = val.indexOf('.');
+            if (dotPos !== -1 && val.length - dotPos > 3) {
+                $(this).val(val.substring(0, dotPos + 3));
+            }
+
             const raw = parseFloat($(this).val());
             if (isNaN(raw) || raw <= 0 || raw > maxDip) {
                 $('#dip_volume_display').text('--');

--- a/views/tank-dip.pug
+++ b/views/tank-dip.pug
@@ -50,12 +50,11 @@ block content
                                     type="text"
                                     inputmode="decimal"
                                     name="dip_reading"
-                                    list="dip_chart_datalist"
-                                    placeholder="e.g. 45 or 45.3"
+                                    placeholder="e.g. 45 or 45.30"
                                     autocomplete="off"
+                                    disabled
                                     required
                                 )
-                                datalist#dip_chart_datalist
                         .col-md-2
                             .form-group
                                 label Volume


### PR DESCRIPTION
## Summary
- Remove datalist dropdown — volume shows live as you type, no suggestions list needed
- Dip reading field is greyed out (disabled) until a tank is selected
- Input trimmed to max 2 decimal places on keystroke

🤖 Generated with [Claude Code](https://claude.com/claude-code)