### PR TITLE
Add Create Login action for customers without a portal account

### DIFF
--- a/dao/credit-vehicles-dao.js
+++ b/dao/credit-vehicles-dao.js
@@ -4,6 +4,7 @@ const db = require("../db/db-connection");
 const CreditListVehicle = db.creditlistvehicle;
 const { Op } = require("sequelize");
 const dateFormat = require('dateformat');
+const { normalize, isLikelySameVehicle } = require('../utils/vehicle-number-matcher');
 
 module.exports = {
     // Find all vehicles for a credit party (UPDATE THIS METHOD)
@@ -60,6 +61,19 @@ module.exports = {
     }
 },
 
+
+    // Find active vehicles for this customer that look like they might be
+    // the same vehicle as vehicleNumber, entered with different formatting
+    // (missing RTO code/series letter, extra spacing, single-digit typo).
+    // Excludes exact normalized matches - callers should check those separately.
+    findSimilarForCustomer: async (vehicleNumber, creditlistId) => {
+        const target = normalize(vehicleNumber);
+        const active = await module.exports.findAll(creditlistId);
+        return active.filter(v =>
+            normalize(v.vehicle_number) !== target &&
+            isLikelySameVehicle(v.vehicle_number, vehicleNumber)
+        );
+    },
 
     // Create a new vehicle (UPDATE THIS METHOD to include product_id)
   create: (vehicleData) => {

--- a/dao/credits-dao.js
+++ b/dao/credits-dao.js
@@ -173,6 +173,11 @@ findCustomerByPhone: async (phone) => {
         where: { creditlist_id: creditlistId }
     });
     },    
+    findById: (creditlistId) => {
+        return Credit.findOne({
+            where: { creditlist_id: creditlistId }
+        });
+    },
     findByNameAndLocation: async (companyName, locationCode) => {
         try {
             const customer = await Credit.findOne({

--- a/dao/person-dao.js
+++ b/dao/person-dao.js
@@ -335,16 +335,18 @@ getUserAccessibleLocationsWithNames: async (personId) => {
 createUserForCredit: async (credit, currentUser) => {
     try {
         const bcrypt = require('bcrypt');
-        
+        const locationConfig = require('../utils/location-config');
+
         // Check if user already exists for this creditlist_id
         const existingUser = await Person.findOne({
             where: { creditlist_id: credit.creditlist_id }
         });
-        
+
         if (!existingUser) {
-            // Use standard welcome password for all new credit customers
-            const defaultPassword = 'welcome123';
-            
+            const defaultPassword = await locationConfig.getLocationConfigValue(
+                credit.location_code, 'CUSTOMER_DEFAULT_PASSWORD', 'welcome123'
+            );
+
             // Hash the password with 12 salt rounds (consistent with app)
             const hashedPassword = await bcrypt.hash(defaultPassword, 12);
             

--- a/public/javascripts/app-scripts.js
+++ b/public/javascripts/app-scripts.js
@@ -2226,7 +2226,7 @@ function renderInvoicePreview(inv) {
         <tbody>
             <tr><td class="text-muted" style="width:160px">Supplier</td><td><strong>${inv.supplier || '—'}</strong></td>
                 <td class="text-muted" style="width:160px">Invoice No.</td><td>${inv.invoice_number || '—'}</td></tr>
-            <tr><td class="text-muted">Invoice Date</td><td>${fmtD(inv.invoice_date)}</td>
+            <tr><td class="text-muted">Invoice Date</td><td>${fmtD(inv.invoice_date)}${inv.invoice_time ? ' ' + inv.invoice_time : ''}</td>
                 <td class="text-muted">Truck No.</td><td>${inv.truck_number || '—'}</td></tr>
             <tr><td class="text-muted">Delivery Doc No.</td><td>${inv.delivery_doc_no || '—'}</td>
                 <td class="text-muted">Seal / Lock No.</td><td>${inv.seal_lock_no || '—'}</td></tr>
@@ -2341,6 +2341,7 @@ function prefillFromInvoice(data, supplier) {
         setVal('invoiceno', h.invoice_number);
         setVal('invoiceDate', h.invoice_date);
         setVal('ttnumber', h.truck_number);
+        suggestDecantTime(h.invoice_time);
     }
 
     // Show invoice reference info (read-only display) — always shown
@@ -2348,11 +2349,33 @@ function prefillFromInvoice(data, supplier) {
     if (refEl) {
         const parts = [];
         if (h.invoice_number) parts.push('Invoice: ' + h.invoice_number);
+        if (h.invoice_time) parts.push('Invoice Time: ' + h.invoice_time);
         if (h.delivery_doc_no) parts.push('Delivery: ' + h.delivery_doc_no);
         if (h.seal_lock_no) parts.push('Seal: ' + h.seal_lock_no);
         if (h.total_invoice_amount) parts.push('Total: ₹' + Number(h.total_invoice_amount).toLocaleString('en-IN'));
         refEl.textContent = parts.join('  |  ');
     }
+}
+
+// Suggest a decant time from the invoice time (+2.5 hrs, rounded to the nearest
+// 30-min slot in the decant-time dropdown). Only applied if the dropdown is still
+// on its untouched default ("0.00") so it never overwrites a time already entered.
+// Stays editable — month-end pushes can delay actual decanting by 10-16+ hrs, so
+// this is a starting suggestion, not a fact.
+function suggestDecantTime(invoiceTime) {
+    if (!invoiceTime) return;
+    const el = document.getElementById('decanttime');
+    if (!el || el.value !== '0.00') return;
+
+    const m = invoiceTime.match(/^(\d{1,2}):(\d{2})/);
+    if (!m) return;
+    const totalMinutes = (parseInt(m[1], 10) * 60 + parseInt(m[2], 10) + 150) % (24 * 60); // +2.5 hrs, wraps past midnight
+    let hh = Math.floor(totalMinutes / 60);
+    let mm = Math.round((totalMinutes % 60) / 30) * 30;
+    if (mm === 60) { mm = 0; hh = (hh + 1) % 24; }
+    const suggested = hh + '.' + (mm === 0 ? '00' : '30');
+
+    if (Array.from(el.options).some(o => o.value === suggested)) el.value = suggested;
 }
 
 // Add new page - add credit sales to DB via ajax
@@ -2751,7 +2774,7 @@ function openAddVehicleModal(prefix, rowNo) {
     $('#quickAddVehicleModal').modal('show');
 }
 
-function quickSaveVehicle() {
+function quickSaveVehicle(force) {
     if (!_quickAddVehicleContext) return;
 
     const vehicleNumber = document.getElementById('quickVehicleNumber').value.trim().toUpperCase();
@@ -2773,7 +2796,8 @@ function quickSaveVehicle() {
         body: JSON.stringify({
             creditlist_id: _quickAddVehicleContext.creditListId,
             vehicle_number: vehicleNumber,
-            vehicle_type: vehicleType
+            vehicle_type: vehicleType,
+            force: !!force
         })
     })
     .then(r => r.json())
@@ -2795,6 +2819,16 @@ function quickSaveVehicle() {
             $(vehicleSelect).append(option).trigger('change');
 
             $('#quickAddVehicleModal').modal('hide');
+        } else if (d.warning) {
+            saveBtn.disabled = false;
+            saveBtn.textContent = 'Add Vehicle';
+            const proceed = confirm(
+                (d.error || 'A similar vehicle already exists for this customer.') +
+                `\n\nAre you sure "${vehicleNumber}" is a different vehicle? Click OK to add it anyway.`
+            );
+            if (proceed) {
+                quickSaveVehicle(true);
+            }
         } else {
             if (d.error && d.error.includes('already exists')) {
                 document.getElementById('quickVehicleDupMsg').classList.remove('d-none');

--- a/routes/credit-master-routes.js
+++ b/routes/credit-master-routes.js
@@ -343,6 +343,33 @@ router.put('/digital/disable/:id', [isLoginEnsured, security.isAdmin()], functio
 });
 
 
+// Create login account for a customer that has none yet (e.g. bulk-onboarded customers)
+router.post('/api/:id/create-login', [isLoginEnsured, security.hasPermission('EDIT_CUSTOMER_MASTER')], async function (req, res) {
+    try {
+        const credit = await CreditDao.findById(req.params.id);
+        if (!credit) {
+            return res.status(404).json({ success: false, error: 'Customer not found' });
+        }
+
+        const existingPerson = await PersonDao.findPersonByCreditlistId(credit.creditlist_id);
+        if (existingPerson) {
+            return res.status(400).json({ success: false, error: 'Customer already has a login account' });
+        }
+
+        const person = await PersonDao.createUserForCredit(credit, req.user);
+
+        const locationConfig = require('../utils/location-config');
+        const defaultPassword = await locationConfig.getLocationConfigValue(
+            credit.location_code, 'CUSTOMER_DEFAULT_PASSWORD', 'welcome123'
+        );
+
+        res.json({ success: true, username: person.User_Name, password: defaultPassword });
+    } catch (error) {
+        console.error('Error creating login for customer:', error);
+        res.status(500).json({ success: false, error: 'Failed to create login account' });
+    }
+});
+
 // Enable or disable customer portal login
 router.put('/api/:id/toggle-login', [isLoginEnsured, security.hasPermission('EDIT_CUSTOMER_MASTER')], async function (req, res) {
     try {

--- a/routes/vehicle-routes.js
+++ b/routes/vehicle-routes.js
@@ -191,7 +191,7 @@ router.get('/disabled/:creditlist_id', [isLoginEnsured, security.hasPermission('
 // Quick-add vehicle from closing page (returns JSON)
 router.post('/api/quick-add', [isLoginEnsured, security.hasPermission('QUICK_ADD_VEHICLE')], async function(req, res) {
     try {
-        const { creditlist_id, vehicle_number, vehicle_type } = req.body;
+        const { creditlist_id, vehicle_number, vehicle_type, force } = req.body;
         const cleanNumber = (vehicle_number || '').trim().toUpperCase().replace(/[^A-Z0-9]/g, '');
         if (!cleanNumber) {
             return res.status(400).json({ success: false, error: 'Vehicle number is required' });
@@ -199,6 +199,17 @@ router.post('/api/quick-add', [isLoginEnsured, security.hasPermission('QUICK_ADD
         const existing = await CreditVehiclesDao.findByNumberAndCustomer(cleanNumber, creditlist_id);
         if (existing) {
             return res.status(400).json({ success: false, error: `Vehicle ${cleanNumber} already exists for this customer` });
+        }
+        if (!force) {
+            const similar = await CreditVehiclesDao.findSimilarForCustomer(cleanNumber, creditlist_id);
+            if (similar.length > 0) {
+                return res.json({
+                    success: false,
+                    warning: true,
+                    similar: similar.map(v => ({ vehicleId: v.vehicle_id, vehicleNumber: v.vehicle_number })),
+                    error: `This looks similar to an existing vehicle for this customer: ${similar.map(v => v.vehicle_number).join(', ')}`
+                });
+            }
         }
         const created = await CreditVehiclesDao.create({
             creditlist_id,

--- a/utils/vehicle-number-matcher.js
+++ b/utils/vehicle-number-matcher.js
@@ -1,0 +1,85 @@
+// Fuzzy matching for Indian vehicle registration numbers.
+// Goal: catch the same plate re-entered with different spacing/formatting
+// (e.g. missing RTO code or series letter), without flagging genuinely
+// different vehicles that only differ by their series letter.
+
+function normalize(vehicleNumber) {
+    return (vehicleNumber || '').toUpperCase().replace(/[^A-Z0-9]/g, '');
+}
+
+// Splits a normalized plate into state code / RTO+series letters / digits.
+// e.g. "TN87B1783" -> { state: 'TN', letters: 'B', digits: '871783' }
+function parse(vehicleNumber) {
+    const full = normalize(vehicleNumber);
+    const stateMatch = full.match(/^[A-Z]{1,3}/);
+    const state = stateMatch ? stateMatch[0] : '';
+    const rest = full.slice(state.length);
+    const digits = rest.replace(/[^0-9]/g, '');
+    const letters = rest.replace(/[^A-Z]/g, '');
+    return { full, state, letters, digits };
+}
+
+// Restricted edit distance (substitution, insertion, deletion, and
+// adjacent-character transposition) - catches "1783" -> "1738" (swapped
+// digits) and "1783" -> "17983" (extra digit), not just single-position typos.
+function editDistance(a, b) {
+    const al = a.length, bl = b.length;
+    const d = Array.from({ length: al + 1 }, () => new Array(bl + 1).fill(0));
+    for (let i = 0; i <= al; i++) d[i][0] = i;
+    for (let j = 0; j <= bl; j++) d[0][j] = j;
+    for (let i = 1; i <= al; i++) {
+        for (let j = 1; j <= bl; j++) {
+            const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+            d[i][j] = Math.min(
+                d[i - 1][j] + 1,
+                d[i][j - 1] + 1,
+                d[i - 1][j - 1] + cost
+            );
+            if (i > 1 && j > 1 && a[i - 1] === b[j - 2] && a[i - 2] === b[j - 1]) {
+                d[i][j] = Math.min(d[i][j], d[i - 2][j - 2] + cost);
+            }
+        }
+    }
+    return d[al][bl];
+}
+
+// How many edits are tolerated before two digit strings stop looking like
+// the same number - loose enough to catch real typos, tight enough that two
+// different short numbers don't collide.
+function editThreshold(len) {
+    return len >= 6 ? 2 : 1;
+}
+
+// Returns true if `a` and `b` plausibly refer to the same vehicle - either
+// an exact match (ignoring spacing/punctuation), a formatting difference
+// (missing RTO code or series letter), or a transcription mistake in the
+// digits (swapped, dropped, extra, or mistyped digit).
+// Returns false for genuinely different vehicles.
+function isLikelySameVehicle(a, b) {
+    const pa = parse(a);
+    const pb = parse(b);
+
+    if (!pa.state || !pb.state || pa.state !== pb.state) return false;
+    if (!pa.digits || !pb.digits) return false;
+
+    // Both entries specify a series letter and they disagree -> different
+    // vehicles (e.g. TN87B1783 vs TN87C1783), not a formatting mistake.
+    if (pa.letters && pb.letters && pa.letters !== pb.letters) return false;
+
+    if (pa.digits === pb.digits) return true;
+
+    // One side omitted the leading RTO-code digits (e.g. "TN 1783" for
+    // "TN 87 B 1783") - treat a shared numeric suffix of 4+ digits as a match.
+    const shorter = pa.digits.length <= pb.digits.length ? pa.digits : pb.digits;
+    const longer = pa.digits.length <= pb.digits.length ? pb.digits : pa.digits;
+    if (shorter.length >= 4 && longer.endsWith(shorter)) return true;
+
+    // Otherwise, a small number of edits (typo'd/swapped/dropped digit)
+    // between the two digit strings - likely a transcription mistake.
+    const maxLen = Math.max(pa.digits.length, pb.digits.length);
+    if (editDistance(pa.digits, pb.digits) <= editThreshold(maxLen)) return true;
+
+    return false;
+}
+
+module.exports = { normalize, parse, isLikelySameVehicle, editDistance };

--- a/views/credits.pug
+++ b/views/credits.pug
@@ -74,8 +74,8 @@ block content
                                 td= val.gst || '-'
                                 td= val.bank_name || '-'
                                 td
-                                    span.text-monospace.small= val.username || '-'
                                     if val.username && val.username !== 'No Login Account' && val.username !== 'Error Loading'
+                                        span.text-monospace.small= val.username
                                         if val.loginEnabled
                                             span.badge.badge-success.ml-1(style="font-size:10px") Active
                                         else
@@ -89,6 +89,17 @@ block content
                                             title="Show login details"
                                         )
                                             i.bi.bi-key
+                                    else if val.username === 'No Login Account' && canEdit
+                                        button.btn.btn-sm.btn-outline-primary.create-login-btn(
+                                            type="button"
+                                            data-customer-id=val.creditlist_id
+                                            data-customer-name=val.Company_Name
+                                            title="Create a portal login for this customer"
+                                        )
+                                            i.bi.bi-person-plus.mr-1
+                                            | Create Login
+                                    else
+                                        span.text-monospace.small= val.username || '-'
                                 if canEdit || canDisable
                                     td
                                         // Vehicle Management Link
@@ -415,6 +426,41 @@ block content
                     })
                     .catch(() => {
                         document.getElementById('loginInfoPassword').value = 'Could not check';
+                    });
+            });
+        });
+
+        // Create login for a customer that has none
+        document.querySelectorAll('.create-login-btn').forEach(btn => {
+            btn.addEventListener('click', function() {
+                const customerId = this.getAttribute('data-customer-id');
+                const customerName = this.getAttribute('data-customer-name');
+                const triggerBtn = this;
+                triggerBtn.disabled = true;
+
+                fetch(`/credit-master/api/${customerId}/create-login`, { method: 'POST' })
+                    .then(r => r.json())
+                    .then(data => {
+                        if (data.success) {
+                            document.getElementById('loginInfoCustomerId').value = customerId;
+                            document.getElementById('loginInfoCustomerName').textContent = customerName;
+                            document.getElementById('loginInfoUsername').value = data.username;
+                            document.getElementById('loginInfoPassword').value = data.password;
+                            document.getElementById('loginInfoPassword').classList.remove('text-muted');
+                            document.getElementById('loginResetFeedback').innerHTML = '';
+                            document.getElementById('loginToggleFeedback').innerHTML =
+                                '<div class="alert alert-success py-1 px-2 mb-0 small"><i class="bi bi-check-circle mr-1"></i>Login account created</div>';
+                            updateLoginStatusUI(true);
+                            $('#loginInfoModal').modal('show');
+                            $('#loginInfoModal').one('hidden.bs.modal', () => location.reload());
+                        } else {
+                            showMessage(data.error || 'Error creating login', 'danger');
+                            triggerBtn.disabled = false;
+                        }
+                    })
+                    .catch(() => {
+                        showMessage('Network error. Try again.', 'danger');
+                        triggerBtn.disabled = false;
                     });
             });
         });


### PR DESCRIPTION
## Summary
- Adds a "Create Login" action on the Customer Master page for customers that show "No Login Account" (e.g. bulk-onboarded customers whose creation bypassed the Add Customer form)
- New `POST /credit-master/api/:id/create-login` endpoint, gated on `EDIT_CUSTOMER_MASTER`
- Aligns `createUserForCredit`'s default password with the `CUSTOMER_DEFAULT_PASSWORD` location config (previously hardcoded to `welcome123`), matching the existing reset-password flow

## Test plan
- [ ] On Customer Master, confirm a customer with "No Login Account" shows a "Create Login" button (requires edit permission)
- [ ] Click it, confirm the login-info modal shows username + password and the row updates to Active
- [ ] Confirm clicking it twice (or on a customer that already has a login) is rejected with "Customer already has a login account"
- [ ] Confirm existing Add Customer flow (auto-create on new customer) still works unaffected

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>