### PR TITLE
Vehicle quick-add: duplicate warning + fix null vehicle type label

### DIFF
--- a/public/javascripts/app-scripts.js
+++ b/public/javascripts/app-scripts.js
@@ -2735,10 +2735,8 @@ function updateCreditAndLoadVehicles(obj, creditRowPrefix, rowNo) {
     if (creditListId && vehicleDataByCredit[creditListId]) {
         // Populate with vehicles for this credit party
         vehicleDataByCredit[creditListId].forEach(vehicle => {
-            const option = new Option(
-                `${vehicle.vehicleNumber} (${vehicle.vehicleType})`, 
-                vehicle.vehicleId
-            );
+            const label = vehicle.vehicleType ? `${vehicle.vehicleNumber} (${vehicle.vehicleType})` : vehicle.vehicleNumber;
+            const option = new Option(label, vehicle.vehicleId);
             $(vehicleSelect).append(option);
         });
     }
@@ -2929,10 +2927,8 @@ function loadVehiclesDynamically(creditListId, vehicleSelectId) {
             
             if (response.success && response.vehicles) {
                 response.vehicles.forEach(vehicle => {
-                    vehicleSelect.append(new Option(
-                        `${vehicle.vehicleNumber} (${vehicle.vehicleType})`,
-                        vehicle.vehicleId
-                    ));
+                    const label = vehicle.vehicleType ? `${vehicle.vehicleNumber} (${vehicle.vehicleType})` : vehicle.vehicleNumber;
+                    vehicleSelect.append(new Option(label, vehicle.vehicleId));
                 });
             }
             


### PR DESCRIPTION
## Summary
- Warn (with override) on likely-duplicate vehicle numbers in the quick-add flow, instead of silently allowing duplicates
- Fix credit-tab vehicle dropdown showing literal "(null)" when vehicle_type is empty