### PR TITLE
Trust nginx reverse proxy for real client IP

### DIFF
--- a/app.js
+++ b/app.js
@@ -196,6 +196,9 @@ const { log } = require('console');
 const deploymentConfig = "./config/app-deployment-" + process.env.ENVIRONMENT;
 const serverConfig = require(deploymentConfig);
 const app = express();
+// Trust exactly one hop (the nginx reverse proxy) so req.ip reflects the real
+// client IP from X-Forwarded-For instead of nginx's own loopback address.
+app.set('trust proxy', 1);
 security.secureApp(app);
 
 


### PR DESCRIPTION
## Summary
- Promotes the trust-proxy fix (verified on beta) to prod.
- app.set('trust proxy', 1) so Express reads the real client IP from X-Forwarded-For instead of nginx's loopback address.
- Prod nginx config already updated separately (server-side, not in git): added X-Real-IP ($remote_addr) and X-Forwarded-For ($http_cf_connecting_ip) headers to the petroMath site's proxy_pass block. Both prod and beta sit behind Cloudflare, so $http_cf_connecting_ip is the reliable source of the real visitor IP.

## Test plan
- [x] Verified end-to-end on beta: real login attempts (desktop curl + actual mobile device) now log the true client IP/IPv6 instead of 127.0.0.1 or a Cloudflare edge IP
- [ ] After merge + prod deploy, confirm a fresh prod login shows a real IP in t_login_logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)