### PR TITLE
Fix sidebar height under DESKTOP_ZOOM

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -1293,9 +1293,9 @@ body {
   width: 260px;
   background: linear-gradient(180deg, #343a40 0%, #212529 100%);
   position: fixed;
-  height: 100vh;
-  left: 0;
   top: 0;
+  bottom: 0;
+  left: 0;
   z-index: 1000;
   overflow-y: auto;
   transition: all 0.3s ease;

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -31,7 +31,7 @@ html
     
     if desktopZoom
       style.
-        @media (max-width: 1600px) { .content-wrapper { zoom: #{desktopZoom}; } }
+        @media (max-width: 1600px) { body { zoom: #{desktopZoom}; } }
 
     style.
       @media print {


### PR DESCRIPTION
## Summary
- Previous fix scoped zoom to `.content-wrapper` to avoid a sidebar cutoff, but that meant the sidebar no longer shrunk with the rest of the page, looking disproportionately large next to zoomed content.
- Root cause: `.sidebar` used `position: fixed; height: 100vh;` — that computed height shrinks under body-level zoom just like everything else, so the box stops reaching the actual window bottom.
- Fix: `top: 0; bottom: 0;` instead of `height: 100vh` so the sidebar always spans the real viewport regardless of zoom. Reverted the zoom target back to `body` so sidebar and content shrink together proportionally.

## Test plan
- [ ] On dev beta as a GAC2 user at ~1536px width: sidebar reaches the bottom of the window, no cutoff
- [ ] Sidebar text/menu items now visibly shrink along with the credit table content
- [ ] Confirm a full-width (~1920px) monitor is unaffected