### PR TITLE
Promote PetroMath_dev_new to master (PRs #750-#760)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,12 +16,9 @@ jobs:
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H $(echo ${{ secrets.DEV_SERVER }} | cut -d@ -f2) >> ~/.ssh/known_hosts
 
-      - name: Deploy to Dev + Beta Prod
+      - name: Deploy to Beta Prod
         run: |
           ssh ${{ secrets.DEV_SERVER }} "
-            cd /home/ubuntu/petromath_dev_new &&
-            git pull origin PetroMath_dev_new
-
             cd /home/ubuntu/petromath_prod_beta &&
             git pull origin PetroMath_dev_new
 

--- a/controllers/location-config-controller.js
+++ b/controllers/location-config-controller.js
@@ -4,6 +4,12 @@ const LocationConfigDao = require('../dao/location-config-dao');
 const LocationDao = require('../dao/location-dao');
 const dateFormat = require('dateformat');
 
+function safeDate(d, fmt) {
+    if (!d) return 'N/A';
+    const parsed = new Date(d);
+    return isNaN(parsed.getTime()) ? 'N/A' : dateFormat(parsed, fmt);
+}
+
 /**
  * Location Config Controller
  * Manages location-specific and global configuration settings
@@ -51,23 +57,29 @@ module.exports = {
             
             // Get all unique setting names for autocomplete
             const settingNames = await LocationConfigDao.getAllSettingNames();
-            
+
+            // Get description catalog (one row per setting_name) for the manage-descriptions UI
+            const catalogMap = await LocationConfigDao.getCatalogMap();
+            const settingCatalog = settingNames.map(name => ({
+                setting_name: name,
+                short_description: catalogMap[name]?.short_description || '',
+                detailed_description: catalogMap[name]?.detailed_description || ''
+            }));
+
             // Format dates for display
             const formattedActiveConfigs = activeConfigs.map(config => ({
                 ...config,
-                effective_start_date_formatted: dateFormat(config.effective_start_date, 'dd-mmm-yyyy'),
-                effective_end_date_formatted: dateFormat(config.effective_end_date, 'dd-mmm-yyyy'),
-                creation_date_formatted: config.creation_date ? 
-                    dateFormat(config.creation_date, 'dd-mmm-yyyy HH:MM') : 'N/A',
+                effective_start_date_formatted: safeDate(config.effective_start_date, 'dd-mmm-yyyy'),
+                effective_end_date_formatted: safeDate(config.effective_end_date, 'dd-mmm-yyyy'),
+                creation_date_formatted: safeDate(config.creation_date, 'dd-mmm-yyyy HH:MM'),
                 is_global: config.location_code === '*'
             }));
-            
+
             const formattedHistoryConfigs = historyConfigs.map(config => ({
                 ...config,
-                effective_start_date_formatted: dateFormat(config.effective_start_date, 'dd-mmm-yyyy'),
-                effective_end_date_formatted: dateFormat(config.effective_end_date, 'dd-mmm-yyyy'),
-                creation_date_formatted: config.creation_date ? 
-                    dateFormat(config.creation_date, 'dd-mmm-yyyy HH:MM') : 'N/A',
+                effective_start_date_formatted: safeDate(config.effective_start_date, 'dd-mmm-yyyy'),
+                effective_end_date_formatted: safeDate(config.effective_end_date, 'dd-mmm-yyyy'),
+                creation_date_formatted: safeDate(config.creation_date, 'dd-mmm-yyyy HH:MM'),
                 is_global: config.location_code === '*'
             }));
 
@@ -79,10 +91,12 @@ module.exports = {
                 historyConfigsData: JSON.stringify(formattedHistoryConfigs),
                 locationsData: JSON.stringify(locations),
                 settingNamesData: JSON.stringify(settingNames),
+                settingCatalogData: JSON.stringify(settingCatalog),
                 activeConfigs: formattedActiveConfigs,
                 historyConfigs: formattedHistoryConfigs,
                 locations: locations,
                 settingNames: settingNames,
+                settingCatalog: settingCatalog,
                 currentFilter: locationFilter,
                 currentDate: new Date().toISOString().split('T')[0],
                 isSuperUser: userRole === 'SuperUser',
@@ -328,6 +342,45 @@ module.exports = {
             res.status(500).json({
                 success: false,
                 error: 'Failed to fetch configuration: ' + error.message
+            });
+        }
+    },
+
+    /**
+     * PUT /location-config/catalog/:settingName
+     * Create/update the description for a setting_name (independent of any location's value).
+     * Any authenticated user with MANAGE_LOCATION_CONFIG can edit descriptions.
+     */
+    updateCatalogDescription: async (req, res, next) => {
+        try {
+            const settingName = req.params.settingName.trim().toUpperCase();
+            const { short_description, detailed_description } = req.body;
+            const username = req.user.username;
+
+            if (!settingName) {
+                return res.status(400).json({
+                    success: false,
+                    error: 'Setting name is required'
+                });
+            }
+
+            const updated = await LocationConfigDao.upsertCatalogEntry(
+                settingName,
+                (short_description || '').trim(),
+                (detailed_description || '').trim(),
+                username
+            );
+
+            res.json({
+                success: true,
+                message: 'Description saved successfully',
+                data: updated
+            });
+        } catch (error) {
+            console.error('Error updating catalog description:', error);
+            res.status(500).json({
+                success: false,
+                error: 'Failed to save description: ' + error.message
             });
         }
     },

--- a/controllers/lubes-invoice-controller.js
+++ b/controllers/lubes-invoice-controller.js
@@ -538,11 +538,22 @@ function gatherLubesInvoices(fromDate, toDate, supplierId, invoiceType, fuelCate
     const { Op } = require('sequelize');
     const TankInvoice = db.tank_invoice;
     const TankInvoiceDtl = db.tank_invoice_dtl;
+    const Product = db.product;
 
     // A fuel category filter only applies when Type=Fuel is explicitly selected;
     // ignore a stray fuel_category param otherwise (e.g. a stale value left over
     // from a hidden form field) so it can never silently suppress Lube results.
     fuelCategory = invoiceType === 'FUEL' ? fuelCategory : '';
+
+    // Only offer the CNG/MS-HSD filter for locations that actually carry a CNG product
+    const hasCngPromise = Product.findOne({
+        where: {
+            location_code: user.location_code,
+            is_tank_product: 1,
+            product_name: db.Sequelize.where(db.Sequelize.fn('UPPER', db.Sequelize.col('product_name')), 'CNG')
+        },
+        attributes: ['product_id']
+    });
 
     const suppliersPromise = lubesInvoiceDao.getSuppliers(user.location_code);
     const lubesPromise = invoiceType === 'FUEL'
@@ -559,8 +570,8 @@ function gatherLubesInvoices(fromDate, toDate, supplierId, invoiceType, fuelCate
             order: [['invoice_date', 'DESC'], ['id', 'DESC']]
         });
 
-    Promise.all([suppliersPromise, lubesPromise, fuelPromise])
-        .then(([suppliers, lubesInvoices, fuelInvoices]) => {
+    Promise.all([suppliersPromise, lubesPromise, fuelPromise, hasCngPromise])
+        .then(([suppliers, lubesInvoices, fuelInvoices, cngProduct]) => {
             let invoiceValues = [];
 
             if (lubesInvoices && lubesInvoices.length > 0) {
@@ -612,6 +623,7 @@ function gatherLubesInvoices(fromDate, toDate, supplierId, invoiceType, fuelCate
                 selectedSupplierId: supplierId,
                 selectedType: invoiceType || '',
                 selectedFuelCategory: fuelCategory || '',
+                hasCngProduct: !!cngProduct,
                 suppliers: suppliers,
                 invoiceValues: invoiceValues,
                 currentDate: utils.currentDate(),

--- a/controllers/lubes-invoice-controller.js
+++ b/controllers/lubes-invoice-controller.js
@@ -562,6 +562,7 @@ function gatherLubesInvoices(fromDate, toDate, supplierId, invoiceType, fuelCate
 
     const fuelWhere = { location_id: user.location_code, invoice_date: { [Op.between]: [fromDate, toDate] } };
     if (fuelCategory) fuelWhere.fuel_category = fuelCategory;
+    if (supplierId) fuelWhere.supplier_id = supplierId;
     const fuelPromise = invoiceType === 'LUBE'
         ? Promise.resolve([])
         : TankInvoice.findAll({

--- a/controllers/lubes-invoice-controller.js
+++ b/controllers/lubes-invoice-controller.js
@@ -19,12 +19,14 @@ const tempLubeInvoiceStore = new Map();
 module.exports = {
     getLubesInvoiceHome: (req, res, next) => {
         gatherLubesInvoices(
-            req.query.invoice_fromDate, 
+            req.query.invoice_fromDate,
             req.query.invoice_toDate,
-            req.query.supplier_id, 
-            req.user, 
-            res, 
-            next, 
+            req.query.supplier_id,
+            req.query.invoice_type,
+            req.query.fuel_category,
+            req.user,
+            res,
+            next,
             {}
         );
     },
@@ -525,25 +527,33 @@ function getLubesInvoiceDetailsPromise(invoiceDetails, req, res, next) {
     });
 }
 
-function gatherLubesInvoices(fromDate, toDate, supplierId, user, res, next, messagesOptional) {
+function gatherLubesInvoices(fromDate, toDate, supplierId, invoiceType, fuelCategory, user, res, next, messagesOptional) {
     // If no dates provided, use financial year dates
     if(fromDate === undefined || toDate === undefined) {
         const financialYearDates = getFinancialYearDates();
         fromDate = financialYearDates.fromDate;
         toDate = financialYearDates.toDate;
     }
-    
+
     const { Op } = require('sequelize');
     const TankInvoice = db.tank_invoice;
     const TankInvoiceDtl = db.tank_invoice_dtl;
 
+    // A fuel category filter only applies to fuel invoices
     const suppliersPromise = lubesInvoiceDao.getSuppliers(user.location_code);
-    const lubesPromise = lubesInvoiceDao.findLubesInvoices(user.location_code, fromDate, toDate, supplierId);
-    const fuelPromise = TankInvoice.findAll({
-        where: { location_id: user.location_code, invoice_date: { [Op.between]: [fromDate, toDate] } },
-        include: [{ model: TankInvoiceDtl, as: 'lines', attributes: ['quantity', 'qty_unit'] }],
-        order: [['invoice_date', 'DESC'], ['id', 'DESC']]
-    });
+    const lubesPromise = (invoiceType === 'FUEL' || fuelCategory)
+        ? Promise.resolve([])
+        : lubesInvoiceDao.findLubesInvoices(user.location_code, fromDate, toDate, supplierId);
+
+    const fuelWhere = { location_id: user.location_code, invoice_date: { [Op.between]: [fromDate, toDate] } };
+    if (fuelCategory) fuelWhere.fuel_category = fuelCategory;
+    const fuelPromise = invoiceType === 'LUBE'
+        ? Promise.resolve([])
+        : TankInvoice.findAll({
+            where: fuelWhere,
+            include: [{ model: TankInvoiceDtl, as: 'lines', attributes: ['quantity', 'qty_unit'] }],
+            order: [['invoice_date', 'DESC'], ['id', 'DESC']]
+        });
 
     Promise.all([suppliersPromise, lubesPromise, fuelPromise])
         .then(([suppliers, lubesInvoices, fuelInvoices]) => {
@@ -582,7 +592,8 @@ function gatherLubesInvoices(fromDate, toDate, supplierId, user, res, next, mess
                         amount: parseFloat(f.total_invoice_amount) || 0,
                         total_lines: (f.lines || []).length,
                         qty_kl: qty > 0 ? qty.toFixed(3) : '',
-                        qty_unit: qty_unit
+                        qty_unit: qty_unit,
+                        fuel_category: f.fuel_category || (qty_unit === 'KG' ? 'CNG' : 'MS_HSD')
                     });
                 });
             }
@@ -595,6 +606,8 @@ function gatherLubesInvoices(fromDate, toDate, supplierId, user, res, next, mess
                 fromDate: fromDate,
                 toDate: toDate,
                 selectedSupplierId: supplierId,
+                selectedType: invoiceType || '',
+                selectedFuelCategory: fuelCategory || '',
                 suppliers: suppliers,
                 invoiceValues: invoiceValues,
                 currentDate: utils.currentDate(),

--- a/controllers/lubes-invoice-controller.js
+++ b/controllers/lubes-invoice-controller.js
@@ -539,9 +539,13 @@ function gatherLubesInvoices(fromDate, toDate, supplierId, invoiceType, fuelCate
     const TankInvoice = db.tank_invoice;
     const TankInvoiceDtl = db.tank_invoice_dtl;
 
-    // A fuel category filter only applies to fuel invoices
+    // A fuel category filter only applies when Type=Fuel is explicitly selected;
+    // ignore a stray fuel_category param otherwise (e.g. a stale value left over
+    // from a hidden form field) so it can never silently suppress Lube results.
+    fuelCategory = invoiceType === 'FUEL' ? fuelCategory : '';
+
     const suppliersPromise = lubesInvoiceDao.getSuppliers(user.location_code);
-    const lubesPromise = (invoiceType === 'FUEL' || fuelCategory)
+    const lubesPromise = invoiceType === 'FUEL'
         ? Promise.resolve([])
         : lubesInvoiceDao.findLubesInvoices(user.location_code, fromDate, toDate, supplierId);
 

--- a/controllers/purchases-controller.js
+++ b/controllers/purchases-controller.js
@@ -225,6 +225,8 @@ module.exports = {
             if (!lines.length) return res.status(400).json({ success: false, error: 'At least one product line is required.' });
             if (lines.some(l => !l.product_id)) return res.status(400).json({ success: false, error: 'All lines must have a product selected.' });
 
+            header.fuel_category = lines.some(l => l.qty_unit === 'KG') ? 'CNG' : 'MS_HSD';
+
             const invoice = await TankInvoiceDao.saveInvoice(
                 header, lines, pdfBuffer, locationCode, header.supplier_id, originalFileName
             );

--- a/controllers/tank-receipt-controller.js
+++ b/controllers/tank-receipt-controller.js
@@ -251,6 +251,8 @@ module.exports = {
                 };
             });
 
+            headerData.fuel_category = lineData.some(l => l.qty_unit === 'KG') ? 'CNG' : 'MS_HSD';
+
             const invoice = await TankInvoiceDao.saveInvoice(headerData, lineData, pdfBuffer, locationCode, Number(supplierId), originalFileName);
             return res.json({ success: true, invoiceId: invoice.id, invoiceNumber: invoice.invoice_number });
         } catch (err) {

--- a/dao/location-config-dao.js
+++ b/dao/location-config-dao.js
@@ -2,6 +2,7 @@ const db = require("../db/db-connection");
 const Sequelize = require("sequelize");
 const { Op } = require("sequelize");
 const LocationConfig = db.location_config;
+const LocationConfigCatalog = db.location_config_catalog;
 
 module.exports = {
     
@@ -140,8 +141,8 @@ module.exports = {
                 ],
                 raw: true
             });
-            
-            return configs;
+
+            return await module.exports.attachCatalogDescriptions(configs);
         } catch (error) {
             console.error('Error in getAllConfigs:', error);
             throw error;
@@ -175,10 +176,84 @@ module.exports = {
                 ],
                 raw: true
             });
-            
-            return configs;
+
+            return await module.exports.attachCatalogDescriptions(configs);
         } catch (error) {
             console.error('Error in getHistoryConfigs:', error);
+            throw error;
+        }
+    },
+
+    // Merge in short/detailed descriptions from the catalog (keyed by setting_name)
+    attachCatalogDescriptions: async (configs) => {
+        if (!configs || configs.length === 0) return configs;
+
+        const catalogMap = await module.exports.getCatalogMap();
+        return configs.map(config => ({
+            ...config,
+            short_description: catalogMap[config.setting_name]?.short_description || null,
+            detailed_description: catalogMap[config.setting_name]?.detailed_description || null
+        }));
+    },
+
+    // Get all catalog entries as a map keyed by setting_name
+    getCatalogMap: async () => {
+        try {
+            const entries = await LocationConfigCatalog.findAll({ raw: true });
+            const map = {};
+            entries.forEach(entry => {
+                map[entry.setting_name] = entry;
+            });
+            return map;
+        } catch (error) {
+            console.error('Error in getCatalogMap:', error);
+            throw error;
+        }
+    },
+
+    // Get all catalog entries as a list (for the manage-descriptions UI)
+    getCatalogList: async () => {
+        try {
+            return await LocationConfigCatalog.findAll({
+                order: [['setting_name', 'ASC']],
+                raw: true
+            });
+        } catch (error) {
+            console.error('Error in getCatalogList:', error);
+            throw error;
+        }
+    },
+
+    // Create or update the description for a setting_name (independent of any config value/row)
+    upsertCatalogEntry: async (settingName, shortDescription, detailedDescription, updatedBy = 'system') => {
+        try {
+            const existing = await LocationConfigCatalog.findByPk(settingName);
+
+            if (existing) {
+                await LocationConfigCatalog.update(
+                    {
+                        short_description: shortDescription,
+                        detailed_description: detailedDescription,
+                        updated_by: updatedBy,
+                        updation_date: new Date()
+                    },
+                    { where: { setting_name: settingName } }
+                );
+            } else {
+                await LocationConfigCatalog.create({
+                    setting_name: settingName,
+                    short_description: shortDescription,
+                    detailed_description: detailedDescription,
+                    created_by: updatedBy,
+                    updated_by: updatedBy,
+                    creation_date: new Date(),
+                    updation_date: new Date()
+                });
+            }
+
+            return await LocationConfigCatalog.findByPk(settingName, { raw: true });
+        } catch (error) {
+            console.error('Error in upsertCatalogEntry:', error);
             throw error;
         }
     },

--- a/db/db-connection.js
+++ b/db/db-connection.js
@@ -63,6 +63,7 @@ db.t_lubes_inv_lines = require("./txn-lubes-lines")(sequelize, Sequelize);
 db.m_supplier = require("./suppliers")(sequelize, Sequelize);
 db.creditlistvehicle = require("./creditlistvehicle")(sequelize, Sequelize);  // Import the creditlistvehicle model
 db.location_config = require('./location-config')(sequelize, Sequelize);
+db.location_config_catalog = require('./location-config-catalog')(sequelize, Sequelize);
 db.txn_digital_sales = require("./txn-digital-sales")(sequelize, Sequelize);
 db.adjustments = require("./adjustments")(sequelize, Sequelize);
 db.dev_tracker = require("./dev-tracker")(sequelize, Sequelize);
@@ -81,6 +82,12 @@ db.gst_filing_log = require("./gst-filing-log")(sequelize, Sequelize);
 db.day_bill = require("./day-bill")(sequelize, Sequelize);
 db.day_bill_header = require("./day-bill-header")(sequelize, Sequelize);
 db.day_bill_items = require("./day-bill-items")(sequelize, Sequelize);
+
+db.location_billing_plan = require("./location-billing-plan")(sequelize, Sequelize);
+db.platform_invoice = require("./platform-invoice")(sequelize, Sequelize);
+db.platform_invoice_items = require("./platform-invoice-items")(sequelize, Sequelize);
+db.platform_payment = require("./platform-payment")(sequelize, Sequelize);
+db.platform_payment_allocation = require("./platform-payment-allocation")(sequelize, Sequelize);
 db.document_store = require("./document-store")(sequelize, Sequelize);
 db.employee = require("./employee")(sequelize, Sequelize);
 db.employee_salary = require("./employee-salary")(sequelize, Sequelize);
@@ -312,6 +319,14 @@ db.day_bill_header.hasMany(db.day_bill_items, {foreignKey: 'header_id', as: 'ite
 db.day_bill_items.belongsTo(db.day_bill_header, {foreignKey: 'header_id'});
 db.day_bill_header.belongsTo(db.credit, {foreignKey: 'vendor_id', targetKey: 'creditlist_id', as: 'vendor'});
 db.day_bill_items.belongsTo(db.product, {foreignKey: 'product_id', targetKey: 'product_id'});
+
+// Platform billing relations
+db.platform_invoice.hasMany(db.platform_invoice_items, {foreignKey: 'invoice_id', as: 'items'});
+db.platform_invoice_items.belongsTo(db.platform_invoice, {foreignKey: 'invoice_id'});
+db.platform_invoice.hasMany(db.platform_payment_allocation, {foreignKey: 'invoice_id', as: 'allocations'});
+db.platform_payment_allocation.belongsTo(db.platform_invoice, {foreignKey: 'invoice_id'});
+db.platform_payment.hasMany(db.platform_payment_allocation, {foreignKey: 'payment_id', as: 'allocations'});
+db.platform_payment_allocation.belongsTo(db.platform_payment, {foreignKey: 'payment_id'});
 
 // Tank invoice relations
 db.tank_invoice.hasMany(db.tank_invoice_dtl, {foreignKey: 'invoice_id', as: 'lines'});

--- a/db/db-connection.js
+++ b/db/db-connection.js
@@ -83,11 +83,6 @@ db.day_bill = require("./day-bill")(sequelize, Sequelize);
 db.day_bill_header = require("./day-bill-header")(sequelize, Sequelize);
 db.day_bill_items = require("./day-bill-items")(sequelize, Sequelize);
 
-db.location_billing_plan = require("./location-billing-plan")(sequelize, Sequelize);
-db.platform_invoice = require("./platform-invoice")(sequelize, Sequelize);
-db.platform_invoice_items = require("./platform-invoice-items")(sequelize, Sequelize);
-db.platform_payment = require("./platform-payment")(sequelize, Sequelize);
-db.platform_payment_allocation = require("./platform-payment-allocation")(sequelize, Sequelize);
 db.document_store = require("./document-store")(sequelize, Sequelize);
 db.employee = require("./employee")(sequelize, Sequelize);
 db.employee_salary = require("./employee-salary")(sequelize, Sequelize);
@@ -319,14 +314,6 @@ db.day_bill_header.hasMany(db.day_bill_items, {foreignKey: 'header_id', as: 'ite
 db.day_bill_items.belongsTo(db.day_bill_header, {foreignKey: 'header_id'});
 db.day_bill_header.belongsTo(db.credit, {foreignKey: 'vendor_id', targetKey: 'creditlist_id', as: 'vendor'});
 db.day_bill_items.belongsTo(db.product, {foreignKey: 'product_id', targetKey: 'product_id'});
-
-// Platform billing relations
-db.platform_invoice.hasMany(db.platform_invoice_items, {foreignKey: 'invoice_id', as: 'items'});
-db.platform_invoice_items.belongsTo(db.platform_invoice, {foreignKey: 'invoice_id'});
-db.platform_invoice.hasMany(db.platform_payment_allocation, {foreignKey: 'invoice_id', as: 'allocations'});
-db.platform_payment_allocation.belongsTo(db.platform_invoice, {foreignKey: 'invoice_id'});
-db.platform_payment.hasMany(db.platform_payment_allocation, {foreignKey: 'payment_id', as: 'allocations'});
-db.platform_payment_allocation.belongsTo(db.platform_payment, {foreignKey: 'payment_id'});
 
 // Tank invoice relations
 db.tank_invoice.hasMany(db.tank_invoice_dtl, {foreignKey: 'invoice_id', as: 'lines'});

--- a/db/location-config-catalog.js
+++ b/db/location-config-catalog.js
@@ -1,0 +1,42 @@
+module.exports = (sequelize, DataTypes) => {
+    const LocationConfigCatalog = sequelize.define('LocationConfigCatalog', {
+        setting_name: {
+            type: DataTypes.STRING(50),
+            primaryKey: true,
+            allowNull: false,
+            comment: 'Configuration setting name (matches m_location_config.setting_name)'
+        },
+        short_description: {
+            type: DataTypes.STRING(255),
+            allowNull: true
+        },
+        detailed_description: {
+            type: DataTypes.TEXT,
+            allowNull: true
+        },
+        created_by: {
+            type: DataTypes.STRING(45),
+            allowNull: true
+        },
+        updated_by: {
+            type: DataTypes.STRING(45),
+            allowNull: true
+        },
+        creation_date: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW
+        },
+        updation_date: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW
+        }
+    }, {
+        tableName: 'm_location_config_catalog',
+        timestamps: false,
+        comment: 'One row per setting_name describing what a m_location_config setting does'
+    });
+
+    return LocationConfigCatalog;
+};

--- a/db/migrations/fuel-invoice-category.sql
+++ b/db/migrations/fuel-invoice-category.sql
@@ -1,0 +1,19 @@
+-- Migration: Add fuel_category column to t_tank_invoice
+-- Distinguishes CNG invoices from regular fuel (MS/HSD) invoices so the
+-- purchase invoice search screen can filter within type=FUEL.
+-- Populated at save time (see purchases-controller.js saveFuelInvoice); backfill
+-- below classifies existing rows from their line items' qty_unit
+-- (CNG is invoiced in KG, MS/HSD in KL).
+
+ALTER TABLE t_tank_invoice
+    ADD COLUMN fuel_category VARCHAR(10) NULL AFTER bay_number;
+
+UPDATE t_tank_invoice ti
+SET fuel_category = CASE
+    WHEN EXISTS (
+        SELECT 1 FROM t_tank_invoice_dtl d
+        WHERE d.invoice_id = ti.id AND d.qty_unit = 'KG'
+    ) THEN 'CNG'
+    ELSE 'MS_HSD'
+END
+WHERE fuel_category IS NULL;

--- a/db/migrations/location-config-catalog.sql
+++ b/db/migrations/location-config-catalog.sql
@@ -1,0 +1,216 @@
+-- Description catalog for m_location_config settings.
+--
+-- m_location_config stores one row per (location_code, setting_name, effective_date_range),
+-- so a description does not belong on that table -- the same setting_name can appear dozens
+-- of times (per-location overrides, history rows). This catalog holds ONE row per setting_name
+-- with a short + detailed description, editable independently of any config value.
+--
+-- Run once per environment. Safe to re-run (CREATE TABLE IF NOT EXISTS + INSERT ... ON DUPLICATE
+-- KEY UPDATE), so re-running after adding/adjusting descriptions below is fine.
+
+CREATE TABLE IF NOT EXISTS m_location_config_catalog (
+    setting_name          VARCHAR(50)  NOT NULL PRIMARY KEY,
+    short_description     VARCHAR(255) NULL,
+    detailed_description  TEXT         NULL,
+    created_by             VARCHAR(45)  NULL,
+    updated_by             VARCHAR(45)  NULL,
+    creation_date          DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updation_date          DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- Backfill: drafted from grepping every getLocationConfigValue()/getSetting()/raw-SQL call site
+-- as of 2026-08-06. Review the detailed_description column and correct anything that doesn't
+-- match actual intent -- these were inferred from usage, not written by the feature owner.
+
+INSERT INTO m_location_config_catalog (setting_name, short_description, detailed_description, created_by, updated_by)
+VALUES
+-- Shift closing / operations
+('ALLOW_SHIFT_REOPEN', 'Allow reopening a closed shift',
+ 'Y/N. When Y, a completed shift closing at this location can be reopened for correction instead of staying locked. Checked in closing-edit-controller.js and home-controller.js.',
+ 'system', 'system'),
+
+('MAX_DAYS_ALLOWED_BACK_DATE_CLOSING', 'Max days a shift closing can be backdated',
+ 'Number of days in the past a shift closing date is allowed to be set to when creating/editing a closing. Checked in home-controller.js, closing-edit-controller.js, bill-controller.js.',
+ 'system', 'system'),
+
+('PUMP_OPENING_READING_READONLY', 'Lock pump opening reading field',
+ 'Y/N. When Y, the pump opening meter reading field on the shift closing screen is read-only and auto-carried from the previous closing instead of being editable.',
+ 'system', 'system'),
+
+('SHOW_2T_SALES_TAB', 'Show 2T oil sales tab on shift closing',
+ 'Y/N. Controls whether the separate 2T (two-stroke) oil sales tab appears on the shift closing screen. Default N; some legacy locations (e.g. carried-over GAC2) run Y.',
+ 'system', 'system'),
+
+('ALLOW_QUICK_ADD_VEHICLE', 'Enable quick-add vehicle modal',
+ 'Y/N. Enables the "+" button next to the vehicle dropdown in the credit tab that opens a modal to add a new vehicle inline (AJAX POST /vehicles/api/quick-add) without leaving the closing screen. Default disabled.',
+ 'system', 'system'),
+
+('CASHFLOW_ENABLED', 'Enable cashflow-based closing workflow',
+ 'Y/N (or true/false in some call sites -- inconsistent, worth standardizing). Gates whether the location uses the cashflow closing workflow (t_cashflow_closing) in addition to/instead of plain shift closing. Checked in reports-dsr-controller.js, bank-statement-dao.js, credit-receipts-dao.js, txn-tankrcpt-dao.js.',
+ 'system', 'system'),
+
+-- Bowser
+('ALLOW_BOWSER_REOPEN', 'Allow reopening a closed bowser closing',
+ 'Y/N. When Y, a completed bowser closing can be reopened for correction. Checked in bowser-controller.js.',
+ 'system', 'system'),
+
+('BOWSER_CLOSING_BACKDATE_DAYS', 'Max days a bowser closing can be backdated',
+ 'Number of days in the past a bowser closing date can be set to. Checked in bowser-controller.js alongside ALLOW_BOWSER_REOPEN.',
+ 'system', 'system'),
+
+-- Employee
+('EMPLOYEE_AUTO_SALARY', 'Auto-generate employee salary entries',
+ 'Y/N. When Y, salary ledger entries are auto-generated for employees rather than requiring manual entry. Checked in employee-controller.js.',
+ 'system', 'system'),
+
+('EMPLOYEE_LEDGER_BACKDATE_DAYS', 'Max days an employee ledger entry can be backdated',
+ 'Number of days in the past an employee ledger entry\'s date can be set to when creating one. 0 = no restriction on backdating.',
+ 'system', 'system'),
+
+('EMPLOYEE_LEDGER_DELETE_DAYS', 'Max days after creation an employee ledger entry can be deleted',
+ 'An employee ledger entry can only be deleted within this many days of its creation date. Prevents deleting old/reconciled entries.',
+ 'system', 'system'),
+
+('DOC_MAX_UPLOAD_MB', 'Max document upload size (MB)',
+ 'Maximum file size in megabytes accepted for document uploads (e.g. employee documents stored in t_document_store). Default 2.',
+ 'system', 'system'),
+
+-- Credit statement / reports
+('CREDIT_STMT_SHOW_PERIOD_SUMMARY', 'Show period summary on credit statement',
+ 'Y/N. Shows/hides the period summary block on the credit statement and credit ledger reports. Default Y.',
+ 'system', 'system'),
+
+('CREDIT_STMT_SHOW_STATEMENT_NUMBER', 'Show sequential statement number',
+ 'Y/N. Shows an auto-generated sequential statement number on the credit statement. Requires the t_credit_statement numbering migration to be in place. Default N.',
+ 'system', 'system'),
+
+('CREDIT_STMT_BALANCE_CRDR_FORMAT', 'Format balance as DR/CR',
+ 'Y/N. When Y, the balance column on the credit statement is displayed as "1,234.56 DR/CR" instead of a plain signed number. Default N.',
+ 'system', 'system'),
+
+('CREDIT_STMT_SHOW_BALANCE', 'Show balance column on credit statement',
+ 'Y/N. Shows/hides the Balance column entirely on the credit statement. Default Y.',
+ 'system', 'system'),
+
+('CREDIT_STMT_SHOW_CUSTOMER_INFO', 'Show customer info block on credit statement',
+ 'Y/N. Shows/hides the customer info block (address, contact, etc.) on the credit statement. Default N.',
+ 'system', 'system'),
+
+('ENABLE_CREDIT_REPORT_EXCEL_DOWNLOAD', 'Enable Excel download on credit reports',
+ 'Y/N. Shows/hides the Excel download button on credit reports. Default N.',
+ 'system', 'system'),
+
+-- Bank / oil company statement
+('ALLOW_MANUAL_BANK_TRANSACTIONS', 'Allow manually adding bank transactions',
+ 'Y/N. Allows manually adding a bank transaction row rather than only importing from a bank statement file. Checked in bank-statement-controller.js and oil-company-statement-controller.js.',
+ 'system', 'system'),
+
+('ALLOW_BANK_RECLASSIFY', 'Allow reclassifying bank transactions',
+ 'Y/N. Allows changing the classification/head of an already-imported bank transaction.',
+ 'system', 'system'),
+
+('ALLOW_BANK_SPLIT', 'Allow splitting a bank transaction',
+ 'Y/N (some call sites compare to the string \'true\' rather than \'Y\' -- worth normalizing). Allows splitting a single bank transaction across multiple accounting heads. Checked in transaction-upload-controller.js, bank-statement-controller.js.',
+ 'system', 'system'),
+
+('ALLOW_OIL_RECLASSIFY', 'Allow reclassifying oil company statement transactions',
+ 'Y/N. Allows changing the classification of an oil company statement transaction, same pattern as ALLOW_BANK_RECLASSIFY but for oil-company-statement-controller.js.',
+ 'system', 'system'),
+
+-- Bill numbering
+('BILL_PREFIX_CREDIT', 'Credit bill number prefix',
+ 'Prefix string prepended to credit sale bill numbers. Used by bill-numbering-service.js.',
+ 'system', 'system'),
+
+('BILL_PREFIX_CASH', 'Cash bill number prefix',
+ 'Prefix string prepended to cash sale bill numbers. Used by bill-numbering-service.js.',
+ 'system', 'system'),
+
+('BILL_SUFFIX_CREDIT', 'Credit bill number suffix',
+ 'Suffix string appended to credit sale bill numbers. Used by bill-numbering-service.js.',
+ 'system', 'system'),
+
+('BILL_SUFFIX_CASH', 'Cash bill number suffix',
+ 'Suffix string appended to cash sale bill numbers. Used by bill-numbering-service.js.',
+ 'system', 'system'),
+
+('BILL_NUMBER_PADDING', 'Bill number zero-padding width',
+ 'Number of digits the numeric part of a bill number is zero-padded to (e.g. 6 -> 000123). Default 6.',
+ 'system', 'system'),
+
+('BILL_RESET_FREQUENCY', 'Bill number sequence reset frequency',
+ 'How often the bill number sequence resets back to the starting number, e.g. FINANCIAL_YEAR. Used by bill-numbering-service.js.',
+ 'system', 'system'),
+
+('BILL_INCLUDE_YEAR', 'Include year in bill number',
+ 'true/false. Whether the financial/calendar year is embedded in the generated bill number.',
+ 'system', 'system'),
+
+('BILL_YEAR_FORMAT', 'Bill number year format',
+ 'Format of the year embedded in the bill number when BILL_INCLUDE_YEAR is enabled, e.g. YY or YYYY.',
+ 'system', 'system'),
+
+('BILL_CREDIT_START_NUMBER', 'Credit bill starting number',
+ 'The number the credit bill sequence starts counting from (or resets to). Default 0.',
+ 'system', 'system'),
+
+('BILL_CASH_START_NUMBER', 'Cash bill starting number',
+ 'The number the cash bill sequence starts counting from (or resets to). Default 0.',
+ 'system', 'system'),
+
+('BILL_UNIFIED_SEQUENCE', 'Use one bill sequence for cash and credit',
+ 'true/false. When true, cash and credit sales share a single unified bill number sequence instead of separate credit/cash sequences.',
+ 'system', 'system'),
+
+('BILL_UNIFIED_PREFIX', 'Unified bill number prefix',
+ 'Prefix used for the unified bill number sequence when BILL_UNIFIED_SEQUENCE is enabled.',
+ 'system', 'system'),
+
+('BILL_UNIFIED_SUFFIX', 'Unified bill number suffix',
+ 'Suffix used for the unified bill number sequence when BILL_UNIFIED_SEQUENCE is enabled.',
+ 'system', 'system'),
+
+('BILL_UNIFIED_START_NUMBER', 'Unified bill sequence starting number',
+ 'The number the unified bill sequence starts counting from (or resets to) when BILL_UNIFIED_SEQUENCE is enabled. Default 0.',
+ 'system', 'system'),
+
+-- GL accounting / Day bill
+('GL_ACCOUNTING_ENABLED', 'Enable GL accounting engine for this location',
+ 'Y/N. Gate checked by the is_gl_accounting_enabled() DB function -- accounting event triggers (CREDIT_SALE, CASH_SALE, DAY_BILL, TANK_INVOICE, LUBES_INVOICE, BOWSER, etc.) only fire when this is Y for the location (or globally via location_code=''*''). See docs/gl-accounting-design.md.',
+ 'system', 'system'),
+
+('GL_LOG_LEVEL', 'GL batch run log verbosity',
+ 'DEBUG, INFO, or ERROR. Controls verbosity of Create Accounting / Generate Events batch run logs. DEBUG = per-event detail, INFO = summaries + errors, ERROR = errors only. Default INFO.',
+ 'system', 'system'),
+
+('DAY_BILL_CONSOLIDATE_THRESHOLD', 'Day bill consolidation revenue threshold',
+ 'Decimal amount. When a vendor/product day bill total for the day is below this threshold, it is consolidated into a single-product (dominant product) bill rather than itemized. Default 20000.',
+ 'system', 'system'),
+
+-- Purchases
+('FUEL_INVOICE_EDIT_DISABLED', 'Disable editing fuel purchase invoices',
+ 'Y/N. When Y, fuel purchase invoices at this location cannot be edited after creation. Checked in purchases-controller.js.',
+ 'system', 'system'),
+
+-- System / misc
+('DEBUG_LOGGING', 'Enable verbose backend debug logging',
+ 'Y/N. Enables verbose backend debug logging for this location (utils/debug-logger.js). Can also be forced on via the DEBUG_LOGGING=true environment variable regardless of this setting.',
+ 'system', 'system'),
+
+('DESKTOP_ZOOM', 'Desktop layout zoom factor',
+ 'Decimal CSS zoom factor (e.g. 0.8) applied to the desktop layout for this location. Temporary display-density tuning knob (see app.js comment) -- intended to be removed once zoom is finalized and baked into style.css.',
+ 'system', 'system'),
+
+('CUSTOMER_DEFAULT_PASSWORD', 'Default password for auto-created customer portal logins',
+ 'Default password assigned when a customer portal login is auto-created for a credit customer (e.g. via the "Create Login" action or onboarding). Falls back to a global (*) default if no location-specific value is set.',
+ 'system', 'system'),
+
+('TALLY_EXPORT_VERSION', 'Tally export format version [DEPRECATED]',
+ 'v1 or v2. Selected which Tally export format a location uses. Tally export is being decommissioned -- do not build on this further; retained only for locations still using the legacy export.',
+ 'system', 'system')
+
+ON DUPLICATE KEY UPDATE
+    short_description    = VALUES(short_description),
+    detailed_description = VALUES(detailed_description),
+    updated_by            = VALUES(updated_by),
+    updation_date          = CURRENT_TIMESTAMP;

--- a/db/txn-tank-invoice.js
+++ b/db/txn-tank-invoice.js
@@ -32,6 +32,11 @@ module.exports = function(sequelize, DataTypes) {
             type: DataTypes.DATEONLY,
             allowNull: true
         },
+        invoice_time: {
+            field: 'invoice_time',
+            type: DataTypes.TIME,
+            allowNull: true
+        },
         truck_number: {
             field: 'truck_number',
             type: DataTypes.STRING(20),
@@ -50,6 +55,11 @@ module.exports = function(sequelize, DataTypes) {
         bay_number: {
             field: 'bay_number',
             type: DataTypes.STRING(20),
+            allowNull: true
+        },
+        fuel_category: {
+            field: 'fuel_category',
+            type: DataTypes.STRING(10),
             allowNull: true
         },
         total_invoice_amount: {

--- a/routes/location-config-routes.js
+++ b/routes/location-config-routes.js
@@ -35,6 +35,12 @@ router.put('/update/:configId',
     locationConfigController.updateConfig
 );
 
+// PUT /location-config/catalog/:settingName - Create/update a setting's description
+router.put('/catalog/:settingName',
+    [isLoginEnsured, security.hasPermission('MANAGE_LOCATION_CONFIG')],
+    locationConfigController.updateCatalogDescription
+);
+
 // ============================================================================
 // API ROUTES (AJAX/JSON)
 // ============================================================================

--- a/views/location-config.pug
+++ b/views/location-config.pug
@@ -178,11 +178,55 @@ block content
                         each location in locations
                             option(value=location.location_code, selected=location.location_code === currentFilter)= location.location_name
 
+        // Setting Catalog Section — the feature directory: every setting_name ever used,
+        // with a short + detailed description, searchable independent of any active/history row.
+        .catalog-section.mb-4
+            h5.mb-2
+                i.bi.bi-journal-text.me-2
+                | Setting Catalog
+                small.text-muted.ms-2 (search by what a setting does, not just its name)
+            .input-group.mb-3(style="max-width: 500px;")
+                .input-group-prepend
+                    span.input-group-text
+                        i.bi.bi-search
+                input.form-control#catalogSearchInput(
+                    type="text",
+                    placeholder="Search setting name or description...",
+                    autocomplete="off"
+                )
+            .table-responsive
+                table.table.table-hover.table-sm#catalog-table
+                    thead.thead-light
+                        tr
+                            th(scope="col" style="width: 20%;") Setting Name
+                            th(scope="col" style="width: 25%;") Short Description
+                            th(scope="col") Detailed Description
+                            th(scope="col" style="width: 60px;") Actions
+                    tbody
+                        if settingCatalog && settingCatalog.length > 0
+                            each entry in settingCatalog
+                                tr
+                                    td
+                                        strong= entry.setting_name
+                                    td.small= entry.short_description || '—'
+                                    td.small.text-muted= entry.detailed_description || '—'
+                                    td
+                                        button.btn.btn-sm.btn-outline-secondary.edit-description-btn(
+                                            type="button",
+                                            data-setting-name=entry.setting_name,
+                                            data-toggle="modal",
+                                            data-target="#editDescriptionModal"
+                                        )
+                                            i.bi.bi-pencil
+                        else
+                            tr
+                                td(colspan="4").text-center.text-muted No settings found
+
         // Active Configs Section
         h5.mb-3
             i.bi.bi-gear-fill.me-2
             | Active Configurations
-        
+
         // Desktop table view
         .desktop-table-view.d-none.d-lg-block
             .table-responsive
@@ -191,6 +235,7 @@ block content
                         tr
                             th(scope="col") Location
                             th(scope="col") Setting Name
+                            th(scope="col") Description
                             th(scope="col") Setting Value
                             th(scope="col") Effective From
                             th(scope="col") Effective Until
@@ -207,6 +252,8 @@ block content
                                             span.badge.badge-location= config.location_code
                                     td
                                         strong= config.setting_name
+                                    td.text-muted.small(title=config.detailed_description || '')
+                                        = config.short_description || '—'
                                     td= config.setting_value
                                     td= config.effective_start_date_formatted
                                     td= config.effective_end_date_formatted
@@ -221,7 +268,7 @@ block content
                                             i.bi.bi-pencil
                         else
                             tr
-                                td(colspan="7").text-center.text-muted No active configurations found
+                                td(colspan="8").text-center.text-muted No active configurations found
         
         // Mobile cards view
         .mobile-cards-view.d-lg-none
@@ -246,6 +293,11 @@ block content
                                         i.bi.bi-pencil
                             .card-body.p-3
                                 .row.g-2
+                                    if config.short_description
+                                        .col-12
+                                            .config-detail
+                                                small Description
+                                                div.text-muted= config.short_description
                                     .col-12
                                         .config-detail
                                             small Setting Value
@@ -447,45 +499,157 @@ block content
                                 span.spinner-border.spinner-border-sm.me-2(style='display:none')
                                 | Update Config
 
+    // Edit Description Modal (edits the catalog entry for a setting_name — not tied to any one row)
+    #editDescriptionModal.modal.fade(tabindex='-1')
+        .modal-dialog.modal-dialog-centered
+            .modal-content
+                .modal-header
+                    h5.modal-title
+                        i.bi.bi-journal-text.me-2
+                        | Edit Description
+                    button.btn-close(type='button' data-dismiss='modal' aria-label='Close')
+                .modal-body
+                    .card.mb-3.bg-light
+                        .card-body.py-2
+                            small.text-muted Setting:
+                            .fw-semibold#descSettingDisplay -
+
+                    form#editDescriptionForm
+                        input#descSettingName(type='hidden')
+                        .row.g-3
+                            .col-12
+                                label.form-label(for='descShortText') Short Description
+                                input.form-control#descShortText(
+                                    type='text',
+                                    maxlength='255',
+                                    placeholder='One-line summary shown in the config table'
+                                )
+                            .col-12
+                                label.form-label(for='descDetailedText') Detailed Description
+                                textarea.form-control#descDetailedText(
+                                    rows='4',
+                                    placeholder='What it does, valid values, where it is used, defaults, etc.'
+                                )
+                            .col-12
+                                .small.text-muted This description applies to the setting wherever it appears — across all locations and history — since it describes the setting itself, not one row.
+                .modal-footer
+                    .row.g-2.w-100
+                        .col-6
+                            button.btn.btn-outline-secondary.w-100(type='button' data-dismiss='modal') Cancel
+                        .col-6
+                            button#saveDescriptionBtn.btn.btn-primary.w-100(type='button')
+                                span.spinner-border.spinner-border-sm.me-2(style='display:none')
+                                | Save Description
+
     // JavaScript
     script.
         // Data from server
         const activeConfigsData = !{activeConfigsData};
         const historyConfigsData = !{historyConfigsData};
         const locationsData = !{locationsData};
+        const settingCatalogData = !{settingCatalogData};
         const isSuperUser = !{isSuperUser};
 
         // Page initialization
         $(document).ready(function() {
             initializeEventListeners();
             initializeSearch();
+            initializeCatalogSearch();
         });
 
         function initializeEventListeners() {
             // Add config button
             $('#saveConfigBtn').on('click', handleSaveConfig);
-            
+
             // Update config button
             $('#updateConfigBtn').on('click', handleUpdateConfig);
-            
+
             // Edit config button
             $('.edit-config-btn').on('click', handleEditClick);
-            
+
+            // Edit description button
+            $('.edit-description-btn').on('click', handleEditDescriptionClick);
+
+            // Save description button
+            $('#saveDescriptionBtn').on('click', handleSaveDescription);
+
             // Refresh button
             $('#refreshDataBtn').on('click', function() {
                 window.location.reload();
             });
-            
+
             // Location filter (SuperUser only)
             $('#locationFilter').on('change', function() {
                 const selectedLocation = $(this).val();
                 window.location.href = `/location-config?location=${selectedLocation}`;
             });
-            
+
             // Setting name input - auto uppercase
             $('#addSettingName').on('input', function() {
                 this.value = this.value.toUpperCase();
             });
+        }
+
+        function initializeCatalogSearch() {
+            $('#catalogSearchInput').on('keyup', function() {
+                const searchTerm = $(this).val().toLowerCase();
+                $('#catalog-table tbody tr').each(function() {
+                    const text = $(this).text().toLowerCase();
+                    $(this).toggle(text.indexOf(searchTerm) > -1);
+                });
+            });
+        }
+
+        function handleEditDescriptionClick(e) {
+            const settingName = $(this).data('setting-name');
+            const entry = settingCatalogData.find(c => c.setting_name === settingName);
+
+            $('#descSettingName').val(settingName);
+            $('#descSettingDisplay').text(settingName);
+            $('#descShortText').val(entry ? entry.short_description : '');
+            $('#descDetailedText').val(entry ? entry.detailed_description : '');
+        }
+
+        async function handleSaveDescription() {
+            const settingName = $('#descSettingName').val();
+            const shortText = $('#descShortText').val().trim();
+            const detailedText = $('#descDetailedText').val().trim();
+
+            const btn = $('#saveDescriptionBtn');
+            const spinner = btn.find('.spinner-border');
+            btn.prop('disabled', true);
+            spinner.show();
+
+            try {
+                const response = await fetch(`/location-config/catalog/${encodeURIComponent(settingName)}`, {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        short_description: shortText,
+                        detailed_description: detailedText
+                    })
+                });
+
+                const result = await response.json();
+
+                if (result.success) {
+                    showAlert(result.message, 'success');
+                    $('#editDescriptionModal').modal('hide');
+                    setTimeout(() => {
+                        window.location.reload();
+                    }, 1000);
+                } else {
+                    showAlert(result.error, 'danger');
+                }
+            } catch (error) {
+                console.error('Error saving description:', error);
+                showAlert('Failed to save description', 'danger');
+            } finally {
+                btn.prop('disabled', false);
+                spinner.hide();
+            }
         }
 
         function initializeSearch() {

--- a/views/location-config.pug
+++ b/views/location-config.pug
@@ -147,6 +147,10 @@ block content
                     h4.mb-0.text-primary.text-center.text-md-left Location Configuration
                 .col-auto.order-1.order-md-2.ml-auto
                     .btn-group
+                        button.btn.btn-outline-primary.btn-sm#openCatalogBtn(type="button", data-toggle="modal", data-target="#settingCatalogModal")
+                            i.bi.bi-journal-text.me-1
+                            span.d-none.d-sm-inline Setting Catalog
+                            span.d-inline.d-sm-none Catalog
                         button.btn.btn-success.btn-sm#addConfigBtn(type="button", data-toggle="modal", data-target="#addConfigModal")
                             i.bi.bi-plus-circle.me-1
                             span.d-none.d-sm-inline Add Config
@@ -177,50 +181,6 @@ block content
                         option(value="*") Global Only
                         each location in locations
                             option(value=location.location_code, selected=location.location_code === currentFilter)= location.location_name
-
-        // Setting Catalog Section — the feature directory: every setting_name ever used,
-        // with a short + detailed description, searchable independent of any active/history row.
-        .catalog-section.mb-4
-            h5.mb-2
-                i.bi.bi-journal-text.me-2
-                | Setting Catalog
-                small.text-muted.ms-2 (search by what a setting does, not just its name)
-            .input-group.mb-3(style="max-width: 500px;")
-                .input-group-prepend
-                    span.input-group-text
-                        i.bi.bi-search
-                input.form-control#catalogSearchInput(
-                    type="text",
-                    placeholder="Search setting name or description...",
-                    autocomplete="off"
-                )
-            .table-responsive
-                table.table.table-hover.table-sm#catalog-table
-                    thead.thead-light
-                        tr
-                            th(scope="col" style="width: 20%;") Setting Name
-                            th(scope="col" style="width: 25%;") Short Description
-                            th(scope="col") Detailed Description
-                            th(scope="col" style="width: 60px;") Actions
-                    tbody
-                        if settingCatalog && settingCatalog.length > 0
-                            each entry in settingCatalog
-                                tr
-                                    td
-                                        strong= entry.setting_name
-                                    td.small= entry.short_description || '—'
-                                    td.small.text-muted= entry.detailed_description || '—'
-                                    td
-                                        button.btn.btn-sm.btn-outline-secondary.edit-description-btn(
-                                            type="button",
-                                            data-setting-name=entry.setting_name,
-                                            data-toggle="modal",
-                                            data-target="#editDescriptionModal"
-                                        )
-                                            i.bi.bi-pencil
-                        else
-                            tr
-                                td(colspan="4").text-center.text-muted No settings found
 
         // Active Configs Section
         h5.mb-3
@@ -499,6 +459,55 @@ block content
                                 span.spinner-border.spinner-border-sm.me-2(style='display:none')
                                 | Update Config
 
+    // Setting Catalog Modal — the feature directory: every setting_name ever used,
+    // with a short + detailed description, searchable independent of any active/history row.
+    #settingCatalogModal.modal.fade(tabindex='-1')
+        .modal-dialog.modal-xl.modal-dialog-scrollable
+            .modal-content
+                .modal-header
+                    h5.modal-title
+                        i.bi.bi-journal-text.me-2
+                        | Setting Catalog
+                        small.text-muted.ms-2 (search by what a setting does, not just its name)
+                    button.btn-close(type='button' data-dismiss='modal' aria-label='Close')
+                .modal-body
+                    .input-group.mb-3
+                        .input-group-prepend
+                            span.input-group-text
+                                i.bi.bi-search
+                        input.form-control#catalogSearchInput(
+                            type="text",
+                            placeholder="Search setting name or description...",
+                            autocomplete="off"
+                        )
+                    .table-responsive
+                        table.table.table-hover.table-sm#catalog-table
+                            thead.thead-light.sticky-top
+                                tr
+                                    th(scope="col" style="width: 20%;") Setting Name
+                                    th(scope="col" style="width: 25%;") Short Description
+                                    th(scope="col") Detailed Description
+                                    th(scope="col" style="width: 60px;") Actions
+                            tbody
+                                if settingCatalog && settingCatalog.length > 0
+                                    each entry in settingCatalog
+                                        tr
+                                            td
+                                                strong= entry.setting_name
+                                            td.small= entry.short_description || '—'
+                                            td.small.text-muted= entry.detailed_description || '—'
+                                            td
+                                                button.btn.btn-sm.btn-outline-secondary.edit-description-btn(
+                                                    type="button",
+                                                    data-setting-name=entry.setting_name
+                                                )
+                                                    i.bi.bi-pencil
+                                else
+                                    tr
+                                        td(colspan="4").text-center.text-muted No settings found
+                .modal-footer
+                    button.btn.btn-outline-secondary(type='button' data-dismiss='modal') Close
+
     // Edit Description Modal (edits the catalog entry for a setting_name — not tied to any one row)
     #editDescriptionModal.modal.fade(tabindex='-1')
         .modal-dialog.modal-dialog-centered
@@ -549,6 +558,7 @@ block content
         const locationsData = !{locationsData};
         const settingCatalogData = !{settingCatalogData};
         const isSuperUser = !{isSuperUser};
+        let descriptionSaveSucceeded = false;
 
         // Page initialization
         $(document).ready(function() {
@@ -572,6 +582,15 @@ block content
 
             // Save description button
             $('#saveDescriptionBtn').on('click', handleSaveDescription);
+
+            // Reopen the catalog modal when the edit-description modal closes,
+            // unless it closed because the save succeeded (page is about to reload).
+            $('#editDescriptionModal').on('hidden.bs.modal', function() {
+                if (!descriptionSaveSucceeded) {
+                    $('#settingCatalogModal').modal('show');
+                }
+                descriptionSaveSucceeded = false;
+            });
 
             // Refresh button
             $('#refreshDataBtn').on('click', function() {
@@ -608,6 +627,13 @@ block content
             $('#descSettingDisplay').text(settingName);
             $('#descShortText').val(entry ? entry.short_description : '');
             $('#descDetailedText').val(entry ? entry.detailed_description : '');
+
+            // Bootstrap 4 doesn't stack modals cleanly — swap the catalog modal out
+            // for the edit modal, and swap back in when the edit modal closes.
+            $('#settingCatalogModal').modal('hide');
+            $('#settingCatalogModal').one('hidden.bs.modal', function() {
+                $('#editDescriptionModal').modal('show');
+            });
         }
 
         async function handleSaveDescription() {
@@ -636,6 +662,7 @@ block content
 
                 if (result.success) {
                     showAlert(result.message, 'success');
+                    descriptionSaveSucceeded = true;
                     $('#editDescriptionModal').modal('hide');
                     setTimeout(() => {
                         window.location.reload();

--- a/views/lubes-invoice-home.pug
+++ b/views/lubes-invoice-home.pug
@@ -174,8 +174,22 @@ block content
                         select#supplier_id.form-control.form-control-sm(name='supplier_id')
                             option(value='') All Suppliers
                             each supplier in suppliers
-                                option(value=supplier.supplier_id, 
+                                option(value=supplier.supplier_id,
                                     selected=selectedSupplierId == supplier.supplier_id)= supplier.supplier_name
+                    td &nbsp;
+                    td Type:
+                    td
+                        select#invoice_type.form-control.form-control-sm(name='invoice_type')
+                            option(value='' selected=selectedType == '') All Types
+                            option(value='FUEL' selected=selectedType == 'FUEL') Fuel
+                            option(value='LUBE' selected=selectedType == 'LUBE') Lube
+                    td &nbsp;
+                    td Fuel Category:
+                    td
+                        select#fuel_category.form-control.form-control-sm(name='fuel_category')
+                            option(value='' selected=selectedFuelCategory == '') All Fuel
+                            option(value='CNG' selected=selectedFuelCategory == 'CNG') CNG
+                            option(value='MS_HSD' selected=selectedFuelCategory == 'MS_HSD') MS / HSD
                     td &nbsp;
                     td
                         button.btn.btn-sm.btn-primary(type='submit') Go
@@ -221,7 +235,7 @@ block content
                             td= val.date
                             td
                                 if val.type === 'FUEL'
-                                    span.badge.badge-warning Fuel
+                                    span.badge.badge-warning= val.fuel_category === 'CNG' ? 'CNG' : 'Fuel (MS/HSD)'
                                 else
                                     span.badge.badge-info Lube
                             td.text-right= val.amount.toLocaleString('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })

--- a/views/lubes-invoice-home.pug
+++ b/views/lubes-invoice-home.pug
@@ -53,6 +53,14 @@ block content
             }
         }
 
+        function toggleFuelCategoryFilter() {
+            const show = document.getElementById('invoice_type').value === 'FUEL';
+            const display = show ? 'table-cell' : 'none';
+            document.getElementById('fuelCategorySpacer').style.display = display;
+            document.getElementById('fuelCategoryLabel').style.display = display;
+            document.getElementById('fuelCategoryField').style.display = display;
+        }
+
         function toggleInvoiceLines(invoiceId, button) {
             const lineContainer = document.getElementById(`invoice-lines-${invoiceId}`);
             const isExpanded = button.getAttribute('aria-expanded') === 'true';
@@ -146,29 +154,31 @@ block content
                             option(value='this_financial_year') This Financial Year
                             option(value='last_financial_year') Last Financial Year
                             option(value='custom', selected=true) Custom Date
-                    td &nbsp;                   
+                    td &nbsp;
                     td#fromDateLabel From Date:
                     td
                         input#invoice_fromDate.form-control.form-control-sm(
-                            type='date', 
-                            name='invoice_fromDate', 
-                            value=fromDate,                            
-                            format="dd/mm/yyyy",
-                            required,
-                            onChange="copyToHidden(this);"
-                        )
-                    td &nbsp;                   
-                    td#toDateLabel To Date:
-                    td
-                        input#invoice_toDate.form-control.form-control-sm(
-                            type='date', 
-                            name='invoice_toDate', 
-                            value=toDate,                             
+                            type='date',
+                            name='invoice_fromDate',
+                            value=fromDate,
                             format="dd/mm/yyyy",
                             required,
                             onChange="copyToHidden(this);"
                         )
                     td &nbsp;
+                    td#toDateLabel To Date:
+                    td
+                        input#invoice_toDate.form-control.form-control-sm(
+                            type='date',
+                            name='invoice_toDate',
+                            value=toDate,
+                            format="dd/mm/yyyy",
+                            required,
+                            onChange="copyToHidden(this);"
+                        )
+                tr
+                    td &nbsp;
+                tr
                     td Supplier:
                     td
                         select#supplier_id.form-control.form-control-sm(name='supplier_id')
@@ -179,13 +189,13 @@ block content
                     td &nbsp;
                     td Type:
                     td
-                        select#invoice_type.form-control.form-control-sm(name='invoice_type')
+                        select#invoice_type.form-control.form-control-sm(name='invoice_type' onchange='toggleFuelCategoryFilter()')
                             option(value='' selected=selectedType == '') All Types
                             option(value='FUEL' selected=selectedType == 'FUEL') Fuel
                             option(value='LUBE' selected=selectedType == 'LUBE') Lube
-                    td &nbsp;
-                    td Fuel Category:
-                    td
+                    td#fuelCategorySpacer(style=selectedType == 'FUEL' ? '' : 'display:none') &nbsp;
+                    td#fuelCategoryLabel(style=selectedType == 'FUEL' ? '' : 'display:none') Fuel Category:
+                    td#fuelCategoryField(style=selectedType == 'FUEL' ? '' : 'display:none')
                         select#fuel_category.form-control.form-control-sm(name='fuel_category')
                             option(value='' selected=selectedFuelCategory == '') All Fuel
                             option(value='CNG' selected=selectedFuelCategory == 'CNG') CNG

--- a/views/lubes-invoice-home.pug
+++ b/views/lubes-invoice-home.pug
@@ -59,6 +59,7 @@ block content
             document.getElementById('fuelCategorySpacer').style.display = display;
             document.getElementById('fuelCategoryLabel').style.display = display;
             document.getElementById('fuelCategoryField').style.display = display;
+            if (!show) document.getElementById('fuel_category').value = '';
         }
 
         function toggleInvoiceLines(invoiceId, button) {

--- a/views/lubes-invoice-home.pug
+++ b/views/lubes-invoice-home.pug
@@ -54,12 +54,14 @@ block content
         }
 
         function toggleFuelCategoryFilter() {
+            const fuelCategorySelect = document.getElementById('fuel_category');
+            if (!fuelCategorySelect) return; // location has no CNG product; filter isn't rendered
             const show = document.getElementById('invoice_type').value === 'FUEL';
             const display = show ? 'table-cell' : 'none';
             document.getElementById('fuelCategorySpacer').style.display = display;
             document.getElementById('fuelCategoryLabel').style.display = display;
             document.getElementById('fuelCategoryField').style.display = display;
-            if (!show) document.getElementById('fuel_category').value = '';
+            if (!show) fuelCategorySelect.value = '';
         }
 
         function toggleInvoiceLines(invoiceId, button) {
@@ -194,13 +196,14 @@ block content
                             option(value='' selected=selectedType == '') All Types
                             option(value='FUEL' selected=selectedType == 'FUEL') Fuel
                             option(value='LUBE' selected=selectedType == 'LUBE') Lube
-                    td#fuelCategorySpacer(style=selectedType == 'FUEL' ? '' : 'display:none') &nbsp;
-                    td#fuelCategoryLabel(style=selectedType == 'FUEL' ? '' : 'display:none') Fuel Category:
-                    td#fuelCategoryField(style=selectedType == 'FUEL' ? '' : 'display:none')
-                        select#fuel_category.form-control.form-control-sm(name='fuel_category')
-                            option(value='' selected=selectedFuelCategory == '') All Fuel
-                            option(value='CNG' selected=selectedFuelCategory == 'CNG') CNG
-                            option(value='MS_HSD' selected=selectedFuelCategory == 'MS_HSD') MS / HSD
+                    if hasCngProduct
+                        td#fuelCategorySpacer(style=selectedType == 'FUEL' ? '' : 'display:none') &nbsp;
+                        td#fuelCategoryLabel(style=selectedType == 'FUEL' ? '' : 'display:none') Fuel Category:
+                        td#fuelCategoryField(style=selectedType == 'FUEL' ? '' : 'display:none')
+                            select#fuel_category.form-control.form-control-sm(name='fuel_category')
+                                option(value='' selected=selectedFuelCategory == '') All Fuel
+                                option(value='CNG' selected=selectedFuelCategory == 'CNG') CNG
+                                option(value='MS_HSD' selected=selectedFuelCategory == 'MS_HSD') MS / HSD
                     td &nbsp;
                     td
                         button.btn.btn-sm.btn-primary(type='submit') Go

--- a/views/reports-bank-recon.pug
+++ b/views/reports-bank-recon.pug
@@ -996,14 +996,14 @@ block content
                     h5#impactModalLabel.modal-title
                         i.bi.bi-exclamation-triangle.me-2
                         | Delete Transaction - Impact Analysis
-                    button.btn-close.btn-close-white(type='button' data-bs-dismiss='modal' aria-label='Close')
+                    button.btn-close.btn-close-white(type='button' data-dismiss='modal' aria-label='Close')
                 .modal-body
                     #impactContent
                         .text-center.p-4
                             .spinner-border.text-primary(role='status')
                             p.mt-2 Loading impact analysis...
                 .modal-footer
-                    button.btn.btn-secondary(type='button' data-bs-dismiss='modal') Cancel
+                    button.btn.btn-secondary(type='button' data-dismiss='modal') Cancel
                     button#btnConfirmDelete.btn.btn-danger(type='button' disabled)
                         i.bi.bi-trash.me-1
                         | Confirm Delete
@@ -1015,7 +1015,7 @@ block content
                     h5#addEntryModalLabel.modal-title
                         i.bi.bi-plus-circle.me-2
                         | Add Entry to PetroMath
-                    button.btn-close.btn-close-white(type='button' data-bs-dismiss='modal' aria-label='Close')
+                    button.btn-close.btn-close-white(type='button' data-dismiss='modal' aria-label='Close')
                 .modal-body
                     form#addEntryForm
                         .row.g-3
@@ -1045,7 +1045,7 @@ block content
                                 label.form-label Remarks
                                 input#modal_remarks.form-control(type='text' maxlength='1000' placeholder='Optional remarks...')
                 .modal-footer
-                    button.btn.btn-secondary(type='button' data-bs-dismiss='modal') Cancel
+                    button.btn.btn-secondary(type='button' data-dismiss='modal') Cancel
                     button#btnSaveEntry.btn.btn-success(type='button' onclick='saveNewEntry()')
                         i.bi.bi-save.me-1
                         | Save Entry


### PR DESCRIPTION
## Summary
Bundles 11 PRs from PetroMath_dev_new that have been soaking on beta:

- #750 Add description catalog for location config settings
- #751 Hotfix: remove premature platform-billing model registration
- #752 Move Setting Catalog into a popup modal
- #753 Fix Cancel buttons in Bank Reconciliation modals
- #754 Add Type and Fuel Category filters to Purchase Invoice search
- #755 Remove failing petromath_dev_new pull from deploy workflow
- #756 Split invoice search filters into two rows; hide Fuel Category unless Type=Fuel
- #757 Set fuel_category on invoices saved via Tank Receipts upload flow
- #758 Fix: stale Fuel Category value silently suppressed Lube invoices
- #759 Only show Fuel Category filter for locations that carry a CNG product
- #760 Fix: Supplier filter ignored for Fuel-type invoices

## Prod DB migrations
Already run on prod (3.233.6.131) ahead of this PR, verified:
- `db/migrations/location-config-catalog.sql` — m_location_config_catalog table + 44 rows
- `db/migrations/fuel-invoice-category.sql` — t_tank_invoice.fuel_category column + backfill (827 MS_HSD, 105 CNG)
- `db/migrations/tank-invoice-time.sql` — t_tank_invoice.invoice_time column

## Test plan
- [ ] Merge this PR
- [ ] Deploy to prod app (SSH + git_pull_petro.sh + PM2 restart) when ready