### PR TITLE
Add professional marketing landing page

### DIFF
--- a/app.js
+++ b/app.js
@@ -529,9 +529,12 @@ app.get('/login', function (req, res) {
 });
 
 // Routes - start
-app.get('/', isLoginEnsured, function (req, res) {
+app.get('/', function (req, res) {
+    if (!req.isAuthenticated()) {
+        return res.sendFile(path.join(__dirname, 'public', 'landing.html'));
+    }
     if(req.user.Role === 'Customer') {
-        res.redirect('/home-customer');    
+        res.redirect('/home-customer');
     }
     if (req.user.Role === 'Cashier') {
         return res.redirect('/dsm-entry');

--- a/public/landing.html
+++ b/public/landing.html
@@ -1,0 +1,431 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PetroMath | Fuel Station Management, Simplified</title>
+<meta name="description" content="PetroMath is complete fuel station management software for Indian petrol pump dealers — shift closing, credit &amp; vehicle tracking, GST-compliant day billing, automated accounting, and stock reports in one place.">
+<link rel="icon" href="/images/mc_logo.jpg">
+<style>
+  :root {
+    --ink: #12161c;
+    --navy: #0d1b2e;
+    --navy-2: #16283f;
+    --paper: #f7f5ef;
+    --amber: #f4c11e;
+    --amber-dark: #d9a300;
+    --muted: #8a94a3;
+    --line: rgba(255,255,255,0.08);
+    --radius: 14px;
+    font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
+  }
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    margin: 0;
+    background: var(--paper);
+    color: var(--ink);
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+  }
+  a { color: inherit; }
+  img { max-width: 100%; display: block; }
+  .wrap { max-width: 1160px; margin: 0 auto; padding: 0 28px; }
+
+  /* ---------- Nav ---------- */
+  header.nav {
+    position: sticky; top: 0; z-index: 50;
+    background: rgba(13,27,46,0.92);
+    backdrop-filter: saturate(180%) blur(10px);
+    border-bottom: 1px solid var(--line);
+  }
+  .nav-inner {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 14px 28px;
+    max-width: 1160px; margin: 0 auto;
+  }
+  .brand { display: flex; align-items: center; gap: 10px; text-decoration: none; }
+  .brand img { width: 34px; height: 34px; border-radius: 8px; }
+  .brand span { color: #fff; font-weight: 700; font-size: 1.15rem; letter-spacing: 0.2px; }
+  nav.links { display: flex; gap: 30px; align-items: center; }
+  nav.links a {
+    color: #c9d2de; text-decoration: none; font-size: 0.92rem; font-weight: 500;
+    transition: color .15s ease;
+  }
+  nav.links a:hover { color: #fff; }
+  .btn {
+    display: inline-flex; align-items: center; justify-content: center;
+    padding: 11px 22px; border-radius: 999px; font-weight: 600; font-size: 0.92rem;
+    text-decoration: none; border: 1px solid transparent; cursor: pointer;
+    transition: transform .15s ease, box-shadow .15s ease, background .15s ease;
+  }
+  .btn-primary { background: var(--amber); color: #1a1400; }
+  .btn-primary:hover { background: var(--amber-dark); transform: translateY(-1px); box-shadow: 0 8px 20px rgba(244,193,30,0.25); }
+  .btn-ghost { border-color: rgba(255,255,255,0.25); color: #fff; }
+  .btn-ghost:hover { border-color: #fff; }
+  .btn-dark { background: var(--navy); color: #fff; }
+  .btn-dark:hover { background: var(--navy-2); transform: translateY(-1px); }
+
+  /* ---------- Hero ---------- */
+  .hero {
+    position: relative;
+    background: linear-gradient(180deg, var(--navy) 0%, #0a1524 100%);
+    color: #fff;
+    overflow: hidden;
+  }
+  .hero::after {
+    content: "";
+    position: absolute; inset: 0;
+    background: url('/images/homepage.jpg') center 30% / cover no-repeat;
+    opacity: 0.28;
+    mix-blend-mode: luminosity;
+  }
+  .hero::before {
+    content: "";
+    position: absolute; inset: 0;
+    background: radial-gradient(ellipse 900px 500px at 20% 0%, rgba(244,193,30,0.16), transparent 60%);
+    z-index: 1;
+  }
+  .hero-inner {
+    position: relative; z-index: 2;
+    padding: 110px 28px 90px;
+    max-width: 1160px; margin: 0 auto;
+  }
+  .eyebrow {
+    display: inline-flex; align-items: center; gap: 8px;
+    background: rgba(244,193,30,0.12); border: 1px solid rgba(244,193,30,0.35);
+    color: var(--amber); font-size: 0.78rem; font-weight: 700; letter-spacing: 0.06em;
+    text-transform: uppercase; padding: 7px 14px; border-radius: 999px;
+    margin-bottom: 26px;
+  }
+  .hero h1 {
+    font-size: clamp(2.2rem, 4.6vw, 3.6rem);
+    line-height: 1.12;
+    font-weight: 800;
+    margin: 0 0 22px;
+    max-width: 820px;
+    letter-spacing: -0.01em;
+  }
+  .hero h1 em { color: var(--amber); font-style: normal; }
+  .hero p.lead {
+    font-size: 1.15rem; color: #cbd5e2; max-width: 620px; line-height: 1.6;
+    margin: 0 0 38px;
+  }
+  .hero-ctas { display: flex; gap: 14px; flex-wrap: wrap; margin-bottom: 64px; }
+  .hero-stats {
+    display: grid; grid-template-columns: repeat(4, 1fr); gap: 24px;
+    border-top: 1px solid var(--line); padding-top: 34px; max-width: 900px;
+  }
+  .hero-stats .stat b { display: block; font-size: 1.7rem; color: #fff; font-weight: 800; }
+  .hero-stats .stat span { font-size: 0.85rem; color: var(--muted); }
+
+  /* ---------- Sections ---------- */
+  section { padding: 96px 0; }
+  .section-head { max-width: 640px; margin: 0 auto 56px; text-align: center; }
+  .section-head .kicker {
+    color: var(--amber-dark); font-weight: 700; font-size: 0.78rem;
+    letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 12px;
+  }
+  .section-head h2 { font-size: clamp(1.6rem, 3vw, 2.3rem); margin: 0 0 14px; letter-spacing: -0.01em; }
+  .section-head p { color: #555f6e; font-size: 1.02rem; line-height: 1.6; margin: 0; }
+
+  /* ---------- Features ---------- */
+  .features {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px;
+  }
+  .feature-card {
+    background: #fff; border: 1px solid #eae6da; border-radius: var(--radius);
+    padding: 30px 26px; transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease;
+  }
+  .feature-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 20px 40px -20px rgba(13,27,46,0.25);
+    border-color: #e2dbc6;
+  }
+  .feature-icon {
+    width: 46px; height: 46px; border-radius: 11px;
+    background: linear-gradient(135deg, var(--amber), var(--amber-dark));
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1.3rem; margin-bottom: 18px;
+  }
+  .feature-card h3 { font-size: 1.05rem; margin: 0 0 8px; }
+  .feature-card p { margin: 0; color: #5c6675; font-size: 0.92rem; line-height: 1.6; }
+
+  /* ---------- Showcase ---------- */
+  .showcase {
+    background: var(--navy); color: #fff;
+  }
+  .showcase-grid {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 60px; align-items: center;
+  }
+  .showcase-grid img {
+    border-radius: var(--radius); box-shadow: 0 30px 60px -20px rgba(0,0,0,0.5);
+    border: 1px solid rgba(255,255,255,0.08);
+  }
+  .showcase-copy .kicker { color: var(--amber); font-weight: 700; font-size: 0.78rem; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 14px; }
+  .showcase-copy h2 { font-size: clamp(1.5rem, 2.6vw, 2.1rem); margin: 0 0 18px; line-height: 1.25; }
+  .showcase-copy p { color: #b9c2cf; line-height: 1.7; margin: 0 0 26px; }
+  .checklist { list-style: none; margin: 0; padding: 0; display: grid; gap: 14px; }
+  .checklist li { display: flex; gap: 12px; align-items: flex-start; color: #dbe2ea; font-size: 0.95rem; }
+  .checklist li .tick {
+    flex: none; width: 20px; height: 20px; border-radius: 50%;
+    background: rgba(244,193,30,0.15); color: var(--amber);
+    display: flex; align-items: center; justify-content: center; font-size: 0.7rem; font-weight: 800;
+    margin-top: 2px;
+  }
+
+  /* ---------- Workflow ---------- */
+  .workflow { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0; counter-reset: step; }
+  .step { position: relative; padding: 0 22px; }
+  .step:not(:first-child)::before {
+    content: ""; position: absolute; top: 22px; left: -6px; width: 100%; height: 2px;
+    background: repeating-linear-gradient(90deg, #ddd6c2 0 8px, transparent 8px 16px);
+  }
+  .step .num {
+    width: 44px; height: 44px; border-radius: 50%; background: var(--navy); color: var(--amber);
+    display: flex; align-items: center; justify-content: center; font-weight: 800; font-size: 1.05rem;
+    position: relative; z-index: 1; margin-bottom: 18px;
+  }
+  .step h4 { margin: 0 0 8px; font-size: 1rem; }
+  .step p { margin: 0; color: #5c6675; font-size: 0.9rem; line-height: 1.6; }
+
+  /* ---------- CTA ---------- */
+  .cta {
+    background: linear-gradient(135deg, var(--amber) 0%, #f7d354 100%);
+    border-radius: 24px; margin: 0 28px; padding: 64px 48px;
+    text-align: center; max-width: 1104px; margin-inline: auto;
+  }
+  .cta h2 { font-size: clamp(1.6rem, 3vw, 2.2rem); margin: 0 0 14px; color: #1a1400; }
+  .cta p { margin: 0 0 32px; color: #4a3c00; font-size: 1.05rem; }
+  .cta .btn-dark { padding: 14px 30px; font-size: 0.98rem; }
+
+  /* ---------- Footer ---------- */
+  footer { background: #0a1220; color: #8a94a3; padding: 56px 0 28px; }
+  .footer-grid {
+    display: grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap: 40px;
+    padding-bottom: 40px; border-bottom: 1px solid var(--line);
+  }
+  footer .brand span { color: #fff; }
+  footer p.tag { font-size: 0.9rem; line-height: 1.7; max-width: 300px; margin: 16px 0 0; }
+  footer h5 { color: #fff; font-size: 0.85rem; margin: 0 0 16px; letter-spacing: 0.04em; text-transform: uppercase; }
+  footer ul { list-style: none; margin: 0; padding: 0; display: grid; gap: 11px; }
+  footer ul a { color: #8a94a3; text-decoration: none; font-size: 0.9rem; }
+  footer ul a:hover { color: #fff; }
+  .footer-bottom { display: flex; justify-content: space-between; align-items: center; padding-top: 26px; font-size: 0.82rem; flex-wrap: wrap; gap: 12px; }
+
+  /* ---------- Responsive ---------- */
+  @media (max-width: 900px) {
+    nav.links { display: none; }
+    .features { grid-template-columns: repeat(2, 1fr); }
+    .showcase-grid { grid-template-columns: 1fr; gap: 34px; }
+    .showcase-grid .img-col { order: -1; }
+    .workflow { grid-template-columns: repeat(2, 1fr); gap: 34px; }
+    .step:nth-child(3)::before, .step:not(:first-child)::before { display: none; }
+    .footer-grid { grid-template-columns: 1fr 1fr; gap: 32px; }
+    .hero-stats { grid-template-columns: repeat(2, 1fr); }
+  }
+  @media (max-width: 560px) {
+    .features { grid-template-columns: 1fr; }
+    .workflow { grid-template-columns: 1fr; }
+    .footer-grid { grid-template-columns: 1fr; }
+    .cta { padding: 44px 26px; margin: 0 16px; }
+  }
+</style>
+</head>
+<body>
+
+<header class="nav">
+  <div class="nav-inner">
+    <a class="brand" href="#top">
+      <img src="/images/mc_logo.jpg" alt="PetroMath logo">
+      <span>PetroMath</span>
+    </a>
+    <nav class="links">
+      <a href="#features">Features</a>
+      <a href="#workflow">How it works</a>
+      <a href="#showcase">Built for pumps</a>
+      <a href="#contact">Contact</a>
+    </nav>
+    <a class="btn btn-primary" href="/login">Sign in</a>
+  </div>
+</header>
+
+<section class="hero" id="top">
+  <div class="hero-inner">
+    <span class="eyebrow">Built for Indian Petrol Pump Dealers</span>
+    <h1>Run your fuel station on <em>one</em> clean system, not five spreadsheets.</h1>
+    <p class="lead">PetroMath handles shift closing, credit &amp; vehicle tracking, GST-compliant day billing, automated accounting, and stock reports — so every shift reconciles itself and every number ties out.</p>
+    <div class="hero-ctas">
+      <a class="btn btn-primary" href="#contact">Request a demo</a>
+      <a class="btn btn-ghost" href="#features">Explore features &darr;</a>
+    </div>
+    <div class="hero-stats">
+      <div class="stat"><b>100%</b><span>Shift-to-ledger reconciliation</span></div>
+      <div class="stat"><b>1</b><span>Bill per vendor, per day — GST ready</span></div>
+      <div class="stat"><b>Multi</b><span>Location support, one dashboard</span></div>
+      <div class="stat"><b>Auto</b><span>Journal entries, zero manual GL</span></div>
+    </div>
+  </div>
+</section>
+
+<section id="features">
+  <div class="wrap">
+    <div class="section-head">
+      <div class="kicker">Everything under one roof</div>
+      <h2>Purpose-built for how fuel stations actually run</h2>
+      <p>Not a generic accounting tool bent into shape — PetroMath is modeled directly on shift closing, tank readings, credit sales, and oil-company billing rules.</p>
+    </div>
+    <div class="features">
+      <div class="feature-card">
+        <div class="feature-icon">⛽</div>
+        <h3>Shift &amp; Cashflow Closing</h3>
+        <p>Capture pump readings, cash sales, and discounts per shift with built-in variance checks before a closing is finalized.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">🚚</div>
+        <h3>Credit &amp; Vehicle Management</h3>
+        <p>Track customer credit limits, vehicle-wise fuel sales, and receipts with statements ready for reconciliation anytime.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">🧾</div>
+        <h3>GST-Compliant Day Billing</h3>
+        <p>One consolidated cash bill and one digital bill per vendor, per day — auto-split proportionately across products and vendors.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">📚</div>
+        <h3>Automated GL Accounting</h3>
+        <p>Every credit sale, cash sale, and day bill posts a balanced journal entry automatically — no manual double entry, no rounding drift.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">🛢️</div>
+        <h3>Tank, Stock &amp; Variance Reports</h3>
+        <p>Tank receipts, stock summary, stock ledger, and shortage/excess reports keep every litre accounted for across pumps and tanks.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">🏦</div>
+        <h3>Bank &amp; Digital Reconciliation</h3>
+        <p>Upload bank statements and digital sale corrections to match settlements against what was actually collected at the pump.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">👥</div>
+        <h3>Employee &amp; Access Management</h3>
+        <p>Role-based access for owners, managers, and attendants, with per-location permissions and full audit visibility.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">📍</div>
+        <h3>Multi-Location Ready</h3>
+        <p>Run one outlet or a chain of them — per-location configuration with a consolidated view for the owner.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon">📄</div>
+        <h3>Automated Invoice Processing</h3>
+        <p>Oil-company invoices are parsed automatically, cutting manual data entry when purchase invoices land.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="showcase" id="showcase">
+  <div class="wrap showcase-grid">
+    <div class="img-col">
+      <img src="/images/landingpage.jpg" alt="A real Indian Oil fuel station running on PetroMath">
+    </div>
+    <div class="showcase-copy">
+      <div class="kicker">Made for the forecourt, not just the office</div>
+      <h2>Built alongside real dealers, tested at real pumps</h2>
+      <p>PetroMath grew out of the day-to-day realities of running an outlet — shift handovers, oil-company compliance, and closing the books at the end of a long day. Every feature exists because a working station needed it.</p>
+      <ul class="checklist">
+        <li><span class="tick">✓</span> Closes match tank readings and cash counted, every shift</li>
+        <li><span class="tick">✓</span> Day-end billing follows oil-company GST rules out of the box</li>
+        <li><span class="tick">✓</span> Accounting entries stay balanced without a bookkeeper double-checking</li>
+        <li><span class="tick">✓</span> Reports owners actually read: variance, stock, and credit ageing</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section id="workflow">
+  <div class="wrap">
+    <div class="section-head">
+      <div class="kicker">A day on PetroMath</div>
+      <h2>From opening reading to closed books</h2>
+      <p>The same flow every shift, every day — no spreadsheets stitched together after the fact.</p>
+    </div>
+    <div class="workflow">
+      <div class="step">
+        <div class="num">1</div>
+        <h4>Close the shift</h4>
+        <p>Attendants log readings, cash, and credit sales; the system flags variances before it's finalized.</p>
+      </div>
+      <div class="step">
+        <div class="num">2</div>
+        <h4>Reconcile cashflow</h4>
+        <p>Cash deposits and digital settlements are matched against what the shift actually recorded.</p>
+      </div>
+      <div class="step">
+        <div class="num">3</div>
+        <h4>Generate the day bill</h4>
+        <p>One cash and one digital bill per vendor is created automatically, split proportionately by sales.</p>
+      </div>
+      <div class="step">
+        <div class="num">4</div>
+        <h4>Books close themselves</h4>
+        <p>GL journal entries post automatically, and stock, GST, and variance reports are ready to review.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="contact">
+  <div class="cta">
+    <h2>See PetroMath running on your own outlet</h2>
+    <p>Bring your last week of closings — we'll show you exactly how they'd look inside PetroMath.</p>
+    <a class="btn btn-dark" href="mailto:petromath.app@gmail.com">Talk to us</a>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    <div class="footer-grid">
+      <div>
+        <a class="brand" href="#top">
+          <img src="/images/mc_logo.jpg" alt="PetroMath logo">
+          <span>PetroMath</span>
+        </a>
+        <p class="tag">Fuel station management software for Indian petrol pump dealers — shift closing, credit tracking, GST billing, and accounting in one place.</p>
+      </div>
+      <div>
+        <h5>Product</h5>
+        <ul>
+          <li><a href="#features">Features</a></li>
+          <li><a href="#workflow">How it works</a></li>
+          <li><a href="#showcase">Built for pumps</a></li>
+        </ul>
+      </div>
+      <div>
+        <h5>Modules</h5>
+        <ul>
+          <li><a href="#features">Shift &amp; Cashflow</a></li>
+          <li><a href="#features">Day Billing</a></li>
+          <li><a href="#features">GL Accounting</a></li>
+          <li><a href="#features">Stock Reports</a></li>
+        </ul>
+      </div>
+      <div>
+        <h5>Get in touch</h5>
+        <ul>
+          <li><a href="mailto:petromath.app@gmail.com">petromath.app@gmail.com</a></li>
+          <li><a href="tel:+916382395671">+91 63823 95671</a></li>
+          <li><a href="/login">Existing customer sign in</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span>© 2026 PetroMath. All rights reserved.</span>
+      <span>Made for fuel stations across India.</span>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `public/landing.html`, a self-contained marketing page covering shift/cashflow closing, credit & vehicle tracking, GST-compliant day billing, automated GL accounting, and stock/tank reports.
- Updates the `/` route in `app.js` so unauthenticated visitors see the landing page; authenticated users still redirect to their existing dashboards exactly as before.

## Test plan
- [x] Verified `/landing.html` returns 200 and all referenced images (`mc_logo.jpg`, `homepage.jpg`, `landingpage.jpg`) load against the local dev server
- [x] Verified `app.js` diff only changes the root route handler, no unrelated changes
- [x] Screenshotted the rendered page (hero, features, showcase, workflow, CTA, footer) to confirm layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)