### PR TITLE
Only show Fuel Category filter for locations that carry a CNG product

### DIFF
--- a/controllers/lubes-invoice-controller.js
+++ b/controllers/lubes-invoice-controller.js
@@ -538,11 +538,22 @@ function gatherLubesInvoices(fromDate, toDate, supplierId, invoiceType, fuelCate
     const { Op } = require('sequelize');
     const TankInvoice = db.tank_invoice;
     const TankInvoiceDtl = db.tank_invoice_dtl;
+    const Product = db.product;
 
     // A fuel category filter only applies when Type=Fuel is explicitly selected;
     // ignore a stray fuel_category param otherwise (e.g. a stale value left over
     // from a hidden form field) so it can never silently suppress Lube results.
     fuelCategory = invoiceType === 'FUEL' ? fuelCategory : '';
+
+    // Only offer the CNG/MS-HSD filter for locations that actually carry a CNG product
+    const hasCngPromise = Product.findOne({
+        where: {
+            location_code: user.location_code,
+            is_tank_product: 1,
+            product_name: db.Sequelize.where(db.Sequelize.fn('UPPER', db.Sequelize.col('product_name')), 'CNG')
+        },
+        attributes: ['product_id']
+    });
 
     const suppliersPromise = lubesInvoiceDao.getSuppliers(user.location_code);
     const lubesPromise = invoiceType === 'FUEL'
@@ -559,8 +570,8 @@ function gatherLubesInvoices(fromDate, toDate, supplierId, invoiceType, fuelCate
             order: [['invoice_date', 'DESC'], ['id', 'DESC']]
         });
 
-    Promise.all([suppliersPromise, lubesPromise, fuelPromise])
-        .then(([suppliers, lubesInvoices, fuelInvoices]) => {
+    Promise.all([suppliersPromise, lubesPromise, fuelPromise, hasCngPromise])
+        .then(([suppliers, lubesInvoices, fuelInvoices, cngProduct]) => {
             let invoiceValues = [];
 
             if (lubesInvoices && lubesInvoices.length > 0) {
@@ -612,6 +623,7 @@ function gatherLubesInvoices(fromDate, toDate, supplierId, invoiceType, fuelCate
                 selectedSupplierId: supplierId,
                 selectedType: invoiceType || '',
                 selectedFuelCategory: fuelCategory || '',
+                hasCngProduct: !!cngProduct,
                 suppliers: suppliers,
                 invoiceValues: invoiceValues,
                 currentDate: utils.currentDate(),

--- a/views/lubes-invoice-home.pug
+++ b/views/lubes-invoice-home.pug
@@ -54,12 +54,14 @@ block content
         }
 
         function toggleFuelCategoryFilter() {
+            const fuelCategorySelect = document.getElementById('fuel_category');
+            if (!fuelCategorySelect) return; // location has no CNG product; filter isn't rendered
             const show = document.getElementById('invoice_type').value === 'FUEL';
             const display = show ? 'table-cell' : 'none';
             document.getElementById('fuelCategorySpacer').style.display = display;
             document.getElementById('fuelCategoryLabel').style.display = display;
             document.getElementById('fuelCategoryField').style.display = display;
-            if (!show) document.getElementById('fuel_category').value = '';
+            if (!show) fuelCategorySelect.value = '';
         }
 
         function toggleInvoiceLines(invoiceId, button) {
@@ -194,13 +196,14 @@ block content
                             option(value='' selected=selectedType == '') All Types
                             option(value='FUEL' selected=selectedType == 'FUEL') Fuel
                             option(value='LUBE' selected=selectedType == 'LUBE') Lube
-                    td#fuelCategorySpacer(style=selectedType == 'FUEL' ? '' : 'display:none') &nbsp;
-                    td#fuelCategoryLabel(style=selectedType == 'FUEL' ? '' : 'display:none') Fuel Category:
-                    td#fuelCategoryField(style=selectedType == 'FUEL' ? '' : 'display:none')
-                        select#fuel_category.form-control.form-control-sm(name='fuel_category')
-                            option(value='' selected=selectedFuelCategory == '') All Fuel
-                            option(value='CNG' selected=selectedFuelCategory == 'CNG') CNG
-                            option(value='MS_HSD' selected=selectedFuelCategory == 'MS_HSD') MS / HSD
+                    if hasCngProduct
+                        td#fuelCategorySpacer(style=selectedType == 'FUEL' ? '' : 'display:none') &nbsp;
+                        td#fuelCategoryLabel(style=selectedType == 'FUEL' ? '' : 'display:none') Fuel Category:
+                        td#fuelCategoryField(style=selectedType == 'FUEL' ? '' : 'display:none')
+                            select#fuel_category.form-control.form-control-sm(name='fuel_category')
+                                option(value='' selected=selectedFuelCategory == '') All Fuel
+                                option(value='CNG' selected=selectedFuelCategory == 'CNG') CNG
+                                option(value='MS_HSD' selected=selectedFuelCategory == 'MS_HSD') MS / HSD
                     td &nbsp;
                     td
                         button.btn.btn-sm.btn-primary(type='submit') Go


### PR DESCRIPTION
## Summary
- The Fuel Category (CNG/MS-HSD) filter on the Purchase Invoice search screen was showing for every location whenever Type=Fuel was picked, including locations like MUE that have no CNG product at all — irrelevant noise
- `gatherLubesInvoices` now checks `m_product` for an `is_tank_product=1` row named "CNG" (case-insensitive) for the user's location; the filter is only rendered (not just CSS-hidden) when that's true
- Verified against dev DB: MUE → false, SFS → true, MME → true

## Test plan
- [ ] Location MUE: confirm Fuel Category filter never appears, even with Type=Fuel selected
- [ ] Location SFS or MME: confirm Fuel Category filter still appears/hides correctly based on Type