### PR TITLE
Trust nginx reverse proxy for real client IP

### DIFF
--- a/app.js
+++ b/app.js
@@ -196,6 +196,9 @@ const { log } = require('console');
 const deploymentConfig = "./config/app-deployment-" + process.env.ENVIRONMENT;
 const serverConfig = require(deploymentConfig);
 const app = express();
+// Trust exactly one hop (the nginx reverse proxy) so req.ip reflects the real
+// client IP from X-Forwarded-For instead of nginx's own loopback address.
+app.set('trust proxy', 1);
 security.secureApp(app);
 
 


### PR DESCRIPTION
## Summary
- Express was reading req.ip from the raw socket peer, which behind nginx's proxy_pass is always nginx's own loopback address - every login log entry showed ::ffff:127.0.0.1 regardless of the actual customer/staff device.
- Worse: the IP-keyed API login rate limiter (5 attempts / 5 min) was effectively shared across every user hitting /api/login combined, since they all looked like the same IP.
- nginx on beta already updated (separately, server-side, not in git) to forward X-Forwarded-For on the beta.petromath.co.in blocks (port 3001).
- app.set('trust proxy', 1) makes Express trust exactly one hop and read the real client IP from that header.

## Test plan
- [x] Verified on beta: nginx config backed up, updated, `nginx -t` passed, reloaded
- [ ] After merge, confirm a fresh beta login shows a real IP in t_login_logs (not 127.0.0.1)
- [ ] No regression to the API login rate limiter or the campaign-public controller's IP capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)