### PR TITLE
Add Type and Fuel Category filters to Purchase Invoice search

### DIFF
--- a/controllers/lubes-invoice-controller.js
+++ b/controllers/lubes-invoice-controller.js
@@ -19,12 +19,14 @@ const tempLubeInvoiceStore = new Map();
 module.exports = {
     getLubesInvoiceHome: (req, res, next) => {
         gatherLubesInvoices(
-            req.query.invoice_fromDate, 
+            req.query.invoice_fromDate,
             req.query.invoice_toDate,
-            req.query.supplier_id, 
-            req.user, 
-            res, 
-            next, 
+            req.query.supplier_id,
+            req.query.invoice_type,
+            req.query.fuel_category,
+            req.user,
+            res,
+            next,
             {}
         );
     },
@@ -525,25 +527,33 @@ function getLubesInvoiceDetailsPromise(invoiceDetails, req, res, next) {
     });
 }
 
-function gatherLubesInvoices(fromDate, toDate, supplierId, user, res, next, messagesOptional) {
+function gatherLubesInvoices(fromDate, toDate, supplierId, invoiceType, fuelCategory, user, res, next, messagesOptional) {
     // If no dates provided, use financial year dates
     if(fromDate === undefined || toDate === undefined) {
         const financialYearDates = getFinancialYearDates();
         fromDate = financialYearDates.fromDate;
         toDate = financialYearDates.toDate;
     }
-    
+
     const { Op } = require('sequelize');
     const TankInvoice = db.tank_invoice;
     const TankInvoiceDtl = db.tank_invoice_dtl;
 
+    // A fuel category filter only applies to fuel invoices
     const suppliersPromise = lubesInvoiceDao.getSuppliers(user.location_code);
-    const lubesPromise = lubesInvoiceDao.findLubesInvoices(user.location_code, fromDate, toDate, supplierId);
-    const fuelPromise = TankInvoice.findAll({
-        where: { location_id: user.location_code, invoice_date: { [Op.between]: [fromDate, toDate] } },
-        include: [{ model: TankInvoiceDtl, as: 'lines', attributes: ['quantity', 'qty_unit'] }],
-        order: [['invoice_date', 'DESC'], ['id', 'DESC']]
-    });
+    const lubesPromise = (invoiceType === 'FUEL' || fuelCategory)
+        ? Promise.resolve([])
+        : lubesInvoiceDao.findLubesInvoices(user.location_code, fromDate, toDate, supplierId);
+
+    const fuelWhere = { location_id: user.location_code, invoice_date: { [Op.between]: [fromDate, toDate] } };
+    if (fuelCategory) fuelWhere.fuel_category = fuelCategory;
+    const fuelPromise = invoiceType === 'LUBE'
+        ? Promise.resolve([])
+        : TankInvoice.findAll({
+            where: fuelWhere,
+            include: [{ model: TankInvoiceDtl, as: 'lines', attributes: ['quantity', 'qty_unit'] }],
+            order: [['invoice_date', 'DESC'], ['id', 'DESC']]
+        });
 
     Promise.all([suppliersPromise, lubesPromise, fuelPromise])
         .then(([suppliers, lubesInvoices, fuelInvoices]) => {
@@ -582,7 +592,8 @@ function gatherLubesInvoices(fromDate, toDate, supplierId, user, res, next, mess
                         amount: parseFloat(f.total_invoice_amount) || 0,
                         total_lines: (f.lines || []).length,
                         qty_kl: qty > 0 ? qty.toFixed(3) : '',
-                        qty_unit: qty_unit
+                        qty_unit: qty_unit,
+                        fuel_category: f.fuel_category || (qty_unit === 'KG' ? 'CNG' : 'MS_HSD')
                     });
                 });
             }
@@ -595,6 +606,8 @@ function gatherLubesInvoices(fromDate, toDate, supplierId, user, res, next, mess
                 fromDate: fromDate,
                 toDate: toDate,
                 selectedSupplierId: supplierId,
+                selectedType: invoiceType || '',
+                selectedFuelCategory: fuelCategory || '',
                 suppliers: suppliers,
                 invoiceValues: invoiceValues,
                 currentDate: utils.currentDate(),

--- a/controllers/purchases-controller.js
+++ b/controllers/purchases-controller.js
@@ -225,6 +225,8 @@ module.exports = {
             if (!lines.length) return res.status(400).json({ success: false, error: 'At least one product line is required.' });
             if (lines.some(l => !l.product_id)) return res.status(400).json({ success: false, error: 'All lines must have a product selected.' });
 
+            header.fuel_category = lines.some(l => l.qty_unit === 'KG') ? 'CNG' : 'MS_HSD';
+
             const invoice = await TankInvoiceDao.saveInvoice(
                 header, lines, pdfBuffer, locationCode, header.supplier_id, originalFileName
             );

--- a/db/migrations/fuel-invoice-category.sql
+++ b/db/migrations/fuel-invoice-category.sql
@@ -1,0 +1,19 @@
+-- Migration: Add fuel_category column to t_tank_invoice
+-- Distinguishes CNG invoices from regular fuel (MS/HSD) invoices so the
+-- purchase invoice search screen can filter within type=FUEL.
+-- Populated at save time (see purchases-controller.js saveFuelInvoice); backfill
+-- below classifies existing rows from their line items' qty_unit
+-- (CNG is invoiced in KG, MS/HSD in KL).
+
+ALTER TABLE t_tank_invoice
+    ADD COLUMN fuel_category VARCHAR(10) NULL AFTER bay_number;
+
+UPDATE t_tank_invoice ti
+SET fuel_category = CASE
+    WHEN EXISTS (
+        SELECT 1 FROM t_tank_invoice_dtl d
+        WHERE d.invoice_id = ti.id AND d.qty_unit = 'KG'
+    ) THEN 'CNG'
+    ELSE 'MS_HSD'
+END
+WHERE fuel_category IS NULL;

--- a/db/txn-tank-invoice.js
+++ b/db/txn-tank-invoice.js
@@ -32,6 +32,11 @@ module.exports = function(sequelize, DataTypes) {
             type: DataTypes.DATEONLY,
             allowNull: true
         },
+        invoice_time: {
+            field: 'invoice_time',
+            type: DataTypes.TIME,
+            allowNull: true
+        },
         truck_number: {
             field: 'truck_number',
             type: DataTypes.STRING(20),
@@ -50,6 +55,11 @@ module.exports = function(sequelize, DataTypes) {
         bay_number: {
             field: 'bay_number',
             type: DataTypes.STRING(20),
+            allowNull: true
+        },
+        fuel_category: {
+            field: 'fuel_category',
+            type: DataTypes.STRING(10),
             allowNull: true
         },
         total_invoice_amount: {

--- a/views/lubes-invoice-home.pug
+++ b/views/lubes-invoice-home.pug
@@ -174,8 +174,22 @@ block content
                         select#supplier_id.form-control.form-control-sm(name='supplier_id')
                             option(value='') All Suppliers
                             each supplier in suppliers
-                                option(value=supplier.supplier_id, 
+                                option(value=supplier.supplier_id,
                                     selected=selectedSupplierId == supplier.supplier_id)= supplier.supplier_name
+                    td &nbsp;
+                    td Type:
+                    td
+                        select#invoice_type.form-control.form-control-sm(name='invoice_type')
+                            option(value='' selected=selectedType == '') All Types
+                            option(value='FUEL' selected=selectedType == 'FUEL') Fuel
+                            option(value='LUBE' selected=selectedType == 'LUBE') Lube
+                    td &nbsp;
+                    td Fuel Category:
+                    td
+                        select#fuel_category.form-control.form-control-sm(name='fuel_category')
+                            option(value='' selected=selectedFuelCategory == '') All Fuel
+                            option(value='CNG' selected=selectedFuelCategory == 'CNG') CNG
+                            option(value='MS_HSD' selected=selectedFuelCategory == 'MS_HSD') MS / HSD
                     td &nbsp;
                     td
                         button.btn.btn-sm.btn-primary(type='submit') Go
@@ -221,7 +235,7 @@ block content
                             td= val.date
                             td
                                 if val.type === 'FUEL'
-                                    span.badge.badge-warning Fuel
+                                    span.badge.badge-warning= val.fuel_category === 'CNG' ? 'CNG' : 'Fuel (MS/HSD)'
                                 else
                                     span.badge.badge-info Lube
                             td.text-right= val.amount.toLocaleString('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })


### PR DESCRIPTION
## Summary
- Adds a Type filter (Fuel/Lube) to the Purchase Invoice search screen (`/lubes-invoice-home`)
- Adds a Fuel Category filter (CNG vs MS/HSD) since fuel invoices weren't distinguishable by sub-type before — driven by a new `fuel_category` column on `t_tank_invoice`, set at save time in `saveFuelInvoice`
- Migration `db/migrations/fuel-invoice-category.sql` adds the column and backfills existing rows from line `qty_unit` (KG = CNG); already run on dev DB

## Test plan
- [ ] Open Purchase Invoice search screen on beta, confirm Type and Fuel Category dropdowns filter correctly
- [ ] Save a new CNG fuel invoice and a new MS/HSD fuel invoice, confirm each gets classified correctly
- [ ] Spot-check SFS location invoices split as CNG vs MS/HSD as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)