### PR TITLE
Fix customer credit statement PDF always rendering mobile layout

### DIFF
--- a/utils/app-pdf-generator.js
+++ b/utils/app-pdf-generator.js
@@ -166,8 +166,20 @@ module.exports = {
                                         tbody {
                                             display: table-row-group;
                                         }
-                                       
-                                       
+
+                                        /* PDFs always render the desktop layout, regardless of the
+                                           requesting device. page.pdf() lays out content using the
+                                           printed page's content-box width (A4 minus margins, ~754px),
+                                           which falls under Bootstrap's 768px 'md' breakpoint, so
+                                           d-md-* responsive toggles would otherwise resolve to mobile. */
+                                        .d-md-none {
+                                            display: none !important;
+                                        }
+                                        .d-none.d-md-block,
+                                        .d-md-block {
+                                            display: block !important;
+                                        }
+
                                     </style>
                                   `;
                                   
@@ -191,7 +203,7 @@ module.exports = {
         console.log(`Browser New page  generation took: ${pageend - browserend}ms`);
       //  await page.setContent(htmlContent);
      //   await page.waitForSelector('body'); // Wait for the body tag to ensure the page is loaded
-        
+
              // Set content with optimized options
              await page.setContent(htmlContent, {
                 waitUntil: 'domcontentloaded',


### PR DESCRIPTION
## Summary
- `page.pdf()` defaults to the print media type, laying out content at the printed page's content-box width (~754px after A4 margins) - just under Bootstrap's 768px `md` breakpoint.
- This caused the responsive `d-md-none`/`d-md-block` toggle in `reports-customer-facing.pug` to always resolve to the mobile card layout in the generated PDF, regardless of the customer's actual device.
- Forces the desktop table layout for all generated PDFs by overriding these classes in the CSS already injected before every PDF render, scoped only to PDF output (on-screen mobile browsing is unaffected).

## Test plan
- [ ] Log in as a Customer-role user, download the credit statement PDF from a desktop browser, confirm it shows the tabular desktop layout (not the mobile card view)
- [ ] Repeat the download from a mobile browser/device, confirm the PDF still shows the desktop table layout
- [ ] Spot-check another PDF report type (e.g. DSR) to confirm no visual regression from this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)