### PR TITLE
Add discount capture to Lube Invoices; remove PDF upload option

### DIFF
--- a/controllers/lubes-invoice-controller.js
+++ b/controllers/lubes-invoice-controller.js
@@ -79,15 +79,15 @@ module.exports = {
             });
     },
     saveLubesInvoice: (req, res, next) => {
-        const { 
+        const {
             invoice_date, invoice_number, supplier_id, location_id, location_code,
-            invoice_amount, notes, items, lubes_hdr_id
+            invoice_amount, cash_discount, notes, items, lubes_hdr_id
         } = req.body;
-        
+
         const saveInvoice = async () => {
             try {
                 let headerData;
-                
+
                 if (lubes_hdr_id) {
                     // Update existing invoice
                     await LubesInvoiceHeader.update({
@@ -95,6 +95,7 @@ module.exports = {
                         invoice_number,
                         supplier_id,
                         invoice_amount,
+                        cash_discount: cash_discount || 0,
                         notes,
                         updated_by: req.user.Person_id,
                         updation_date: new Date()
@@ -102,9 +103,9 @@ module.exports = {
                         where: { lubes_hdr_id: lubes_hdr_id }
                     });
                     headerData = { lubes_hdr_id };
-                    
+
                     // Delete existing lines to replace with new ones
-                    await LubesInvoiceLine.destroy({ 
+                    await LubesInvoiceLine.destroy({
                         where: { lubes_hdr_id: lubes_hdr_id }
                     });
                 } else {
@@ -114,6 +115,7 @@ module.exports = {
                         invoice_number,
                         supplier_id,
                         invoice_amount,
+                        cash_discount: cash_discount || 0,
                         notes,
                         location_id,
                         location_code,
@@ -122,7 +124,7 @@ module.exports = {
                         creation_date: new Date()
                     });
                 }
-                
+
                 // Prepare and save line items
                 if (items && items.length > 0) {
                     const lineItems = items.map(item => ({
@@ -131,6 +133,7 @@ module.exports = {
                         qty: item.qty,
                         mrp: item.mrp || 0,
                         net_rate: item.net_rate || 0,
+                        discount_amount: item.discount_amount || 0,
                         amount: item.amount,
                         notes: item.notes,
                         created_by: req.user.Person_id,

--- a/dao/lubes-invoice-dao.js
+++ b/dao/lubes-invoice-dao.js
@@ -92,28 +92,30 @@ module.exports = {
                 }
             ],
             attributes: [
-                'lubes_line_id', 
-                'product_id', 
-                'qty', 
-                'amount', 
-                'mrp', 
-                'net_rate', 
+                'lubes_line_id',
+                'product_id',
+                'qty',
+                'amount',
+                'mrp',
+                'net_rate',
+                'discount_amount',
                 'notes'
             ]
         });
     },
-    
+
     saveLubesInvoiceLines: (data) => {
         const lines = LubesInvoiceLine.bulkCreate(data, {
             returning: true,
             updateOnDuplicate: [
-                "product_id", 
-                "qty", 
-                "mrp", 
-                "net_rate", 
-                "amount", 
-                "notes", 
-                "updated_by", 
+                "product_id",
+                "qty",
+                "mrp",
+                "net_rate",
+                "discount_amount",
+                "amount",
+                "notes",
+                "updated_by",
                 "updation_date"
             ]
         });

--- a/db/migrations/adblue-lube-product-flag.sql
+++ b/db/migrations/adblue-lube-product-flag.sql
@@ -1,0 +1,10 @@
+-- Data fix: MAK ADBLUE - LOOSE is a metered/tank product (is_tank_product=1) that is
+-- also purchased via lube invoices, same pattern as 2T LOOSE (is_tank_product=1 AND
+-- is_lube_product=1). It was missing is_lube_product=1, so it never appeared in the
+-- Lube Invoice product dropdown (which filters on is_lube_product=1).
+
+UPDATE m_product
+SET is_lube_product = 1
+WHERE product_name = 'MAK ADBLUE - LOOSE'
+  AND is_tank_product = 1
+  AND is_lube_product = 0;

--- a/db/migrations/lube-invoice-discount.sql
+++ b/db/migrations/lube-invoice-discount.sql
@@ -1,0 +1,11 @@
+-- Migration: Capture discounts on Lube Invoices
+-- Both BPCL and IOCL lube invoices show a two-tier discount: a per-line discount
+-- (reducing that line's taxable value) and a separate cash discount applied to the
+-- invoice total. Captured as absolute rupee amounts, matching how suppliers present
+-- them (not percentages).
+
+ALTER TABLE t_lubes_inv_lines
+    ADD COLUMN discount_amount DECIMAL(12,2) NULL DEFAULT 0 AFTER net_rate;
+
+ALTER TABLE t_lubes_inv_hdr
+    ADD COLUMN cash_discount DECIMAL(15,2) NULL DEFAULT 0 AFTER invoice_amount;

--- a/db/txn-lubes-header.js
+++ b/db/txn-lubes-header.js
@@ -25,6 +25,10 @@ module.exports = function(sequelize, DataTypes) {
             field: 'invoice_amount',
             type: DataTypes.DECIMAL(15, 2)
         },
+        cash_discount: {
+            field: 'cash_discount',
+            type: DataTypes.DECIMAL(15, 2)
+        },
         notes: {
             field: 'notes',
             type: DataTypes.STRING(300)

--- a/db/txn-lubes-lines.js
+++ b/db/txn-lubes-lines.js
@@ -37,6 +37,7 @@ module.exports = function(sequelize, DataTypes) {
             field: 'notes',
             type: DataTypes.STRING(300)
         },
+        discount_amount:      { field: 'discount_amount',      type: DataTypes.DECIMAL(12,2), allowNull: true },
         created_by: DataTypes.STRING,
         updated_by: DataTypes.STRING,
         creation_date: DataTypes.DATE,

--- a/public/javascripts/lubes-invoice.js
+++ b/public/javascripts/lubes-invoice.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const invoiceNumberInput = document.getElementById('invoice_number');
     const supplierSelect = document.getElementById('supplier_id');
     const invoiceDateInput = document.getElementById('invoice_date');
+    const cashDiscountInput = document.getElementById('cash_discount');
 
     // Store all suppliers with their effective dates
     let allSuppliers = [];
@@ -139,6 +140,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const mrpInput = row.querySelector('.mrp');
         const netRateInput = row.querySelector('.net-rate');
         const quantityInput = row.querySelector('.quantity');
+        const discountInput = row.querySelector('.discount');
         const amountInput = row.querySelector('.amount');
         const removeBtn = row.querySelector('.remove-row');
         
@@ -158,14 +160,15 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         }
         
-        // Calculate amount based on net rate and quantity
+        // Calculate amount based on net rate, quantity and discount
         function calculateAmount() {
             const netRate = parseFloat(netRateInput.value) || 0;
             const quantity = parseFloat(quantityInput.value) || 0;
-            
-            const calculatedAmount = netRate * quantity;
+            const discount = parseFloat(discountInput.value) || 0;
+
+            const calculatedAmount = (netRate * quantity) - discount;
             amountInput.value = calculatedAmount.toFixed(2);
-            
+
             calculateTotal();
         }
         
@@ -188,7 +191,12 @@ document.addEventListener('DOMContentLoaded', function() {
         if (quantityInput) {
             quantityInput.addEventListener('input', calculateAmount);
         }
-        
+
+        // Discount input event
+        if (discountInput) {
+            discountInput.addEventListener('input', calculateAmount);
+        }
+
         // Remove row button
         if (removeBtn) {
             removeBtn.addEventListener('click', function() {
@@ -226,6 +234,9 @@ document.addEventListener('DOMContentLoaded', function() {
                     <input class="form-control quantity" type="number" name="items[${rowCount}][qty]" step="0.01" min="0.01" required>
                 </td>
                 <td>
+                    <input class="form-control discount" type="number" name="items[${rowCount}][discount_amount]" step="0.01" min="0" value="0.00">
+                </td>
+                <td>
                     <input class="form-control amount" type="number" name="items[${rowCount}][amount]" readonly>
                 </td>
                 <td>
@@ -259,15 +270,22 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Calculate total invoice amount
     function calculateTotal() {
-        const total = [...itemsTable.querySelectorAll('.amount')]
+        const linesTotal = [...itemsTable.querySelectorAll('.amount')]
             .reduce((sum, input) => sum + (parseFloat(input.value) || 0), 0);
-        
+        const cashDiscount = cashDiscountInput ? (parseFloat(cashDiscountInput.value) || 0) : 0;
+        const total = linesTotal - cashDiscount;
+
         document.getElementById('invoice_amount').value = total.toFixed(2);
-        
+
         // Enable/disable close button based on total
         if (closeBtn) {
             closeBtn.disabled = total <= 0;
         }
+    }
+
+    // Cash discount input event
+    if (cashDiscountInput) {
+        cashDiscountInput.addEventListener('input', calculateTotal);
     }
 
     // Validate form before submission
@@ -351,15 +369,17 @@ document.addEventListener('DOMContentLoaded', function() {
                 const mrpInput = row.querySelector('.mrp');
                 const netRateInput = row.querySelector('.net-rate');
                 const quantityInput = row.querySelector('.quantity');
+                const discountInput = row.querySelector('.discount');
                 const amountInput = row.querySelector('.amount');
                 const notesInput = row.querySelector('.notes');
-                
+
                 if (productSelect && productSelect.value) {
                     items.push({
                         product_id: productSelect.value,
                         mrp: mrpInput.value,
                         net_rate: netRateInput.value,
                         qty: quantityInput.value,
+                        discount_amount: discountInput ? discountInput.value : 0,
                         amount: amountInput.value,
                         notes: notesInput ? notesInput.value : ''
                     });

--- a/views/lubes-invoice-home.pug
+++ b/views/lubes-invoice-home.pug
@@ -213,7 +213,6 @@ block content
                             button.btn.btn-sm.btn-primary.dropdown-toggle(type='button' data-toggle='dropdown') New Purchase
                             div.dropdown-menu
                                 a.dropdown-item(href='/purchases/fuel-invoice/new') Fuel Invoice
-                                a.dropdown-item(href='/lubes-invoice/upload') Lube Invoice (Upload PDF)
                                 a.dropdown-item(href='/lubes-invoice/new') Lube Invoice (Manual)
             
             input(type='hidden' id='invoice_fromDate_hiddenValue' name='invoice_fromDate_hiddenValue' value=fromDate)

--- a/views/lubes-invoice.pug
+++ b/views/lubes-invoice.pug
@@ -67,6 +67,7 @@ block content
                             th MRP
                             th Net Rate
                             th Quantity
+                            th Discount
                             th Amount
                             th Notes
                             th Action
@@ -109,18 +110,26 @@ block content
                                         )
                                     td
                                         input.form-control.quantity(
-                                            type='number' 
-                                            name=`items[${index}][qty]` 
-                                            step='0.01' 
-                                            min='0.01' 
-                                            value=line.qty 
+                                            type='number'
+                                            name=`items[${index}][qty]`
+                                            step='0.01'
+                                            min='0.01'
+                                            value=line.qty
                                             required
                                         )
                                     td
+                                        input.form-control.discount(
+                                            type='number'
+                                            name=`items[${index}][discount_amount]`
+                                            step='0.01'
+                                            min='0'
+                                            value=(line && line.discount_amount !== undefined) ? parseFloat(line.discount_amount).toFixed(2) : '0.00'
+                                        )
+                                    td
                                         input.form-control.amount(
-                                            type='number' 
-                                            name=`items[${index}][amount]` 
-                                            value=(line && line.amount !== undefined) ? parseFloat(line.amount).toFixed(2) : '0.00' 
+                                            type='number'
+                                            name=`items[${index}][amount]`
+                                            value=(line && line.amount !== undefined) ? parseFloat(line.amount).toFixed(2) : '0.00'
                                             readonly
                                         )
                                     td
@@ -161,16 +170,24 @@ block content
                                     )
                                 td
                                     input.form-control.quantity(
-                                        type='number' 
-                                        name='items[0][qty]' 
-                                        step='0.01' 
-                                        min='0.01' 
+                                        type='number'
+                                        name='items[0][qty]'
+                                        step='0.01'
+                                        min='0.01'
                                         required
                                     )
                                 td
+                                    input.form-control.discount(
+                                        type='number'
+                                        name='items[0][discount_amount]'
+                                        step='0.01'
+                                        min='0'
+                                        value='0.00'
+                                    )
+                                td
                                     input.form-control.amount(
-                                        type='number' 
-                                        name='items[0][amount]' 
+                                        type='number'
+                                        name='items[0][amount]'
                                         readonly
                                     )
                                 td
@@ -182,19 +199,29 @@ block content
                                     button.btn.btn-danger.remove-row(type='button') Remove
                 
                 div.row.mt-3
-                    div.col-md-4
+                    div.col-md-3
                         if(invoiceStatus != 'CLOSED')
                             button#add-row-btn.btn.btn-secondary(type='button') Add Row
-                    div.col-md-4
+                    div.col-md-3
                         div.form-group
                             label(for='notes') Notes
                             textarea#notes.form-control(name='notes' rows='2')=invoice ? invoice.notes : ''
-                    div.col-md-4
+                    div.col-md-3
+                        div.form-group
+                            label(for='cash_discount') Cash Discount
+                            input#cash_discount.form-control(
+                                type='number'
+                                name='cash_discount'
+                                step='0.01'
+                                min='0'
+                                value=(invoice && invoice.cash_discount !== undefined && invoice.cash_discount !== null) ? parseFloat(invoice.cash_discount).toFixed(2) : '0.00'
+                            )
+                    div.col-md-3
                         div.form-group
                             label.fw-bold Total Amount:
                             input#invoice_amount.form-control.fw-bold(
-                                type='number' 
-                                name='invoice_amount' 
+                                type='number'
+                                name='invoice_amount'
                                 readonly
                                 value=(invoice && invoice.invoice_amount !== undefined) ? parseFloat(invoice.invoice_amount).toFixed(2) : '0.00'
                             )


### PR DESCRIPTION
## Summary
- Removes "Lube Invoice (Upload PDF)" from the New Purchase menu (that flow is unfinished/abandoned)
- Adds discount capture to the Lube Invoice manual-entry form, matching how both BPCL and IOCL invoices present discounts:
  - **Line-level discount** (`t_lubes_inv_lines.discount_amount`): `amount = (net_rate * qty) - discount`
  - **Invoice-level cash discount** (`t_lubes_inv_hdr.cash_discount`): `invoice_amount = sum(line amounts) - cash_discount`
- Both captured as absolute rupee amounts (not %), matching the source invoices
- GST/tax capture is explicitly deferred to a separate pass (discussed separately)

## DB migration
`db/migrations/lube-invoice-discount.sql` — adds `discount_amount` to `t_lubes_inv_lines` and `cash_discount` to `t_lubes_inv_hdr`. Already run on dev DB and verified with a round-trip test (create/read/delete via the actual DAO functions).

## Test plan
- [ ] Open a new Lube Invoice, add a line, enter a discount, confirm Amount recomputes
- [ ] Enter a Cash Discount on the header, confirm Total Amount recomputes
- [ ] Save, reopen the invoice, confirm both discount values reload correctly
- [ ] Confirm "Lube Invoice (Upload PDF)" no longer appears in New Purchase menu