### PR TITLE
GL: Tally XML export with bundled masters and special char escaping

### DIFF
--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -1574,6 +1574,65 @@ router.get('/api/events/:eventId/source', [isLoginEnsured, security.isAdmin()], 
     }
 });
 
+// ── Tally Export ──────────────────────────────────────────────────────────────
+
+const tallyExportService = require('../services/gl-tally-export-service');
+
+// GET /gl/api/tally-export/preview?from_date=&to_date=&include_exported=0
+router.get('/api/tally-export/preview', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode    = req.user.location_code;
+    const { from_date, to_date, include_exported } = req.query;
+    if (!from_date || !to_date) return res.status(400).json({ error: 'from_date and to_date are required' });
+    try {
+        const result = await tallyExportService.preview(locationCode, from_date, to_date, include_exported === '1');
+        res.json(result);
+    } catch (err) {
+        console.error('Tally export preview error:', err);
+        res.status(500).json({ error: err.message });
+    }
+});
+
+// POST /gl/api/tally-export
+// Body: { from_date, to_date, include_exported }
+// Returns XML file as download; marks vouchers as is_exported='Y'.
+router.post('/api/tally-export', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode   = req.user.location_code;
+    const exportedBy     = req.user.username || String(req.user.Person_id);
+    const { from_date, to_date, include_exported } = req.body;
+    if (!from_date || !to_date) return res.status(400).json({ error: 'from_date and to_date are required' });
+    try {
+        const result = await tallyExportService.generateAndExport(
+            locationCode, from_date, to_date, !!include_exported, exportedBy
+        );
+        if (!result.xml) return res.status(400).json({ error: 'No vouchers found for this date range.' });
+
+        res.setHeader('Content-Type', 'text/xml; charset=utf-8');
+        res.setHeader('Content-Disposition', `attachment; filename="${result.fileName}"`);
+        res.send(result.xml);
+    } catch (err) {
+        console.error('Tally export error:', err);
+        res.status(500).json({ error: err.message });
+    }
+});
+
+// GET /gl/api/tally-export/history — recent export batches for this location
+router.get('/api/tally-export/history', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    try {
+        const rows = await db.sequelize.query(`
+            SELECT batch_id, from_date, to_date, voucher_count, exported_at, exported_by, file_name
+            FROM gl_export_batches
+            WHERE location_code = :locationCode
+            ORDER BY batch_id DESC
+            LIMIT 20
+        `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT });
+        res.json(rows);
+    } catch (err) {
+        console.error('Tally export history error:', err);
+        res.status(500).json({ error: err.message });
+    }
+});
+
 module.exports = router;
 
 // Exported helper — used by products route to populate ledger dropdowns server-side

--- a/services/gl-tally-export-service.js
+++ b/services/gl-tally-export-service.js
@@ -1,0 +1,255 @@
+'use strict';
+const db = require('../db/db-connection');
+
+function xmlEscape(str) {
+    if (str == null) return '';
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+function tallyDate(d) {
+    // YYYY-MM-DD → YYYYMMDD
+    return String(d).replace(/-/g, '').substring(0, 8);
+}
+
+const VOUCHER_TYPE_MAP = {
+    SALES:    'Sales',
+    PURCHASE: 'Purchase',
+    PAYMENT:  'Payment',
+    RECEIPT:  'Receipt',
+    JOURNAL:  'Journal',
+    CONTRA:   'Contra'
+};
+
+// Sort groups so parents always appear before children in the XML.
+function topologicalSort(groupIds, allGroupMap) {
+    const result  = [];
+    const visited = new Set();
+
+    function visit(id) {
+        if (!id || visited.has(id)) return;
+        const g = allGroupMap.get(id);
+        if (!g) return;
+        if (g.parent_group_id) visit(g.parent_group_id);
+        visited.add(id);
+        result.push(g);
+    }
+
+    for (const id of groupIds) visit(id);
+    return result;
+}
+
+// Returns a count of what would be exported — no writes.
+async function preview(locationCode, fromDate, toDate, includeExported) {
+    const exportedClause = includeExported ? '' : "AND h.is_exported = 'N'";
+    const [row] = await db.sequelize.query(`
+        SELECT
+            COUNT(DISTINCT h.voucher_id) AS voucher_count,
+            COUNT(DISTINCT l.ledger_id)  AS ledger_count
+        FROM gl_journal_headers h
+        JOIN gl_journal_lines l ON l.voucher_id = h.voucher_id
+        WHERE h.location_code = :locationCode
+          AND h.voucher_date  BETWEEN :fromDate AND :toDate
+          ${exportedClause}
+    `, { replacements: { locationCode, fromDate, toDate }, type: db.Sequelize.QueryTypes.SELECT });
+    return { voucher_count: parseInt(row.voucher_count), ledger_count: parseInt(row.ledger_count) };
+}
+
+// Generates Tally XML, marks vouchers as exported, logs gl_export_batches row.
+async function generateAndExport(locationCode, fromDate, toDate, includeExported, exportedBy) {
+    const exportedClause = includeExported ? '' : "AND h.is_exported = 'N'";
+
+    // 1. All voucher lines in range
+    const rows = await db.sequelize.query(`
+        SELECT
+            h.voucher_id,
+            h.voucher_type,
+            DATE_FORMAT(h.voucher_date, '%Y-%m-%d') AS voucher_date,
+            h.voucher_no,
+            h.narration,
+            h.is_reversal,
+            l.line_no,
+            l.ledger_id,
+            l.dr_amount,
+            l.cr_amount,
+            COALESCE(gl.tally_ledger_name, gl.ledger_name) AS tally_ledger_name,
+            gl.group_id
+        FROM gl_journal_headers h
+        JOIN gl_journal_lines l  ON l.voucher_id = h.voucher_id
+        JOIN gl_ledgers gl       ON gl.ledger_id  = l.ledger_id
+        WHERE h.location_code = :locationCode
+          AND h.voucher_date  BETWEEN :fromDate AND :toDate
+          ${exportedClause}
+        ORDER BY h.voucher_date, h.voucher_id, l.line_no
+    `, { replacements: { locationCode, fromDate, toDate }, type: db.Sequelize.QueryTypes.SELECT });
+
+    if (!rows.length) return { xml: null, voucherCount: 0, ledgerCount: 0, groupCount: 0 };
+
+    // 2. Unique ledger_ids used in these vouchers
+    const ledgerIds = [...new Set(rows.map(r => r.ledger_id))];
+
+    // 3. Full ledger + group info for those ledgers
+    const ledgerRows = await db.sequelize.query(`
+        SELECT
+            l.ledger_id,
+            COALESCE(l.tally_ledger_name, l.ledger_name) AS tally_ledger_name,
+            l.group_id,
+            COALESCE(g.tally_group_name, g.group_name)   AS tally_group_name,
+            g.parent_group_id
+        FROM gl_ledgers l
+        JOIN gl_ledger_groups g ON g.group_id = l.group_id
+        WHERE l.ledger_id IN (:ledgerIds)
+    `, { replacements: { ledgerIds }, type: db.Sequelize.QueryTypes.SELECT });
+
+    // 4. Walk group tree upward — collect all ancestor groups too
+    const allGroupRows = await db.sequelize.query(`
+        SELECT group_id, group_name, tally_group_name, parent_group_id
+        FROM gl_ledger_groups
+        WHERE location_code = :locationCode
+    `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT });
+
+    const allGroupMap = new Map(allGroupRows.map(g => [g.group_id, g]));
+
+    const neededGroupIds = new Set();
+    function collectAncestors(id) {
+        if (!id || neededGroupIds.has(id)) return;
+        neededGroupIds.add(id);
+        const g = allGroupMap.get(id);
+        if (g && g.parent_group_id) collectAncestors(g.parent_group_id);
+    }
+    ledgerRows.forEach(l => collectAncestors(l.group_id));
+
+    const sortedGroups = topologicalSort([...neededGroupIds], allGroupMap);
+
+    // 5. Build voucher map
+    const voucherMap = new Map();
+    for (const r of rows) {
+        if (!voucherMap.has(r.voucher_id)) {
+            voucherMap.set(r.voucher_id, {
+                voucher_id:   r.voucher_id,
+                voucher_type: r.voucher_type,
+                voucher_date: r.voucher_date,
+                voucher_no:   r.voucher_no,
+                narration:    r.narration,
+                is_reversal:  r.is_reversal,
+                lines:        []
+            });
+        }
+        voucherMap.get(r.voucher_id).lines.push({
+            ledger_name: r.tally_ledger_name,
+            dr_amount:   parseFloat(r.dr_amount || 0),
+            cr_amount:   parseFloat(r.cr_amount || 0)
+        });
+    }
+    const vouchers = [...voucherMap.values()];
+
+    // 6. Generate XML
+    const out = [];
+    out.push(`<?xml version="1.0" encoding="UTF-8"?>`);
+    out.push(`<ENVELOPE>`);
+    out.push(`  <HEADER>`);
+    out.push(`    <TALLYREQUEST>Import Data</TALLYREQUEST>`);
+    out.push(`  </HEADER>`);
+    out.push(`  <BODY>`);
+    out.push(`    <IMPORTDATA>`);
+    out.push(`      <REQUESTDESC>`);
+    out.push(`        <REPORTNAME>Vouchers</REPORTNAME>`);
+    out.push(`      </REQUESTDESC>`);
+    out.push(`      <REQUESTDATA>`);
+
+    // Groups — parents before children, ACTION=CREATE is idempotent in Tally
+    for (const g of sortedGroups) {
+        const name   = xmlEscape(g.tally_group_name || g.group_name);
+        const parent = g.parent_group_id
+            ? xmlEscape((allGroupMap.get(g.parent_group_id) || {}).tally_group_name || (allGroupMap.get(g.parent_group_id) || {}).group_name || '')
+            : '';
+        out.push(`        <TALLYMESSAGE xmlns:UDF="TallyUDF">`);
+        out.push(`          <GROUP ACTION="CREATE">`);
+        out.push(`            <NAME>${name}</NAME>`);
+        if (parent) out.push(`            <PARENT>${parent}</PARENT>`);
+        out.push(`          </GROUP>`);
+        out.push(`        </TALLYMESSAGE>`);
+    }
+
+    // Ledgers — ACTION=CREATE skipped silently if already exists in Tally
+    const emittedLedgerIds = new Set();
+    for (const l of ledgerRows) {
+        if (emittedLedgerIds.has(l.ledger_id)) continue;
+        emittedLedgerIds.add(l.ledger_id);
+        out.push(`        <TALLYMESSAGE xmlns:UDF="TallyUDF">`);
+        out.push(`          <LEDGER ACTION="CREATE">`);
+        out.push(`            <NAME>${xmlEscape(l.tally_ledger_name)}</NAME>`);
+        out.push(`            <PARENT>${xmlEscape(l.tally_group_name)}</PARENT>`);
+        out.push(`          </LEDGER>`);
+        out.push(`        </TALLYMESSAGE>`);
+    }
+
+    // Vouchers
+    for (const v of vouchers) {
+        const tallyType = VOUCHER_TYPE_MAP[v.voucher_type] || 'Journal';
+        const isRev     = v.is_reversal === 'Y';
+        let narr = xmlEscape(v.narration || '');
+        if (isRev) narr = '[REVERSAL] ' + narr;
+
+        out.push(`        <TALLYMESSAGE xmlns:UDF="TallyUDF">`);
+        out.push(`          <VOUCHER VCHTYPE="${tallyType}" ACTION="CREATE">`);
+        out.push(`            <DATE>${tallyDate(v.voucher_date)}</DATE>`);
+        out.push(`            <VOUCHERTYPENAME>${tallyType}</VOUCHERTYPENAME>`);
+        out.push(`            <VOUCHERNUMBER>${xmlEscape(v.voucher_no || '')}</VOUCHERNUMBER>`);
+        if (narr) out.push(`            <NARRATION>${narr}</NARRATION>`);
+
+        for (const line of v.lines) {
+            const isDebit = line.dr_amount > 0;
+            // Tally convention: DR → ISDEEMEDPOSITIVE=Yes, AMOUNT=negative
+            //                   CR → ISDEEMEDPOSITIVE=No,  AMOUNT=positive
+            const amount  = isDebit ? -(line.dr_amount) : line.cr_amount;
+            out.push(`            <ALLLEDGERENTRIES.LIST>`);
+            out.push(`              <LEDGERNAME>${xmlEscape(line.ledger_name)}</LEDGERNAME>`);
+            out.push(`              <ISDEEMEDPOSITIVE>${isDebit ? 'Yes' : 'No'}</ISDEEMEDPOSITIVE>`);
+            out.push(`              <AMOUNT>${amount.toFixed(2)}</AMOUNT>`);
+            out.push(`            </ALLLEDGERENTRIES.LIST>`);
+        }
+
+        out.push(`          </VOUCHER>`);
+        out.push(`        </TALLYMESSAGE>`);
+    }
+
+    out.push(`      </REQUESTDATA>`);
+    out.push(`    </IMPORTDATA>`);
+    out.push(`  </BODY>`);
+    out.push(`</ENVELOPE>`);
+
+    const xml = out.join('\n');
+
+    // 7. Mark all exported vouchers as is_exported='Y'
+    const voucherIds = vouchers.map(v => v.voucher_id);
+    const chunkSize  = 100;
+    for (let i = 0; i < voucherIds.length; i += chunkSize) {
+        const chunk        = voucherIds.slice(i, i + chunkSize);
+        const placeholders = chunk.map((_, j) => `:vid${i + j}`).join(', ');
+        const rpl          = { locationCode };
+        chunk.forEach((id, j) => { rpl[`vid${i + j}`] = id; });
+        await db.sequelize.query(`
+            UPDATE gl_journal_headers
+            SET is_exported = 'Y'
+            WHERE voucher_id IN (${placeholders}) AND location_code = :locationCode
+        `, { replacements: rpl, type: db.Sequelize.QueryTypes.UPDATE });
+    }
+
+    // 8. Log export batch
+    const fileName = `tally_export_${locationCode}_${fromDate}_${toDate}.xml`;
+    await db.sequelize.query(`
+        INSERT INTO gl_export_batches (location_code, from_date, to_date, voucher_count, exported_by, file_name)
+        VALUES (:locationCode, :fromDate, :toDate, :voucherCount, :exportedBy, :fileName)
+    `, {
+        replacements: { locationCode, fromDate, toDate, voucherCount: vouchers.length, exportedBy, fileName },
+        type: db.Sequelize.QueryTypes.INSERT
+    });
+
+    return { xml, fileName, voucherCount: vouchers.length, ledgerCount: emittedLedgerIds.size, groupCount: sortedGroups.length };
+}
+
+module.exports = { preview, generateAndExport };

--- a/views/gl-control.pug
+++ b/views/gl-control.pug
@@ -15,6 +15,8 @@ block content
                 a.nav-link(id="tab-accounting" data-toggle="tab" href="#pane-accounting" role="tab") Create Accounting
             li.nav-item
                 a.nav-link(id="tab-generate" data-toggle="tab" href="#pane-generate" role="tab") Generate Events
+            li.nav-item
+                a.nav-link(id="tab-export" data-toggle="tab" href="#pane-export" role="tab") Tally Export
 
         .tab-content
 
@@ -180,6 +182,48 @@ block content
                 #geBatchRuns
                     .text-muted.small Loading…
 
+
+            //- ── Tally Export ────────────────────────────────────────────────
+            #pane-export.tab-pane.fade(role="tabpanel")
+
+                p.text-muted.small.mb-3
+                    | Generates a Tally-compatible XML file for the selected date range.
+                    | Groups and ledgers are bundled before each voucher — new parties and accounts created in PetroMath are automatically included, so import never fails on missing ledger.
+
+                .row.align-items-end.mb-3
+                    .col-auto
+                        label.small.mb-1 Period
+                        select.form-control.form-control-sm#exPeriod(onchange="glSetPeriod(this)" data-from="exFrom" data-to="exTo")
+                            option(value="this_month") This Month
+                            option(value="last_month") Last Month
+                            option(value="this_fy") This Financial Year
+                            option(value="last_fy") Last Financial Year
+                            option(value="custom" selected) Custom
+                    .col-auto
+                        label.small.mb-1 From Date
+                        input.form-control.form-control-sm(type="date" id="exFrom" value=fromDate)
+                    .col-auto
+                        label.small.mb-1 To Date
+                        input.form-control.form-control-sm(type="date" id="exTo" value=toDate)
+                    .col-auto.align-self-end
+                        button.btn.btn-outline-secondary.btn-sm#btnExPreview Preview
+                    .col-auto.align-self-end
+                        .custom-control.custom-switch
+                            input.custom-control-input(type="checkbox" id="chkReexport")
+                            label.custom-control-label.small(for="chkReexport") Include already exported
+
+                #exPreviewResult.mb-3(style="display:none")
+                    .alert.py-2.small.mb-0#exPreviewBody
+
+                button.btn.btn-success.mb-3#btnExExport(disabled)
+                    i.bi.bi-download.mr-1
+                    | Download XML
+
+                hr
+                h6.mb-2 Export History
+                    button.btn.btn-outline-secondary.btn-sm.ml-2(type="button" onclick="loadExportHistory()") Refresh
+                #exHistory
+                    .text-muted.small Loading…
 
     //- ── Source Detail Modal ─────────────────────────────────────────────────
     .modal.fade#sourceDetailModal(tabindex="-1" role="dialog")
@@ -484,6 +528,123 @@ block content
 
         document.getElementById('tab-accounting').addEventListener('shown.bs.tab', function() { loadBatchRuns('ca'); });
         document.getElementById('tab-generate').addEventListener('shown.bs.tab',  function() { loadBatchRuns('ge'); });
+        document.getElementById('tab-export').addEventListener('shown.bs.tab',    loadExportHistory);
+
+        // ── Tally Export ──────────────────────────────────────────────────────
+
+        let exPreviewData = null;
+
+        async function loadExportHistory() {
+            const el = document.getElementById('exHistory');
+            el.innerHTML = '<p class="text-muted small">Loading…</p>';
+            try {
+                const rows = await fetch('/gl/api/tally-export/history').then(r => r.json());
+                if (!rows.length) { el.innerHTML = '<p class="text-muted small mb-0">No exports yet.</p>'; return; }
+                const rowsHtml = rows.map(function(r) {
+                    return `<tr>
+                        <td class="small">${r.batch_id}</td>
+                        <td class="small">${(r.from_date||'').toString().substring(0,10)}</td>
+                        <td class="small">${(r.to_date||'').toString().substring(0,10)}</td>
+                        <td class="small">${r.voucher_count}</td>
+                        <td class="small">${r.exported_by||''}</td>
+                        <td class="small">${r.exported_at ? new Date(r.exported_at).toLocaleString('en-IN') : ''}</td>
+                        <td class="small text-muted" style="font-size:0.75rem">${r.file_name||''}</td>
+                    </tr>`;
+                }).join('');
+                el.innerHTML = `<div class="table-responsive"><table class="table table-sm table-bordered table-hover">
+                    <thead class="thead-dark"><tr>
+                        <th style="width:50px">ID</th>
+                        <th style="width:90px">From</th><th style="width:90px">To</th>
+                        <th style="width:80px">Vouchers</th>
+                        <th>By</th>
+                        <th style="width:150px">Exported At</th>
+                        <th>File</th>
+                    </tr></thead><tbody>${rowsHtml}</tbody></table></div>`;
+            } catch (e) {
+                el.innerHTML = '<p class="text-danger small">' + e.message + '</p>';
+            }
+        }
+
+        document.getElementById('btnExPreview').addEventListener('click', async function() {
+            const from = document.getElementById('exFrom').value;
+            const to   = document.getElementById('exTo').value;
+            if (!from || !to) { alert('Please select a date range.'); return; }
+            const includeExported = document.getElementById('chkReexport').checked;
+            this.disabled = true;
+            this.textContent = 'Checking…';
+            try {
+                const qs   = new URLSearchParams({ from_date: from, to_date: to, include_exported: includeExported ? '1' : '0' });
+                const data = await fetch('/gl/api/tally-export/preview?' + qs).then(r => r.json());
+                const wrap = document.getElementById('exPreviewResult');
+                const body = document.getElementById('exPreviewBody');
+                if (data.error) {
+                    body.className = 'alert alert-danger py-2 small mb-0';
+                    body.textContent = data.error;
+                    document.getElementById('btnExExport').disabled = true;
+                    exPreviewData = null;
+                } else if (!data.voucher_count) {
+                    body.className = 'alert alert-warning py-2 small mb-0';
+                    body.textContent = 'No vouchers found for this date range.';
+                    document.getElementById('btnExExport').disabled = true;
+                    exPreviewData = null;
+                } else {
+                    body.className = 'alert alert-info py-2 small mb-0';
+                    body.innerHTML = '<strong>' + data.voucher_count + '</strong> voucher(s) across <strong>' + data.ledger_count + '</strong> unique ledger(s) — ready to export.';
+                    document.getElementById('btnExExport').disabled = false;
+                    exPreviewData = { from, to, includeExported };
+                }
+                wrap.style.display = '';
+            } catch (e) {
+                alert('Error: ' + e.message);
+            } finally {
+                this.disabled = false;
+                this.textContent = 'Preview';
+            }
+        });
+
+        document.getElementById('btnExExport').addEventListener('click', async function() {
+            if (!exPreviewData) return;
+            const { from, to, includeExported } = exPreviewData;
+            this.disabled = true;
+            const orig = this.innerHTML;
+            this.innerHTML = '<span class="spinner-border spinner-border-sm mr-1"></span>Generating…';
+            try {
+                const resp = await fetch('/gl/api/tally-export', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ from_date: from, to_date: to, include_exported: includeExported })
+                });
+                if (!resp.ok) {
+                    const err = await resp.json().catch(function() { return {}; });
+                    alert('Export failed: ' + (err.error || resp.statusText));
+                    return;
+                }
+                // Extract filename from Content-Disposition header
+                const cd       = resp.headers.get('Content-Disposition') || '';
+                const fnMatch  = cd.match(/filename="?([^";\n]+)"?/);
+                const fileName = fnMatch ? fnMatch[1] : 'tally_export.xml';
+
+                const xml  = await resp.text();
+                const blob = new Blob([xml], { type: 'text/xml' });
+                const url  = URL.createObjectURL(blob);
+                const a    = document.createElement('a');
+                a.href     = url;
+                a.download = fileName;
+                a.click();
+                URL.revokeObjectURL(url);
+
+                // Reset state + refresh history
+                document.getElementById('exPreviewResult').style.display = 'none';
+                document.getElementById('btnExExport').disabled = true;
+                exPreviewData = null;
+                loadExportHistory();
+            } catch (e) {
+                alert('Export error: ' + e.message);
+            } finally {
+                this.disabled = false;
+                this.innerHTML = orig;
+            }
+        });
 
         // Auto-load summary on page open
         loadSummary();


### PR DESCRIPTION
## Summary
- Adds **Tally Export** tab to GL Control page (`/gl/control`)
- New `services/gl-tally-export-service.js` handles XML generation
- Groups and ledgers bundled with `ACTION=\"CREATE\"` (idempotent) before vouchers — new credit parties/accounts auto-created on Tally import, eliminating missing-ledger import failures
- All text properly XML-escaped (`&`, `<`, `>`, `"`) — handles company names with `&` etc.
- Marks `is_exported='Y'` on vouchers after export; logs to `gl_export_batches`
- \"Include already exported\" toggle for re-export scenarios
- Export history shown in tab

## New endpoints
- `GET /gl/api/tally-export/preview` — count pending vouchers before download
- `POST /gl/api/tally-export` — generate XML, mark exported, return file download
- `GET /gl/api/tally-export/history` — last 20 export batches

## Test plan
- [ ] GL Control → Tally Export tab loads
- [ ] Preview shows correct voucher/ledger count for a date range
- [ ] Download XML triggers file download
- [ ] Import XML into Tally — no missing-ledger errors even for new parties
- [ ] Company names with `&` export without breaking XML
- [ ] \"Include already exported\" checkbox includes previously exported vouchers
- [ ] Export history table populates after download

🤖 Generated with [Claude Code](https://claude.com/claude-code)