### PR TITLE
Fix: stale Fuel Category value silently suppressed Lube invoices

### DIFF
--- a/controllers/lubes-invoice-controller.js
+++ b/controllers/lubes-invoice-controller.js
@@ -539,9 +539,13 @@ function gatherLubesInvoices(fromDate, toDate, supplierId, invoiceType, fuelCate
     const TankInvoice = db.tank_invoice;
     const TankInvoiceDtl = db.tank_invoice_dtl;
 
-    // A fuel category filter only applies to fuel invoices
+    // A fuel category filter only applies when Type=Fuel is explicitly selected;
+    // ignore a stray fuel_category param otherwise (e.g. a stale value left over
+    // from a hidden form field) so it can never silently suppress Lube results.
+    fuelCategory = invoiceType === 'FUEL' ? fuelCategory : '';
+
     const suppliersPromise = lubesInvoiceDao.getSuppliers(user.location_code);
-    const lubesPromise = (invoiceType === 'FUEL' || fuelCategory)
+    const lubesPromise = invoiceType === 'FUEL'
         ? Promise.resolve([])
         : lubesInvoiceDao.findLubesInvoices(user.location_code, fromDate, toDate, supplierId);
 

--- a/views/lubes-invoice-home.pug
+++ b/views/lubes-invoice-home.pug
@@ -59,6 +59,7 @@ block content
             document.getElementById('fuelCategorySpacer').style.display = display;
             document.getElementById('fuelCategoryLabel').style.display = display;
             document.getElementById('fuelCategoryField').style.display = display;
+            if (!show) document.getElementById('fuel_category').value = '';
         }
 
         function toggleInvoiceLines(invoiceId, button) {


### PR DESCRIPTION
## Summary
- Bug: on the Purchase Invoice search screen, searching with Type=All and Supplier=All could still return zero Lube invoices, if the user had ever previously selected Type=Fuel + a Fuel Category — the Fuel Category `<select>` was only hidden via CSS, not cleared, so its stale value kept submitting with the form
- Server-side (`gatherLubesInvoices`) treated any non-empty `fuel_category` param as fuel-only, silently dropping all Lube results regardless of the visible Type selection
- Fix: reset the select's value when it's hidden (client-side), and ignore `fuel_category` server-side unless `invoice_type=FUEL` is explicitly selected (defense in depth)

## Test plan
- [ ] On `/lubes-invoice-home`, select Type=Fuel, Fuel Category=CNG, search
- [ ] Switch Type back to "All Types", search again — confirm Lube invoices now appear
- [ ] Location MUE specifically (reported by user) — confirm Lube invoices show under All Types/All Suppliers