### PR TITLE
Remove failing petromath_dev_new pull from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,12 +16,9 @@ jobs:
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H $(echo ${{ secrets.DEV_SERVER }} | cut -d@ -f2) >> ~/.ssh/known_hosts
 
-      - name: Deploy to Dev + Beta Prod
+      - name: Deploy to Beta Prod
         run: |
           ssh ${{ secrets.DEV_SERVER }} "
-            cd /home/ubuntu/petromath_dev_new &&
-            git pull origin PetroMath_dev_new
-
             cd /home/ubuntu/petromath_prod_beta &&
             git pull origin PetroMath_dev_new
 


### PR DESCRIPTION
## Summary
- `.github/workflows/deploy.yml` no longer pulls into `/home/ubuntu/petromath_dev_new` on the deploy server
- That step has been failing every run (uncommitted local changes to `package.json`/`package-lock.json` on the server blocking the merge), silently, since it wasn't `&&`-chained to the beta pull — beta deploys were unaffected but the logs were noisy/misleading
- Beta pull (`petromath_prod_beta`) + `pm2 restart all` unchanged

## Test plan
- [ ] Merge and confirm the deploy workflow run is clean (no pull error) and beta still updates