### PR TITLE
Tank dip: data-entry warnings for pump/dip readings

### DIFF
--- a/controllers/tank-dip-controller.js
+++ b/controllers/tank-dip-controller.js
@@ -107,12 +107,33 @@ exports.getTankDipEntry = async function (req, res, next) {
 
         // Get the last readings for each tank's pumps
         const lastReadings = {};
+        const pumpHistory = {};
+        const tankBaseline = {};
         for (const tank of tanks) {
             const readings = await TankDipDao.getLatestPumpReadings(tank.tank_id);
             lastReadings[tank.tank_id] = readings;
-        }        
 
-        
+            const history = await TankDipDao.getPumpReadingHistory(tank.tank_id);
+            pumpHistory[tank.tank_id] = buildPumpRateBaseline(history);
+
+            const latestDip = await TankDipDao.getLatestDip(tank.tank_id);
+            if (latestDip) {
+                const lastDipTs = new Date(`${latestDip.dip_date}T${latestDip.dip_time}`).getTime();
+                const receiptRows = await TankDipDao.getReceiptsSince(tank.tank_id, locationCode, latestDip.dip_date);
+                const receiptsSinceLastDip = receiptRows.reduce((sum, r) => {
+                    const ts = toReceiptTs(r.decant_date, r.decant_time);
+                    return ts > lastDipTs ? sum + parseFloat(r.quantity || 0) * 1000 : sum;
+                }, 0);
+
+                tankBaseline[tank.tank_id] = {
+                    lastDipReading: parseFloat(latestDip.dip_reading),
+                    lastDipTs: lastDipTs,
+                    receiptsSinceLastDip: receiptsSinceLastDip
+                };
+            }
+        }
+
+
         res.render('tank-dip', {
             title: 'Tank Dip Entry',
             user: req.user,
@@ -121,10 +142,12 @@ exports.getTankDipEntry = async function (req, res, next) {
             pumpTankMappings: pumpTankMappings,
             existingDips: dipsWithReadings,
             lastReadings: lastReadings,
+            pumpHistory: pumpHistory,
+            tankBaseline: tankBaseline,
             searchDate: today,
             allowPastDate: allowPastDate,
             allowTankDipDelete: allowTankDipDelete,
-            currentDate: today  
+            currentDate: today
         });
     } catch (error) {
         console.error('Error fetching tank dip data:', error);
@@ -430,6 +453,54 @@ exports.getDipDetails = async (req, res) => {
 
 
 
+
+function toReceiptTs(decantDate, decantTime) {
+    const raw = (decantTime || '0').toString();
+    let hh, mm;
+    if (raw.includes(':')) {
+        hh = raw.slice(0, 2);
+        mm = raw.slice(3, 5);
+    } else {
+        const parts = raw.split('.');
+        hh = String(parseInt(parts[0] || '0', 10)).padStart(2, '0');
+        mm = parts[1] === '3' ? '30' : (parts[1] || '00').padEnd(2, '0').slice(0, 2);
+    }
+    const dateStr = dateFormat(new Date(decantDate), "yyyy-mm-dd");
+    return new Date(`${dateStr}T${hh}:${mm}:00`).getTime();
+}
+
+function buildPumpRateBaseline(history) {
+    const byPump = {};
+    (history || []).forEach(h => {
+        const pumpId = h.pump_id;
+        if (!byPump[pumpId]) byPump[pumpId] = [];
+        const dateStr = dateFormat(new Date(h.dip_date), "yyyy-mm-dd");
+        byPump[pumpId].push({
+            reading: parseFloat(h.reading),
+            ts: new Date(`${dateStr}T${h.dip_time}`).getTime()
+        });
+    });
+
+    const baseline = {};
+    Object.keys(byPump).forEach(pumpId => {
+        const entries = byPump[pumpId].sort((a, b) => a.ts - b.ts);
+        const newest = entries[entries.length - 1];
+        const oldest = entries[0];
+        let avgPerDay = null;
+        if (entries.length >= 2) {
+            const daysSpan = (newest.ts - oldest.ts) / 86400000;
+            if (daysSpan > 0) {
+                avgPerDay = Math.max((newest.reading - oldest.reading) / daysSpan, 0);
+            }
+        }
+        baseline[pumpId] = {
+            lastReading: newest.reading,
+            lastTs: newest.ts,
+            avgPerDay: avgPerDay
+        };
+    });
+    return baseline;
+}
 
 function calculateIntermediateDipCm(dipChartLines) {
     let result = [];

--- a/dao/tank-dip-dao.js
+++ b/dao/tank-dip-dao.js
@@ -161,6 +161,73 @@ function TankDipDao() {
         }
     };
 
+    this.getPumpReadingHistory = async function(tank_id, maxEntries = 8) {
+        try {
+            const result = await db.sequelize.query(
+                `SELECT tr.pump_id, tr.reading, td.dip_date, td.dip_time
+                 FROM t_tank_reading tr
+                 JOIN t_tank_dip td ON tr.tdip_id = td.tdip_id
+                 WHERE td.tdip_id IN (
+                     SELECT tdip_id FROM t_tank_dip
+                     WHERE tank_id = :tank_id
+                     ORDER BY dip_date DESC, dip_time DESC
+                     LIMIT ${parseInt(maxEntries, 10)}
+                 )`,
+                {
+                    replacements: { tank_id: tank_id },
+                    type: db.Sequelize.QueryTypes.SELECT
+                }
+            );
+            return result;
+        } catch (error) {
+            console.error("Error getting pump reading history:", error);
+            throw error;
+        }
+    };
+
+    this.getLatestDip = async function(tank_id) {
+        try {
+            const result = await db.sequelize.query(
+                `SELECT dip_reading,
+                        DATE_FORMAT(dip_date, '%Y-%m-%d') AS dip_date,
+                        TIME_FORMAT(dip_time, '%H:%i:%s') AS dip_time
+                 FROM t_tank_dip
+                 WHERE tank_id = :tank_id
+                 ORDER BY dip_date DESC, dip_time DESC
+                 LIMIT 1`,
+                {
+                    replacements: { tank_id: tank_id },
+                    type: db.Sequelize.QueryTypes.SELECT
+                }
+            );
+            return result[0] || null;
+        } catch (error) {
+            console.error("Error getting latest dip:", error);
+            throw error;
+        }
+    };
+
+    this.getReceiptsSince = async function(tank_id, locationCode, sinceDate) {
+        try {
+            const result = await db.sequelize.query(
+                `SELECT dtl.quantity, rcpt.decant_date, rcpt.decant_time
+                 FROM t_tank_stk_rcpt_dtl dtl
+                 INNER JOIN t_tank_stk_rcpt rcpt ON rcpt.ttank_id = dtl.ttank_id
+                 WHERE dtl.tank_id = :tank_id
+                   AND rcpt.location_code = :locationCode
+                   AND rcpt.decant_date >= :sinceDate`,
+                {
+                    replacements: { tank_id: tank_id, locationCode: locationCode, sinceDate: sinceDate },
+                    type: db.Sequelize.QueryTypes.SELECT
+                }
+            );
+            return result;
+        } catch (error) {
+            console.error("Error getting receipts since date:", error);
+            throw error;
+        }
+    };
+
     this.delete = async function(tdip_id) {
         return await db.sequelize.transaction(async (t) => {
             // Delete tank readings first

--- a/dao/tank-dip-dao.js
+++ b/dao/tank-dip-dao.js
@@ -168,10 +168,12 @@ function TankDipDao() {
                  FROM t_tank_reading tr
                  JOIN t_tank_dip td ON tr.tdip_id = td.tdip_id
                  WHERE td.tdip_id IN (
-                     SELECT tdip_id FROM t_tank_dip
-                     WHERE tank_id = :tank_id
-                     ORDER BY dip_date DESC, dip_time DESC
-                     LIMIT ${parseInt(maxEntries, 10)}
+                     SELECT tdip_id FROM (
+                         SELECT tdip_id FROM t_tank_dip
+                         WHERE tank_id = :tank_id
+                         ORDER BY dip_date DESC, dip_time DESC
+                         LIMIT ${parseInt(maxEntries, 10)}
+                     ) AS recent_dips
                  )`,
                 {
                     replacements: { tank_id: tank_id },

--- a/public/javascripts/tank-dip.js
+++ b/public/javascripts/tank-dip.js
@@ -68,17 +68,31 @@ $(document).ready(function() {
 });
 
 
+// Shared state for the currently selected tank's dip chart, used by both
+// the dip volume display and the live tank-variance check.
+const currentTankState = { dipVolumeMap: {}, maxDip: 0 };
+
+function volumeForDip(dipCm) {
+    if (isNaN(dipCm) || dipCm <= 0 || dipCm > currentTankState.maxDip) return null;
+    const floor = Math.floor(dipCm);
+    const frac  = dipCm - floor;
+    const volFloor = currentTankState.dipVolumeMap[floor] || 0;
+    const volCeil  = currentTankState.dipVolumeMap[floor + 1] || volFloor;
+    return frac > 0 ? volFloor + frac * (volCeil - volFloor) : volFloor;
+}
+
 function updateTankInfo(tankId) {
     if (!tankId) {
         $('#tankInfo, #connectedPumpsSection, #noPumpsMessage').hide();
         $('#dip_reading').val('').prop('disabled', true);
         $('#dip_volume_display').text('--');
+        $('#dip_variance_warning').hide();
         return;
     }
 
     const selectedOption = $(`#tank_id option[value="${tankId}"]`);
     const tank = tanks.find(t => t.tank_id === parseInt(tankId));
-    
+
     if (tank) {
         $('#productCode').text(tank.product_code);
         $('#tankCapacity').text(`${tank.tank_orig_capacity} liters`);
@@ -87,17 +101,18 @@ function updateTankInfo(tankId) {
 
         // Build lookup map: dip_cm (integer key) -> volume_liters
         const chartLines = (tank.m_tank_dipchart_header && tank.m_tank_dipchart_header.m_tank_dipchart_lines) || [];
-        const dipVolumeMap = {};
-        let maxDip = 0;
+        currentTankState.dipVolumeMap = {};
+        currentTankState.maxDip = 0;
         chartLines.forEach(line => {
             const cm = Math.round(parseFloat(line.dip_cm));
-            dipVolumeMap[cm] = parseFloat(line.volume_liters);
-            if (cm > maxDip) maxDip = cm;
+            currentTankState.dipVolumeMap[cm] = parseFloat(line.volume_liters);
+            if (cm > currentTankState.maxDip) currentTankState.maxDip = cm;
         });
 
         const dipInput = $('#dip_reading');
         dipInput.val('').prop('disabled', false);
         $('#dip_volume_display').text('--');
+        $('#dip_variance_warning').hide();
 
         dipInput.off('input').on('input', function() {
             // Restrict to max 2 decimal places
@@ -107,20 +122,46 @@ function updateTankInfo(tankId) {
                 $(this).val(val.substring(0, dotPos + 3));
             }
 
-            const raw = parseFloat($(this).val());
-            if (isNaN(raw) || raw <= 0 || raw > maxDip) {
-                $('#dip_volume_display').text('--');
-                return;
-            }
-            const floor = Math.floor(raw);
-            const frac  = raw - floor;
-            const volFloor = dipVolumeMap[floor] || 0;
-            const volCeil  = dipVolumeMap[floor + 1] || volFloor;
-            const vol = frac > 0 ? volFloor + frac * (volCeil - volFloor) : volFloor;
-            $('#dip_volume_display').text(vol.toLocaleString('en-IN', {maximumFractionDigits: 2}) + ' L');
+            const vol = volumeForDip(parseFloat($(this).val()));
+            $('#dip_volume_display').text(vol !== null ? vol.toLocaleString('en-IN', {maximumFractionDigits: 2}) + ' L' : '--');
+            recalcTankVariance();
         });
 
         updatePumpReadings(tankId);
+    }
+}
+
+function recalcTankVariance() {
+    const tankId = $('#tank_id').val();
+    const baseline = tankBaseline[tankId];
+    const warningEl = $('#dip_variance_warning');
+
+    if (!baseline) { warningEl.hide(); return; }
+
+    const dipVal = parseFloat($('#dip_reading').val());
+    const openingVolume = volumeForDip(baseline.lastDipReading);
+    const actualVolume = volumeForDip(dipVal);
+    if (openingVolume === null || actualVolume === null) { warningEl.hide(); return; }
+
+    let grossSales = 0;
+    $('.pump-reading-input').each(function() {
+        const last = parseFloat($(this).attr('data-last'));
+        const cur = parseFloat($(this).val());
+        if (!isNaN(last) && !isNaN(cur) && cur > last) {
+            grossSales += (cur - last);
+        }
+    });
+
+    const receipts = baseline.receiptsSinceLastDip || 0;
+    const expected = openingVolume + receipts - grossSales;
+    const variance = actualVolume - expected;
+
+    if (Math.abs(variance) >= 100) {
+        warningEl.attr('title',
+            `Expected ~${expected.toFixed(0)} L (opening ${openingVolume.toFixed(0)} + receipts ${receipts.toFixed(0)} - sales ${grossSales.toFixed(0)}) | You entered ~${actualVolume.toFixed(0)} L | Diff: ${variance.toFixed(0)} L`
+        ).show();
+    } else {
+        warningEl.hide();
     }
 }
 
@@ -141,15 +182,17 @@ function updatePumpReadings(tankId) {
 
     $('#pumpReadingsContainer').empty();
 
-    connectedPumps.forEach(pump => {  
+    connectedPumps.forEach(pump => {
         const lastReading = lastReadings[tankId]?.find(r => r.pump_id === pump.pump_id);
+        const baseline = (pumpHistory[tankId] || {})[pump.pump_id];
         const pumpHtml = `
             <div class="col-md-4 mb-3">
                 <div class="form-group">
                     <label>${pump.pump_code} (${pump.pump_make})
-                      ${lastReading ? 
-                            `<span class="text-muted ml-2">Last: ${lastReading.reading}</span>` : 
+                      ${lastReading ?
+                            `<span class="text-muted ml-2">Last: ${lastReading.reading}</span>` :
                             ''}
+                      <span class="pump-deviation-warning text-warning font-weight-bold ml-1" style="display:none" title=""> ⚠</span>
                     </label>
                     <input
                         type="number"
@@ -158,8 +201,9 @@ function updatePumpReadings(tankId) {
                         step="0.001"
                         min="0"
                         ${lastReading?.reading ? `data-last="${lastReading.reading}"` : ''}
+                        ${baseline?.avgPerDay != null ? `data-avg-per-day="${baseline.avgPerDay}" data-last-ts="${baseline.lastTs}"` : ''}
                         value="${pump.reading || ''}"  // Ensure the value is set correctly
-                        required                        
+                        required
                     >
                 </div>
             </div>
@@ -174,8 +218,43 @@ function updatePumpReadings(tankId) {
         validatePumpReading(this);
     });
 
+    $(document).off('input', '.pump-reading-input').on('input', '.pump-reading-input', function() {
+        checkPumpReadingDeviation(this);
+        recalcTankVariance();
+    });
+
     $('#connectedPumpsSection').show();
     $('#noPumpsMessage').hide();
+}
+
+function checkPumpReadingDeviation(input) {
+    const warningSpan = $(input).closest('.form-group').find('.pump-deviation-warning');
+    const avgPerDay = parseFloat($(input).attr('data-avg-per-day'));
+    const lastTs = parseFloat($(input).attr('data-last-ts'));
+    const lastReading = parseFloat($(input).attr('data-last')) || 0;
+    const currentReading = parseFloat($(input).val());
+
+    if (isNaN(avgPerDay) || isNaN(lastTs) || isNaN(currentReading)) {
+        warningSpan.hide();
+        return;
+    }
+
+    const dipDate = $('#dip_date').val();
+    const dipTime = $('#dip_time').val() || '00:00';
+    const currentTs = dipDate ? new Date(`${dipDate}T${dipTime}`).getTime() : Date.now();
+    const daysSince = Math.max((currentTs - lastTs) / 86400000, 1 / 24);
+
+    const expectedDelta = avgPerDay * daysSince;
+    const actualDelta = currentReading - lastReading;
+
+    const lowerBound = Math.min(expectedDelta * 0.2, expectedDelta - 50);
+    const upperBound = Math.max(expectedDelta * 5, expectedDelta + 50);
+
+    if (actualDelta < lowerBound || actualDelta > upperBound) {
+        warningSpan.attr('title', `Last: ${lastReading} | Usual change over ${daysSince.toFixed(1)} day(s): ~${expectedDelta.toFixed(0)} L | You entered: ${actualDelta.toFixed(0)} L`).show();
+    } else {
+        warningSpan.hide();
+    }
 }
 
 

--- a/views/tank-dip.pug
+++ b/views/tank-dip.pug
@@ -58,7 +58,9 @@ block content
                         .col-md-2
                             .form-group
                                 label Volume
-                                div#dip_volume_display.pt-2.font-weight-bold.text-primary --
+                                div.pt-2
+                                    span#dip_volume_display.font-weight-bold.text-primary --
+                                    span#dip_variance_warning.text-warning.font-weight-bold.ml-1(style="display:none" title="") ⚠
 
                     //- Tank Info Display
                     #tankInfo.row.mt-3(style="display: none;")
@@ -140,6 +142,8 @@ block content
         const tanks = !{JSON.stringify(tanks)};
         const pumpTankMappings = !{JSON.stringify(pumpTankMappings)};
         const lastReadings = !{JSON.stringify(lastReadings)};
+        const pumpHistory = !{JSON.stringify(pumpHistory)};
+        const tankBaseline = !{JSON.stringify(tankBaseline)};
         window.allowPastDate = #{allowPastDate};
         // Now you can use the 'tanks' array in your JavaScript code.
         console.log(tanks);


### PR DESCRIPTION
## Summary
- Pump readings: warn (non-blocking) when a new reading's delta deviates sharply from the recent historical daily-rate baseline for that pump — catches digit-typos that still increase the meter
- Dip reading: live replica of the Tank Variance report's expected-vs-actual formula (opening + receipts - sales); warns if implied variance is >=100L
- Both advisory only, never block submission
- Fix: wrap LIMIT subquery in a derived table — MySQL rejects LIMIT directly inside IN (subquery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)