### PR TITLE
Move DESKTOP_ZOOM/APP_VERSION middleware before route mounts

### DIFF
--- a/app.js
+++ b/app.js
@@ -382,6 +382,26 @@ const addUserLocationInfo = async (req, res, next) => {
 app.use(addUserLocationInfo);
 app.use(addDebugLogging);
 
+app.use((req, res, next) => {
+    res.locals.APP_VERSION = process.env.APP_VERSION || 'stable';
+    res.locals.SERVER_PORT = process.env.SERVER_PORT;
+    next();
+});
+
+// Load DESKTOP_ZOOM from m_location_config (setting_name='DESKTOP_ZOOM', location_code='*' or per-location)
+// Remove this middleware once zoom is finalized and baked into style.css
+const { getLocationConfigValue } = require('./utils/location-config');
+app.use(async (req, res, next) => {
+    try {
+        const locationCode = (req.user && req.user.location_code) ? req.user.location_code : '*';
+        const zoom = await getLocationConfigValue(locationCode, 'DESKTOP_ZOOM', null);
+        res.locals.desktopZoom = zoom; // e.g. '0.85' or null to disable
+    } catch (e) {
+        res.locals.desktopZoom = null;
+    }
+    next();
+});
+
 
 
 // Route logging middleware - tracks user navigation patterns for analytics
@@ -455,27 +475,6 @@ app.use('/admin/onboarding', onboardingAdminRoutes);
 
 
 //app.use('/auditing-utilities', auditingUtilitiesRoutes);
-app.use((req, res, next) => {
-    res.locals.APP_VERSION = process.env.APP_VERSION || 'stable';
-    res.locals.SERVER_PORT = process.env.SERVER_PORT;
-    next();
-});
-
-// Load DESKTOP_ZOOM from m_location_config (setting_name='DESKTOP_ZOOM', location_code='*' or per-location)
-// Remove this middleware once zoom is finalized and baked into style.css
-const { getLocationConfigValue } = require('./utils/location-config');
-app.use(async (req, res, next) => {
-    try {
-        const locationCode = (req.user && req.user.location_code) ? req.user.location_code : '*';
-        const zoom = await getLocationConfigValue(locationCode, 'DESKTOP_ZOOM', null);
-        res.locals.desktopZoom = zoom; // e.g. '0.85' or null to disable
-    } catch (e) {
-        res.locals.desktopZoom = null;
-    }
-    next();
-});
-
-
 
 
 


### PR DESCRIPTION
## Summary
- `DESKTOP_ZOOM` and `APP_VERSION`/`SERVER_PORT` res.locals middleware were registered in app.js after ~25 routers were already mounted (vehicles, products, credit-master, bills, tank-master, bank-master, gl, day-bill, employees, bowser, onboarding, etc.).
- Express dispatches in registration order, so any request handled by one of those earlier routers never reached this middleware — `res.locals.desktopZoom` and `res.locals.APP_VERSION` stayed unset, meaning DESKTOP_ZOOM silently didn't apply on those pages (reported: works on Masters > Users, not on Masters > Customers) and the CANARY badge was missing too.
- Moved both blocks to sit right after the existing `addDebugLogging` middleware, which already correctly runs before all router mounts. No logic changes, pure ordering fix.

## Test plan
- [ ] On dev beta as GAC2 at ~1536px: Masters > Customers (credit-master) now zooms same as Masters > Users
- [ ] Spot check a few other previously-unaffected routes (vehicles, products, bills, day-bill)
- [ ] CANARY badge shows on all pages, not just the ones after the old middleware position