### PR TITLE
Raise DESKTOP_ZOOM breakpoint to 1600px

### DIFF
--- a/views/layout.pug
+++ b/views/layout.pug
@@ -31,7 +31,7 @@ html
     
     if desktopZoom
       style.
-        @media (max-width: 1440px) { body { zoom: #{desktopZoom}; } }
+        @media (max-width: 1600px) { body { zoom: #{desktopZoom}; } }
 
     style.
       @media print {


### PR DESCRIPTION
## Summary
- GAC2's new `DESKTOP_ZOOM` config (shrinks the app on smaller screens to relieve the cramped shift-closing credit tab) wasn't applying on a common 15.6" laptop panel because the media query cutoff (1440px) missed 1920x1080 laptops running at 125% Windows scaling (~1536px effective viewport).
- Raised the breakpoint from 1440px to 1600px in `views/layout.pug` so it covers that case. Only GAC2 currently has `DESKTOP_ZOOM` set, so this is a safe, isolated change.

## Test plan
- [ ] Deploy to dev beta, log in as GAC2 (or a user pointed at GAC2), resize browser to ~1536px width, confirm the zoom style block now applies and the credit tab table fits
- [ ] Confirm a full-width (~1920px) monitor is unaffected