### PR TITLE
Set fuel_category on invoices saved via Tank Receipts upload flow

### DIFF
--- a/controllers/tank-receipt-controller.js
+++ b/controllers/tank-receipt-controller.js
@@ -251,6 +251,8 @@ module.exports = {
                 };
             });
 
+            headerData.fuel_category = lineData.some(l => l.qty_unit === 'KG') ? 'CNG' : 'MS_HSD';
+
             const invoice = await TankInvoiceDao.saveInvoice(headerData, lineData, pdfBuffer, locationCode, Number(supplierId), originalFileName);
             return res.json({ success: true, invoiceId: invoice.id, invoiceNumber: invoice.invoice_number });
         } catch (err) {


### PR DESCRIPTION
## Summary
- `saveFuelInvoice` (manual entry / fuel-invoice.pug) already sets `fuel_category` from line `qty_unit`, but `saveInvoiceWithProducts` (`POST /tank-receipts/save-invoice`, used by the New Decant page's upload-and-confirm flow) is a separate save path into the same `t_tank_invoice` table and was missing it.
- Without this, invoices saved via the Tank Receipts upload flow would get `fuel_category=NULL` and silently drop out of both the CNG and MS/HSD filters on the Purchase Invoice search screen, while still showing under the generic Fuel/All Types filter.

## Test plan
- [ ] Upload a fuel invoice PDF via the New Decant / Tank Receipts page, confirm products, save
- [ ] Confirm the saved invoice shows correctly as CNG or MS/HSD under the Purchase Invoice search screen's Fuel Category filter