### PR TITLE
Hotfix: remove premature platform-billing model registration

### DIFF
--- a/db/db-connection.js
+++ b/db/db-connection.js
@@ -83,11 +83,6 @@ db.day_bill = require("./day-bill")(sequelize, Sequelize);
 db.day_bill_header = require("./day-bill-header")(sequelize, Sequelize);
 db.day_bill_items = require("./day-bill-items")(sequelize, Sequelize);
 
-db.location_billing_plan = require("./location-billing-plan")(sequelize, Sequelize);
-db.platform_invoice = require("./platform-invoice")(sequelize, Sequelize);
-db.platform_invoice_items = require("./platform-invoice-items")(sequelize, Sequelize);
-db.platform_payment = require("./platform-payment")(sequelize, Sequelize);
-db.platform_payment_allocation = require("./platform-payment-allocation")(sequelize, Sequelize);
 db.document_store = require("./document-store")(sequelize, Sequelize);
 db.employee = require("./employee")(sequelize, Sequelize);
 db.employee_salary = require("./employee-salary")(sequelize, Sequelize);
@@ -319,14 +314,6 @@ db.day_bill_header.hasMany(db.day_bill_items, {foreignKey: 'header_id', as: 'ite
 db.day_bill_items.belongsTo(db.day_bill_header, {foreignKey: 'header_id'});
 db.day_bill_header.belongsTo(db.credit, {foreignKey: 'vendor_id', targetKey: 'creditlist_id', as: 'vendor'});
 db.day_bill_items.belongsTo(db.product, {foreignKey: 'product_id', targetKey: 'product_id'});
-
-// Platform billing relations
-db.platform_invoice.hasMany(db.platform_invoice_items, {foreignKey: 'invoice_id', as: 'items'});
-db.platform_invoice_items.belongsTo(db.platform_invoice, {foreignKey: 'invoice_id'});
-db.platform_invoice.hasMany(db.platform_payment_allocation, {foreignKey: 'invoice_id', as: 'allocations'});
-db.platform_payment_allocation.belongsTo(db.platform_invoice, {foreignKey: 'invoice_id'});
-db.platform_payment.hasMany(db.platform_payment_allocation, {foreignKey: 'payment_id', as: 'allocations'});
-db.platform_payment_allocation.belongsTo(db.platform_payment, {foreignKey: 'payment_id'});
 
 // Tank invoice relations
 db.tank_invoice.hasMany(db.tank_invoice_dtl, {foreignKey: 'invoice_id', as: 'lines'});


### PR DESCRIPTION
## Summary
- Beta is down: PR #750 accidentally committed pre-existing uncommitted lines in \`db/db-connection.js\` that register platform-billing Sequelize models whose source files were never committed. \`git pull\` on beta left it referencing missing modules -> \`MODULE_NOT_FOUND\` on boot, PM2 stuck in a restart loop.
- Removes those \`require()\` calls and their association block. The actual platform-billing files are untouched locally and can be committed properly once that feature is ready.

## Test plan
- [ ] Merge, confirm beta deploy workflow runs
- [ ] \`pm2 list\` on beta shows \`petromath-beta\` as \`online\`, not restarting
- [ ] \`/location-config\` loads with the Setting Catalog section working

🤖 Generated with [Claude Code](https://claude.com/claude-code)