### PR TITLE
Shift-closing responsive layout fixes for GAC2 (DESKTOP_ZOOM)

### DIFF
--- a/app.js
+++ b/app.js
@@ -382,6 +382,26 @@ const addUserLocationInfo = async (req, res, next) => {
 app.use(addUserLocationInfo);
 app.use(addDebugLogging);
 
+app.use((req, res, next) => {
+    res.locals.APP_VERSION = process.env.APP_VERSION || 'stable';
+    res.locals.SERVER_PORT = process.env.SERVER_PORT;
+    next();
+});
+
+// Load DESKTOP_ZOOM from m_location_config (setting_name='DESKTOP_ZOOM', location_code='*' or per-location)
+// Remove this middleware once zoom is finalized and baked into style.css
+const { getLocationConfigValue } = require('./utils/location-config');
+app.use(async (req, res, next) => {
+    try {
+        const locationCode = (req.user && req.user.location_code) ? req.user.location_code : '*';
+        const zoom = await getLocationConfigValue(locationCode, 'DESKTOP_ZOOM', null);
+        res.locals.desktopZoom = zoom; // e.g. '0.85' or null to disable
+    } catch (e) {
+        res.locals.desktopZoom = null;
+    }
+    next();
+});
+
 
 
 // Route logging middleware - tracks user navigation patterns for analytics
@@ -455,27 +475,6 @@ app.use('/admin/onboarding', onboardingAdminRoutes);
 
 
 //app.use('/auditing-utilities', auditingUtilitiesRoutes);
-app.use((req, res, next) => {
-    res.locals.APP_VERSION = process.env.APP_VERSION || 'stable';
-    res.locals.SERVER_PORT = process.env.SERVER_PORT;
-    next();
-});
-
-// Load DESKTOP_ZOOM from m_location_config (setting_name='DESKTOP_ZOOM', location_code='*' or per-location)
-// Remove this middleware once zoom is finalized and baked into style.css
-const { getLocationConfigValue } = require('./utils/location-config');
-app.use(async (req, res, next) => {
-    try {
-        const locationCode = (req.user && req.user.location_code) ? req.user.location_code : '*';
-        const zoom = await getLocationConfigValue(locationCode, 'DESKTOP_ZOOM', null);
-        res.locals.desktopZoom = zoom; // e.g. '0.85' or null to disable
-    } catch (e) {
-        res.locals.desktopZoom = null;
-    }
-    next();
-});
-
-
 
 
 

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -1293,9 +1293,9 @@ body {
   width: 260px;
   background: linear-gradient(180deg, #343a40 0%, #212529 100%);
   position: fixed;
-  height: 100vh;
-  left: 0;
   top: 0;
+  bottom: 0;
+  left: 0;
   z-index: 1000;
   overflow-y: auto;
   transition: all 0.3s ease;

--- a/views/edit-draft-closing.pug
+++ b/views/edit-draft-closing.pug
@@ -385,6 +385,8 @@ block content
                         #credit-table .col-qty       { width: 6%; }
                         #credit-table .col-sale      { width: 10%; } /* extra space for sale */
                         #credit-table .col-notes     { width: 10%; }
+                        #credit-table .col-off-meter { width: 5%; text-align: center; }
+                        #credit-table .col-delete    { width: 3%; text-align: center; }
                     div
                         div.col-16
                             div.table-responsive
@@ -392,21 +394,21 @@ block content
                                     tbody.w-100
                                         thead(class="thead-light")
                                             tr
-                                                th(scope="col") Bill Date
-                                                th(scope="col") Product
-                                                th(scope="col") Bill #                                                
-                                                th(scope="col") Company
-                                                th(scope="col") Vehicle Number
-                                                th(scope="col") Odometer
-                                                th(scope="col") Price
-                                                th(scope="col") Price Discount
-                                                th(scope="col") Quantity
-                                                th(scope="col") Sale
-                                                th(scope="col") Notes
+                                                th.col-date(scope="col") Bill Date
+                                                th.col-product(scope="col") Product
+                                                th.col-bill(scope="col") Bill #
+                                                th.col-company(scope="col") Company
+                                                th.col-vehicle(scope="col") Vehicle Number
+                                                th.col-odo(scope="col") Odometer
+                                                th.col-price(scope="col") Price
+                                                th.col-discount(scope="col") Price Discount
+                                                th.col-qty(scope="col") Quantity
+                                                th.col-sale(scope="col") Sale
+                                                th.col-notes(scope="col") Notes
                                                 if allowOffMeterSale
-                                                    th(scope="col") Off Meter
+                                                    th.col-off-meter(scope="col") Off Meter
                                                 if(!freezedRecord)
-                                                    th(scope="col")
+                                                    th.col-delete(scope="col")
                                             - var rowCnt = 0
                                             while rowCnt < maxCreditsRowCnt
                                                 +addCredits(rowCnt, t_credits[rowCnt++])

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -31,7 +31,7 @@ html
     
     if desktopZoom
       style.
-        @media (max-width: 1600px) { .content-wrapper { zoom: #{desktopZoom}; } }
+        @media (max-width: 1600px) { body { zoom: #{desktopZoom}; } }
 
     style.
       @media print {

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -31,7 +31,7 @@ html
     
     if desktopZoom
       style.
-        @media (max-width: 1600px) { body { zoom: #{desktopZoom}; } }
+        @media (max-width: 1600px) { .content-wrapper { zoom: #{desktopZoom}; } }
 
     style.
       @media print {

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -31,7 +31,7 @@ html
     
     if desktopZoom
       style.
-        @media (max-width: 1440px) { body { zoom: #{desktopZoom}; } }
+        @media (max-width: 1600px) { body { zoom: #{desktopZoom}; } }
 
     style.
       @media print {


### PR DESCRIPTION
## Summary
- Enabled and fixed the existing DESKTOP_ZOOM location-config mechanism to relieve the cramped shift-closing credit tab on laptop-sized screens for GAC2:
  - Raised the zoom breakpoint from 1440px to 1600px to cover common 1920x1080 laptop panels at 125% Windows scaling.
  - Fixed dead column-width CSS on edit-draft-closing.pug's credit table (missing col-* classes on `<th>`), so Bill #/Sale columns size correctly instead of being auto-sized by the browser.
  - Fixed `.sidebar` (position:fixed + height:100vh) so it doesn't get cut off under body-level zoom — switched to top:0/bottom:0.
  - Moved the DESKTOP_ZOOM/APP_VERSION middleware earlier in app.js, before ~25 routers that were previously mounted ahead of it (credit-master/Customers, vehicles, products, bills, etc.) and therefore never received the zoom setting or CANARY badge.
- A separate SQL migration (`db/migrations/desktop-zoom-gac2.sql`) was already run directly against prod to set `DESKTOP_ZOOM='0.85'` for GAC2 only — no other location is affected by the zoom value itself.

## Test plan
- [x] Verified incrementally on dev beta across 4 rounds of fixes (breakpoint, column CSS, sidebar height, middleware order)
- [ ] Final check on prod: GAC2 credit tab at ~1536px width, sidebar not cut off, Masters > Customers zooms same as Users