### PR TITLE
Fix: MySQL LIMIT+IN subquery error on tank dip page

### DIFF
--- a/dao/tank-dip-dao.js
+++ b/dao/tank-dip-dao.js
@@ -168,10 +168,12 @@ function TankDipDao() {
                  FROM t_tank_reading tr
                  JOIN t_tank_dip td ON tr.tdip_id = td.tdip_id
                  WHERE td.tdip_id IN (
-                     SELECT tdip_id FROM t_tank_dip
-                     WHERE tank_id = :tank_id
-                     ORDER BY dip_date DESC, dip_time DESC
-                     LIMIT ${parseInt(maxEntries, 10)}
+                     SELECT tdip_id FROM (
+                         SELECT tdip_id FROM t_tank_dip
+                         WHERE tank_id = :tank_id
+                         ORDER BY dip_date DESC, dip_time DESC
+                         LIMIT ${parseInt(maxEntries, 10)}
+                     ) AS recent_dips
                  )`,
                 {
                     replacements: { tank_id: tank_id },


### PR DESCRIPTION
## Summary
Fixes "This version of MySQL doesn't yet support 'LIMIT & IN/ALL/ANY/SOME subquery'" error on /tank-dip, introduced by the pump reading history query in PR #713. Wrapped the LIMIT subquery in a derived table, which MySQL allows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)