### PR TITLE
Bank upload history: track and display which screen created each record

### DIFF
--- a/controllers/bank-reconciliation-controller.js
+++ b/controllers/bank-reconciliation-controller.js
@@ -785,6 +785,7 @@ if (accountValidation.warning) {
         await bankReconDao.insertUploadHistory({
             location_code: locationCode,
             bank_id: bankId,
+            source_screen: 'BANK_RECON',
             source_file: req.file.originalname,
             uploaded_by: userName,
             total_transactions: transactions.length,
@@ -848,6 +849,7 @@ saveBankStatement: async (req, res) => {
         await bankReconDao.insertUploadHistory({
             location_code: locationCode,
             bank_id: bankId,
+            source_screen: 'BANK_RECON',
             source_file: sourceFile,
             uploaded_by: userName,
             total_transactions: transactions.length,
@@ -872,6 +874,7 @@ saveBankStatement: async (req, res) => {
             await bankReconDao.insertUploadHistory({
                 location_code: req.user.location_code,
                 bank_id: parseInt(req.body.bank_id),
+                source_screen: 'BANK_RECON',
                 source_file: req.body.transactions[0]?.source_file || 'Unknown',
                 uploaded_by: req.user.User_Name || req.user.username,
                 total_transactions: req.body.transactions?.length || 0,

--- a/controllers/transaction-upload-controller.js
+++ b/controllers/transaction-upload-controller.js
@@ -1170,6 +1170,7 @@ previewTransactions: async (req, res) => {
                 await bankReconDao.insertUploadHistory({
                     location_code: locationCode,
                     bank_id: bankId,
+                    source_screen: 'TRANSACTION_UPLOAD',
                     source_file: sourceFile,
                     uploaded_by: userName,
                     total_transactions: totalTransactions,
@@ -1198,6 +1199,7 @@ previewTransactions: async (req, res) => {
             await bankReconDao.insertUploadHistory({
                 location_code: locationCode,
                 bank_id: bankId,
+                source_screen: 'TRANSACTION_UPLOAD',
                 source_file: sourceFile,
                 uploaded_by: userName,
                 total_transactions: totalTransactions,
@@ -1223,6 +1225,7 @@ previewTransactions: async (req, res) => {
                 await bankReconDao.insertUploadHistory({
                     location_code: req.user.location_code,
                     bank_id: parseInt(req.body.bank_id, 10),
+                    source_screen: 'TRANSACTION_UPLOAD',
                     source_file: req.body.source_file || req.body.transactions?.[0]?.source_file || 'Unknown',
                     uploaded_by: req.user.User_Name || req.user.username || req.user.user_id,
                     total_transactions: parseInt(req.body.total_transactions, 10) || req.body.transactions?.length || 0,

--- a/dao/bank-reconciliation-dao.js
+++ b/dao/bank-reconciliation-dao.js
@@ -481,14 +481,15 @@ insertUploadHistory: async (historyData) => {
     try {
         const result = await db.sequelize.query(
             `INSERT INTO t_bank_statement_upload_history
-             (location_code, bank_id, source_file, uploaded_by, 
+             (location_code, bank_id, source_screen, source_file, uploaded_by,
               total_transactions, duplicates_found, transactions_imported,
               first_txn_date, last_txn_date, status, remarks)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
             {
                 replacements: [
                     historyData.location_code,
                     historyData.bank_id,
+                    historyData.source_screen || 'BANK_RECON',
                     historyData.source_file,
                     historyData.uploaded_by,
                     historyData.total_transactions || 0,
@@ -519,8 +520,9 @@ getUploadHistory: async (locationCode, bankId = null, limit = 10) => {
         
         if (bankId) {
             query = `
-                SELECT 
+                SELECT
                     h.upload_id,
+                    h.source_screen,
                     h.source_file,
                     DATE_FORMAT(h.upload_date, '%d-%m-%Y %H:%i') as upload_date,
                     h.uploaded_by,
@@ -542,8 +544,9 @@ getUploadHistory: async (locationCode, bankId = null, limit = 10) => {
             replacements = [locationCode, bankId, limit];
         } else {
             query = `
-                SELECT 
+                SELECT
                     h.upload_id,
+                    h.source_screen,
                     h.source_file,
                     DATE_FORMAT(h.upload_date, '%d-%m-%Y %H:%i') as upload_date,
                     h.uploaded_by,

--- a/db/migrations/bank-statement-upload-history-source.sql
+++ b/db/migrations/bank-statement-upload-history-source.sql
@@ -1,0 +1,27 @@
+-- Add source_screen to t_bank_statement_upload_history so the Bank Reconciliation
+-- upload-history view can distinguish uploads made via the Transaction Upload
+-- screen from uploads made via Bank Reconciliation's own upload flow — both
+-- write to this shared table today with no way to tell them apart.
+
+SET @add_col = (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 't_bank_statement_upload_history'
+      AND COLUMN_NAME = 'source_screen'
+);
+SET @sql = IF(@add_col = 0,
+    'ALTER TABLE t_bank_statement_upload_history ADD COLUMN source_screen VARCHAR(30) NOT NULL DEFAULT ''BANK_RECON'' AFTER bank_id',
+    'SELECT ''source_screen column already exists'' AS msg'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Backfill existing rows: Transaction Upload always stamps remarks with
+-- 'retained_file=...' (see saveTransactions in transaction-upload-controller.js);
+-- Bank Reconciliation's own remarks pattern is 'Replaced <date> to <date> (...)'
+-- or a raw error message. Everything else defaults to BANK_RECON above.
+UPDATE t_bank_statement_upload_history
+SET source_screen = 'TRANSACTION_UPLOAD'
+WHERE remarks LIKE 'retained_file=%'
+   OR remarks LIKE 'Partial save%retained_file=%';

--- a/views/reports-bank-recon.pug
+++ b/views/reports-bank-recon.pug
@@ -592,6 +592,7 @@ block content
                         <thead style="position: sticky; top: 0; background-color: #f8f9fa; z-index: 5;">
                             <tr>
                                 <th>Upload Date</th>
+                                <th>Source</th>
                                 <th>File Name</th>
                                 <th>First Date</th>
                                 <th>Last Date</th>
@@ -604,14 +605,17 @@ block content
                         </thead>
                         <tbody>
             `;
-            
+
             history.forEach(h => {
-                const statusBadge = h.status === 'COMPLETED' ? 'badge-success' : 
+                const statusBadge = h.status === 'COMPLETED' ? 'badge-success' :
                                 h.status === 'FAILED' ? 'badge-danger' : 'badge-warning';
-                                
+                const sourceBadge = h.source_screen === 'TRANSACTION_UPLOAD' ? 'badge-info' : 'badge-secondary';
+                const sourceLabel = h.source_screen === 'TRANSACTION_UPLOAD' ? 'Transaction Upload' : 'Bank Recon';
+
                 html += `
                     <tr>
                         <td style="white-space: nowrap;">${h.upload_date}</td>
+                        <td><span class="badge ${sourceBadge}">${sourceLabel}</span></td>
                         <td><small>${h.source_file}</small></td>
                         <td style="white-space: nowrap;">${h.first_txn_date || '-'}</td>
                         <td style="white-space: nowrap;">${h.last_txn_date || '-'}</td>


### PR DESCRIPTION
## Summary
- `t_bank_statement_upload_history` is written to by both the Transaction Upload screen and Bank Reconciliation's own upload flow, but had no column distinguishing them — Bank Reconciliation's upload-history view showed both mixed together with zero indication of source.
- Added `source_screen` column (migration backfills existing rows from the `remarks` pattern — Transaction Upload always stamps `retained_file=...`). Turned out ~99% of the 1090 historical rows on prod were actually from Transaction Upload, not Bank Recon itself.
- Both controllers now pass `source_screen` on every `insertUploadHistory` call (success and failure paths, 6 call sites total).
- Bank Reconciliation's upload-history table now shows a "Source" badge column per row.

## Test plan
- [x] Migration run on dev DB, verified column + backfill counts, zero ambiguous null-remarks rows.
- [x] Migration run on prod DB (1090 rows), verified: 1078 `TRANSACTION_UPLOAD`, 12 `BANK_RECON`, zero null-remarks rows — spot-checked all 12 `BANK_RECON` fallback rows individually to confirm they're genuinely from Bank Recon's own remarks pattern, not misclassified.
- [x] Syntax-checked all edited JS files.
- [ ] Manual verification on dev beta: upload via Transaction Upload, confirm it shows "Transaction Upload" badge in Bank Reconciliation's history view; same for a Bank Recon upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)