### PR TITLE
Tank variance: gap warning when dip readings are more than 7 days apart

### DIFF
--- a/controllers/stock-reports-controller.js
+++ b/controllers/stock-reports-controller.js
@@ -672,6 +672,7 @@ function buildTankVarianceRows(raw, fromDate, toDate) {
             const expected = opening + receiptLiters - netSales;
             const variance = actual - expected;
             const variancePct = netSales > 0 ? (variance / netSales) * 100 : null;
+            const gapDays = Math.round((curr.ts - prev.ts) / (1000 * 60 * 60 * 24));
 
             rows.push({
                 date: curr.dip_date,
@@ -686,7 +687,9 @@ function buildTankVarianceRows(raw, fromDate, toDate) {
                 expected_liters: expected,
                 actual_liters: actual,
                 variance_liters: variance,
-                variance_pct: variancePct
+                variance_pct: variancePct,
+                gap_days: gapDays,
+                gap_warning: gapDays > 7
             });
         }
     });

--- a/views/reports-tank-variance.pug
+++ b/views/reports-tank-variance.pug
@@ -79,6 +79,7 @@ block content
                             - var totalExpected = 0
                             - var totalActual = 0
                             - var totalVariance = 0
+                            - var hasGapWarning = false
                             each row in groupedByTank[tankCode]
                                 - totalOpening += row.opening_liters || 0
                                 - totalReceipts += row.receipts_liters || 0
@@ -88,8 +89,12 @@ block content
                                 - totalExpected += row.expected_liters || 0
                                 - totalActual += row.actual_liters || 0
                                 - totalVariance += row.variance_liters || 0
-                                tr(class=(Math.abs(row.variance_liters) >= 100 ? 'table-warning' : ''))
-                                    td= row.date_display
+                                - if (row.gap_warning) hasGapWarning = true
+                                tr(class=(row.gap_warning ? 'table-secondary' : (Math.abs(row.variance_liters) >= 100 ? 'table-warning' : '')))
+                                    td
+                                        = row.date_display
+                                        if row.gap_warning
+                                            span.ml-1(title=`Previous reading was ${row.gap_days} days ago`) ⚠
                                     td= row.time
                                     td= row.tank_code
                                     td= row.product_code
@@ -123,6 +128,14 @@ block content
                                         = ((totalVariance / totalSales) * 100).toFixed(2) + '%'
                                     else
                                         | -
+            - var anyGapWarning = varianceRows.some(r => r.gap_warning)
+            if anyGapWarning
+                .alert.alert-warning.mt-3.small
+                    strong ⚠ Note:&nbsp;
+                    | One or more rows are marked ⚠ because the previous dip reading was taken more than 7 days earlier.
+                    | For these rows, Gross Sales and Variance figures accumulate over the entire gap period and do not represent a single day's movement.
+                    | These rows should be disregarded for variance analysis.
+
         else
             div.row &nbsp;
             div.alert.alert-info.text-center No records to display for selected range.


### PR DESCRIPTION
## Summary
- Rows where consecutive dip readings are more than 7 days apart are greyed and marked ⚠
- Tooltip on the date cell shows the exact gap in days
- Yellow footnote at the bottom of the report explains that these rows accumulate sales over the gap period and should not be used for variance analysis
- Applies to both screen view and PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)