### PR TITLE
Fix: Supplier filter ignored for Fuel-type invoices on Purchase Invoice search

### DIFF
--- a/controllers/lubes-invoice-controller.js
+++ b/controllers/lubes-invoice-controller.js
@@ -562,6 +562,7 @@ function gatherLubesInvoices(fromDate, toDate, supplierId, invoiceType, fuelCate
 
     const fuelWhere = { location_id: user.location_code, invoice_date: { [Op.between]: [fromDate, toDate] } };
     if (fuelCategory) fuelWhere.fuel_category = fuelCategory;
+    if (supplierId) fuelWhere.supplier_id = supplierId;
     const fuelPromise = invoiceType === 'LUBE'
         ? Promise.resolve([])
         : TankInvoice.findAll({


### PR DESCRIPTION
## Summary
- On the Purchase Invoice search screen, picking a Supplier + Type=Fuel ignored the supplier filter entirely for fuel invoices — `fuelWhere` never included `supplier_id`, only the Lube query filtered by it
- Reported case: MUE + "SAKTHI GANESH AUTO SERVICE" (a lube-only vendor, 0 fuel invoices) showed all of IOCL's fuel invoices instead of an empty list
- Fix: add `supplier_id` to `fuelWhere` when a supplier is selected

## Test plan
- [ ] MUE, Supplier=SAKTHI GANESH AUTO SERVICE, Type=Fuel → confirm empty result
- [ ] MUE, Supplier=IOCL, Type=Fuel → confirm only IOCL invoices show