### PR TITLE
Vehicle quick-add: warn on similar vehicle across other customers

### DIFF
--- a/dao/credit-vehicles-dao.js
+++ b/dao/credit-vehicles-dao.js
@@ -146,6 +146,19 @@ module.exports = {
         });
     },
 
+    // Find active vehicles anywhere else at this location (any other customer)
+    // that look like they might be the same vehicle as vehicleNumber - either
+    // an exact match or a formatting/typo variant. Used to warn when a plate
+    // is being quick-added under what might be the wrong customer.
+    findSimilarAcrossLocation: async (vehicleNumber, locationCode, excludeCreditlistId) => {
+        const target = normalize(vehicleNumber);
+        const all = await module.exports.findAllVehiclesForLocation(locationCode);
+        return all.filter(v =>
+            String(v.creditlist_id) !== String(excludeCreditlistId) &&
+            (normalize(v.vehicle_number) === target || isLikelySameVehicle(v.vehicle_number, vehicleNumber))
+        );
+    },
+
     findAllVehiclesForLocation: (locationCode) => {
     return db.sequelize.query(
         `SELECT 

--- a/routes/vehicle-routes.js
+++ b/routes/vehicle-routes.js
@@ -202,12 +202,22 @@ router.post('/api/quick-add', [isLoginEnsured, security.hasPermission('QUICK_ADD
         }
         if (!force) {
             const similar = await CreditVehiclesDao.findSimilarForCustomer(cleanNumber, creditlist_id);
-            if (similar.length > 0) {
+            const similarElsewhere = await CreditVehiclesDao.findSimilarAcrossLocation(cleanNumber, req.user.location_code, creditlist_id);
+
+            if (similar.length > 0 || similarElsewhere.length > 0) {
+                const messages = [];
+                if (similar.length > 0) {
+                    messages.push(`This looks similar to an existing vehicle for this customer: ${similar.map(v => v.vehicle_number).join(', ')}`);
+                }
+                if (similarElsewhere.length > 0) {
+                    const elsewhereList = similarElsewhere.map(v => `${v.vehicle_number} (${v.company_name})`).join(', ');
+                    messages.push(`This vehicle is already registered under another customer: ${elsewhereList}`);
+                }
                 return res.json({
                     success: false,
                     warning: true,
-                    similar: similar.map(v => ({ vehicleId: v.vehicle_id, vehicleNumber: v.vehicle_number })),
-                    error: `This looks similar to an existing vehicle for this customer: ${similar.map(v => v.vehicle_number).join(', ')}`
+                    similar: [...similar, ...similarElsewhere].map(v => ({ vehicleId: v.vehicle_id, vehicleNumber: v.vehicle_number })),
+                    error: messages.join('\n')
                 });
             }
         }


### PR DESCRIPTION
## Summary
- Quick-add duplicate check now also scans other customers at the same location, not just the current customer
- Still a soft, overridable warning (confirm dialog), not a hard block