### PR TITLE
Bank recon: replace duplicate-check with delete-and-reinsert; fix 413

### DIFF
--- a/app.js
+++ b/app.js
@@ -289,8 +289,8 @@ const addDebugLogging = async (req, res, next) => {
 
 app.use(flash());
 app.use(require('cookie-parser')('keyboard cat'));
-app.use(bodyParser.urlencoded({ extended: true }));
-app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true, limit: '10mb' }));
+app.use(bodyParser.json({ limit: '10mb' }));
 app.use(require('express-session')({ secret: 'keyboard cat', resave: false, saveUninitialized: false }));
 app.use(passport.initialize());
 app.use(passport.session());
@@ -480,8 +480,8 @@ app.use(async (req, res, next) => {
 
 
 app.use(logger('dev'));
-app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
+app.use(express.json({ limit: '10mb' }));
+app.use(express.urlencoded({ extended: false, limit: '10mb' }));
 
 
 

--- a/controllers/bank-reconciliation-controller.js
+++ b/controllers/bank-reconciliation-controller.js
@@ -777,35 +777,13 @@ if (accountValidation.warning) {
     console.warn('ACCOUNT VALIDATION WARNING:', accountValidation.warning);
 }
 
-        // ========== STEP 6: Check for duplicates ==========
+        // ========== STEP 6: Return response ==========
 
-     
-        
-        const duplicates = await bankReconDao.checkDuplicates(locationCode, bankId, transactions);
-        
-     
-        const transactionsWithDupFlag = transactions.map(txn => {
-            const isDup = duplicates.some(dup => 
-                dup.txn_date === txn.txn_date && 
-                dup.description === txn.description &&
-                parseFloat(dup.credit_amount) === parseFloat(txn.credit_amount) &&
-                parseFloat(dup.debit_amount) === parseFloat(txn.debit_amount)
-            );
-            return {
-                ...txn,
-                is_duplicate: isDup
-            };
-        });
-
-        // ========== STEP 7: Return response ==========
-        
         res.json({
             success: true,
-            transactions: transactionsWithDupFlag,
-            duplicates: duplicates,
+            transactions: transactions,
             summary: {
                 total: transactions.length,
-                duplicates: duplicates.length,
                 excluded_today: excludedTodayCount.length,
                 last_uploaded_date: lastUploadedDate,
                 earliest_upload_date: earliestUploadDate,
@@ -848,25 +826,14 @@ saveBankStatement: async (req, res) => {
             });
         }
 
-        // Filter out duplicates (only save non-duplicates)
-        const nonDuplicates = transactions.filter(t => !t.is_duplicate);
-
-        if (nonDuplicates.length === 0) {
-            return res.status(400).json({
-                success: false,
-                error: 'All transactions are duplicates. Nothing to import.'
-            });
-        }
-
-        // Calculate date range
-        const dates = nonDuplicates.map(t => t.txn_date).sort();
+        // Calculate date range from uploaded transactions
+        const dates = transactions.map(t => t.txn_date).filter(Boolean).sort();
         const firstTxnDate = dates[0];
         const lastTxnDate = dates[dates.length - 1];
 
-        // Insert transactions
-        const result = await bankReconDao.bulkInsertStatements(
-            locationCode, bankId, nonDuplicates, userName
-        );
+        // Delete existing records for this date range, then insert fresh
+        await bankReconDao.deleteStatementsByDateRange(locationCode, bankId, firstTxnDate, lastTxnDate);
+        const result = await bankReconDao.bulkInsertStatements(locationCode, bankId, transactions, userName);
 
         // Record upload history
         await bankReconDao.insertUploadHistory({
@@ -875,17 +842,17 @@ saveBankStatement: async (req, res) => {
             source_file: sourceFile,
             uploaded_by: userName,
             total_transactions: transactions.length,
-            duplicates_found: transactions.length - nonDuplicates.length,
+            duplicates_found: 0,
             transactions_imported: result.inserted,
             first_txn_date: firstTxnDate,
             last_txn_date: lastTxnDate,
             status: 'COMPLETED',
-            remarks: `Imported ${result.inserted} transactions from ${firstTxnDate} to ${lastTxnDate}`
+            remarks: `Replaced ${firstTxnDate} to ${lastTxnDate} (${result.inserted} rows)`
         });
 
         res.json({
             success: true,
-            message: `${result.inserted} transactions imported successfully (${transactions.length - nonDuplicates.length} duplicates skipped)`
+            message: `${result.inserted} transactions imported successfully`
         });
 
     } catch (error) {

--- a/dao/bank-reconciliation-dao.js
+++ b/dao/bank-reconciliation-dao.js
@@ -577,6 +577,19 @@ getUploadHistory: async (locationCode, bankId = null, limit = 10) => {
     }
 },
 
+    deleteStatementsByDateRange: async (locationCode, bankId, fromDate, toDate) => {
+        await db.sequelize.query(
+            `DELETE FROM t_bank_statement_actual
+             WHERE location_code = :locationCode
+               AND bank_id = :bankId
+               AND txn_date BETWEEN :fromDate AND :toDate`,
+            {
+                replacements: { locationCode, bankId, fromDate, toDate },
+                type: db.Sequelize.QueryTypes.DELETE
+            }
+        );
+    },
+
     /**
      * Bulk insert bank statement transactions
      */


### PR DESCRIPTION
## Summary
- Removed duplicate-detection from bank statement upload preview — all rows from the file are shown as-is
- Save now deletes existing `t_bank_statement_actual` rows for the uploaded date range, then inserts all rows fresh — statement table mirrors the Excel exactly
- Added `deleteStatementsByDateRange` to the DAO
- Raised Express body-parser limit to 10mb to fix 413 Content Too Large on large statements

## Test plan
- [ ] Upload a large bank statement — confirm no 413 error on save
- [ ] Upload a statement for a date range that already has data — confirm old rows are replaced cleanly
- [ ] Verify all rows from the file appear in the recon view with no missing/skipped entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)