### PR TITLE
GL accounting: fix base_amount rounding to ensure DR=CR balance

### DIFF
--- a/services/create-accounting-service.js
+++ b/services/create-accounting-service.js
@@ -365,9 +365,10 @@ async function processCreditSaleEvent(event, processedBy) {
     if (!customerLedgerId) throw new Error(`GL ledger not found for customer ${row.customer_name} (creditlist_id:${row.creditlist_id})`);
 
     const totalAmount = parseFloat(row.amount);
-    const baseAmount  = parseFloat(row.base_amount  || totalAmount);
     const cgstAmount  = parseFloat(row.cgst_amount  || 0);
     const sgstAmount  = parseFloat(row.sgst_amount  || 0);
+    // Derive base from total so DR always equals CR (stored base_amount may be independently rounded)
+    const baseAmount  = totalAmount - cgstAmount - sgstAmount;
     const qty         = parseFloat(row.qty).toFixed(3);
     const narration   = `${qty} ${row.product_name} | ₹${totalAmount.toFixed(2)} | ${row.customer_name} | Bill: ${row.bill_no}`;
 
@@ -443,9 +444,10 @@ async function processCashSaleEvent(event, processedBy) {
     if (!cashLedgerId) throw new Error(`Cash-in-Hand ledger not found for location ${location_code}`);
 
     const totalAmount = parseFloat(row.amount);
-    const baseAmount  = parseFloat(row.base_amount  || totalAmount);
     const cgstAmount  = parseFloat(row.cgst_amount  || 0);
     const sgstAmount  = parseFloat(row.sgst_amount  || 0);
+    // Derive base from total so DR always equals CR (stored base_amount may be independently rounded)
+    const baseAmount  = totalAmount - cgstAmount - sgstAmount;
     const qty         = parseFloat(row.qty).toFixed(3);
     const narration   = `${qty} ${row.product_name} | ₹${totalAmount.toFixed(2)} | Bill: ${row.bill_no}`;
 


### PR DESCRIPTION
## Summary
- Fixes 1-paise DR/CR imbalance in GL journal entries for `CASH_SALE` and `CREDIT_SALE` events
- Root cause: `base_amount`, `cgst_amount`, `sgst_amount` were all independently rounded in `t_cashsales` / `t_credits`, causing their sum to differ from the actual total by ±0.01
- Fix: derive `base_amount = total - cgst - sgst` instead of reading the stored value — base absorbs any rounding residual, so every voucher balances exactly

## Test plan
- [ ] Generate events and create accounting for a date range containing GST sales
- [ ] Run imbalance check: `SELECT voucher_id FROM gl_journal_lines GROUP BY voucher_id HAVING ABS(ROUND(SUM(dr_amount),4) - ROUND(SUM(cr_amount),4)) > 0.001` — should return 0 rows
- [ ] Export to Tally XML — vouchers should import without balance errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)