### PR TITLE
Landing page: footer credits + hero copy tweak

### DIFF
--- a/public/landing.html
+++ b/public/landing.html
@@ -201,7 +201,7 @@
   }
   .carousel-dots .dot.active { background: var(--amber); transform: scale(1.2); }
   .photo-credit {
-    margin: 12px 2px 0; font-size: 0.72rem; color: #6b7686; line-height: 1.6;
+    margin: 14px 0 0; font-size: 0.72rem; color: #6b7686; line-height: 1.6;
   }
   .photo-credit a { color: #6b7686; text-decoration: underline; }
   .showcase-copy .kicker { color: var(--amber); font-weight: 700; font-size: 0.78rem; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 14px; }
@@ -294,7 +294,7 @@
 
 <section class="hero" id="top">
   <div class="hero-inner">
-    <span class="eyebrow">Built for Indian Petrol Pump Dealers</span>
+    <span class="eyebrow">Built for Petrol Pump Dealers</span>
     <h1>Run your fuel station on <em>one</em> clean system, not five spreadsheets.</h1>
     <p class="lead">PetroMath handles shift closing, credit &amp; vehicle tracking, GST-compliant day billing, automated accounting, and stock reports — so every shift reconciles itself and every number ties out.</p>
     <div class="hero-ctas">
@@ -396,7 +396,6 @@
           <button class="dot" data-index="3" aria-label="Show Nayara Energy slide"></button>
         </div>
       </div>
-      <p class="photo-credit">Station photos: Bharat Petroleum &amp; Nayara Energy by Manukrishnan80, Hindustan Petroleum by I.Mahesh — <a href="https://commons.wikimedia.org/" target="_blank" rel="noopener">Wikimedia Commons</a>, CC BY-SA.</p>
     </div>
     <div class="showcase-copy">
       <div class="kicker">Made for the forecourt, not just the office</div>
@@ -492,6 +491,7 @@
       <span>© 2026 PetroMath. All rights reserved.</span>
       <span>Made for fuel stations across India.</span>
     </div>
+    <p class="photo-credit">Station photos: Bharat Petroleum &amp; Nayara Energy by Manukrishnan80, Hindustan Petroleum by I.Mahesh — <a href="https://commons.wikimedia.org/" target="_blank" rel="noopener">Wikimedia Commons</a>, CC BY-SA.</p>
   </div>
 </footer>
 


### PR DESCRIPTION
## Summary
- Moves the Wikimedia Commons photo attribution from under the carousel into the footer as a quiet credits line.
- Drops "Indian" from the hero eyebrow badge ("Built for Petrol Pump Dealers").

## Test plan
- [x] Screenshotted the showcase section (clean, no inline credit) and footer (credit line present) to confirm placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)