### PR TITLE
Add SuperUser Preview As feature

### DIFF
--- a/app.js
+++ b/app.js
@@ -139,6 +139,7 @@ var CreditDao = require("./dao/credits-dao");
 const SupplierDao = require("./dao/supplier-dao");
 const LoginLogDao = require("./dao/login-log-dao");
 const LocationDao = require("./dao/location-dao");
+const MenuManagementDao = require("./dao/menu-management-dao");
 const { handleVersionRouting } = require('./utils/version-routing');
 
 db.sequelize.sync();
@@ -317,7 +318,10 @@ const bypassLoginInDev = async (req, res, next) => {
         const currentLocation = req.session.selectedLocation || "MUE";
         
         // Check if user needs to be created or location changed
-        if (!req.user || req.user.location_code !== currentLocation || req.session.menuCacheCleared) {
+        // (skip while a preview is active — its location_code intentionally differs
+        // from the session's real selectedLocation)
+        if (!req.session.previewOriginal &&
+            (!req.user || req.user.location_code !== currentLocation || req.session.menuCacheCleared)) {
             try {
                 const role = "SuperUser";
                 
@@ -357,9 +361,15 @@ const addUserLocationInfo = async (req, res, next) => {
     if (req.user && req.user.Person_id) {
         try {
             const personId = req.user.Person_id;
-            
-            // SuperUsers always get the location switcher (can access all locations)
-            if (req.user.Role === 'SuperUser') {
+            const isPreviewing = !!(req.session && req.session.previewOriginal);
+
+            if (isPreviewing) {
+                // Previewing as another role/location — the location switcher (which
+                // resolves against the real person's own access) doesn't apply here.
+                req.user.hasMultipleLocations = false;
+                req.user.availableLocations = [];
+            } else if (req.user.Role === 'SuperUser') {
+                // SuperUsers always get the location switcher (can access all locations)
                 req.user.hasMultipleLocations = true;
                 // Get all locations for SuperUsers
                 const allLocations = await LocationDao.findAllLocations();
@@ -372,11 +382,11 @@ const addUserLocationInfo = async (req, res, next) => {
             } else {
                 // Regular users: check their actual location access
                 const userLocations = await PersonDao.getUserAccessibleLocationsWithNames(personId);
-                
+
                 req.user.hasMultipleLocations = userLocations.length > 1;
                 req.user.availableLocations = userLocations;
             }
-            
+
         } catch (error) {
             console.error('Error adding user location info:', error);
             // Don't break the request - just set defaults
@@ -384,7 +394,7 @@ const addUserLocationInfo = async (req, res, next) => {
             req.user.availableLocations = [];
         }
     }
-    
+
     next();
 };
 
@@ -394,6 +404,8 @@ app.use(addDebugLogging);
 app.use((req, res, next) => {
     res.locals.APP_VERSION = process.env.APP_VERSION || 'stable';
     res.locals.SERVER_PORT = process.env.SERVER_PORT;
+    res.locals.isPreviewing = !!(req.session && req.session.previewOriginal);
+    res.locals.previewMeta = (req.session && req.session.previewMeta) || null;
     next();
 });
 
@@ -1752,6 +1764,110 @@ app.post('/select-location', isLoginEnsured, async function (req, res) {
     } catch (error) {
         console.error("Error processing location selection:", error);
         res.status(500).send("An error occurred while processing your request.");
+    }
+});
+
+// SuperUser "Preview As" — lets a SuperUser see the app exactly as another Role+Location
+// would (menu access and hasPermission checks are both Role+Location scoped, not per-person,
+// so this reproduces what a real user at that location sees without touching their account).
+// Allowed while already previewing too, so it can be used to switch target or to exit.
+function isSuperUserOrPreviewing(req, res, next) {
+    if ((req.user && req.user.Role === 'SuperUser') || (req.session && req.session.previewOriginal)) {
+        return next();
+    }
+    res.status(403).send('You do not have access to this page.');
+}
+
+app.get('/preview-as', isLoginEnsured, isSuperUserOrPreviewing, async function (req, res) {
+    try {
+        const allRoles = await MenuManagementDao.getAllRoles();
+        const roles = allRoles.filter(r => r.role_name !== 'SuperUser');
+        const locations = await LocationDao.findActiveLocations();
+
+        res.render('preview-as', {
+            title: 'Preview As',
+            roles: roles,
+            locations: locations,
+            isPreviewing: !!req.session.previewOriginal,
+            previewMeta: req.session.previewMeta || null
+        });
+    } catch (error) {
+        console.error("Error loading preview-as page:", error);
+        res.status(500).send("An error occurred while loading the preview page.");
+    }
+});
+
+app.post('/preview-as', isLoginEnsured, isSuperUserOrPreviewing, async function (req, res) {
+    try {
+        const { role, location } = req.body;
+
+        if (!role || !location) {
+            return res.status(400).send('Role and location are required.');
+        }
+        if (role === 'SuperUser') {
+            return res.status(400).send('Cannot preview as SuperUser.');
+        }
+
+        // Capture the real identity only once, so switching the preview target mid-preview
+        // doesn't overwrite it with a previously-previewed role/location.
+        if (!req.session.previewOriginal) {
+            req.session.previewOriginal = {
+                Role: req.user.Role,
+                location_code: req.user.location_code,
+                isAdmin: req.user.isAdmin,
+                allowedMenus: req.user.allowedMenus,
+                menuDetails: req.user.menuDetails,
+                service_tier: req.user.service_tier
+            };
+        }
+
+        const locationStatus = await LocationDao.isLocationActive(location);
+        const menus = await MenuAccessDao.getAllowedMenusForUser(role, location);
+
+        req.user.Role = role;
+        req.user.location_code = location;
+        req.user.isAdmin = security.isAdminChk({ Role: role });
+        req.user.allowedMenus = menus.map(m => m.menu_code);
+        req.user.menuDetails = menus;
+        req.user.service_tier = locationStatus.service_tier || 'standard';
+
+        req.session.previewMeta = {
+            role: role,
+            location: location,
+            startedAt: (req.session.previewMeta && req.session.previewMeta.startedAt) || new Date()
+        };
+
+        // req.user.User_Name/Person_id stay the real SuperUser's throughout preview, so
+        // existing route/login logging still attributes activity to them, not the target role.
+        console.log(`[PREVIEW] ${req.user.User_Name} previewing as role=${role} location=${location}`);
+
+        res.redirect('/home');
+    } catch (error) {
+        console.error("Error starting preview:", error);
+        res.status(500).send("An error occurred while starting preview.");
+    }
+});
+
+app.post('/preview-as/exit', isLoginEnsured, isSuperUserOrPreviewing, async function (req, res) {
+    try {
+        if (req.session.previewOriginal) {
+            const original = req.session.previewOriginal;
+            req.user.Role = original.Role;
+            req.user.location_code = original.location_code;
+            req.user.isAdmin = original.isAdmin;
+            req.user.allowedMenus = original.allowedMenus;
+            req.user.menuDetails = original.menuDetails;
+            req.user.service_tier = original.service_tier;
+
+            console.log(`[PREVIEW] ${req.user.User_Name} exited preview mode`);
+
+            delete req.session.previewOriginal;
+            delete req.session.previewMeta;
+        }
+        res.redirect('/home');
+    } catch (error) {
+        console.error("Error exiting preview:", error);
+        res.status(500).send("An error occurred while exiting preview.");
     }
 });
 

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -33,6 +33,19 @@ html
       style.
         @media (max-width: 1600px) { body { zoom: #{desktopZoom}; } }
 
+    if isPreviewing
+      style.
+        body { padding-top: 34px !important; }
+        .sidebar { top: 34px !important; height: calc(100% - 34px) !important; }
+        .preview-mode-banner {
+          position: fixed; top: 0; left: 0; right: 0; z-index: 2000;
+          height: 34px; display: flex; align-items: center; justify-content: center; gap: 12px;
+          background: #6f42c1; color: #fff; font-size: 0.85rem;
+        }
+        .preview-mode-banner a, .preview-mode-banner button {
+          color: #fff; text-decoration: underline; background: none; border: none; font-size: 0.85rem; padding: 0;
+        }
+
     style.
       @media print {
         table.table-bordered {
@@ -50,7 +63,15 @@ html
     - isFreezedRecord = true;
 
   body(onload='populateSummaryFn(' + isFreezedRecord +');')
-    
+
+    if isPreviewing && previewMeta
+      .preview-mode-banner
+        i.bi.bi-eye-fill
+        span Previewing as #{previewMeta.role} @ #{previewMeta.location}
+        a(href="/preview-as") Switch
+        form(method="POST" action="/preview-as/exit" style="display:inline;")
+          button(type="submit") Exit Preview
+
     if user
       div#ajax-loading.d-sm-none
         img#loading-image(src=`/images/ajax-loader.gif?v=${CACHE_BUST}`, alt="Loading...", width="300px", height="300px")
@@ -77,6 +98,11 @@ html
             if APP_VERSION === 'canary'
               br
               span(style='background-color: orange; color: white; font-size: 0.6rem; padding: 1px 3px; border-radius: 2px;') CANARY
+            if user.Role === 'SuperUser' && !isPreviewing
+              br
+              a(href="/preview-as" style="font-size: 0.8rem;")
+                i.bi.bi-eye.me-1
+                | Preview As...
 
         
         // Dynamic Menu Grouping Logic - Unified approach

--- a/views/preview-as.pug
+++ b/views/preview-as.pug
@@ -1,0 +1,52 @@
+extends layout
+
+block content
+    style.
+        .preview-container { max-width: 480px; margin: 40px auto; }
+        .preview-card { border-radius: 8px; }
+        .preview-card .card-header { background: #6f42c1; color: #fff; }
+        .preview-current { background: #fff3cd; border: 1px solid #ffe69c; border-radius: 6px; padding: 10px 14px; margin-bottom: 16px; font-size: 0.9rem; }
+
+    div.preview-container
+        div.card.preview-card.shadow-sm
+            div.card-header.py-3
+                h5.mb-0
+                    i.bi.bi-eye.me-2
+                    | Preview As
+            div.card-body.p-4
+                p.text-muted.mb-3 See the app exactly as a given Role at a given Location would see it — menu access and permissions are Role+Location scoped, so this matches what a real user there sees.
+
+                if isPreviewing && previewMeta
+                    div.preview-current
+                        i.bi.bi-info-circle.me-1
+                        | Currently previewing as
+                        strong &nbsp;#{previewMeta.role}&nbsp;
+                        | at
+                        strong &nbsp;#{previewMeta.location}
+                        form(method='POST' action='/preview-as/exit' style='display:inline; margin-left: 10px;')
+                            button.btn.btn-sm.btn-outline-secondary(type='submit') Exit Preview
+
+                form(method='POST' action='/preview-as')
+                    div.form-group.mb-3
+                        label.form-label.text-muted.fw-bold Role:
+                        select.form-control(name='role', required)
+                            option(value='') -- Select Role --
+                            each role in roles
+                                option(value=role.role_name, selected=previewMeta && previewMeta.role === role.role_name) #{role.role_display_name || role.role_name}
+
+                    div.form-group.mb-4
+                        label.form-label.text-muted.fw-bold Location:
+                        select.form-control(name='location', required)
+                            option(value='') -- Select Location --
+                            each location in locations
+                                option(value=location.location_code, selected=previewMeta && previewMeta.location === location.location_code) #{location.location_name} (#{location.location_code})
+
+                    div.row.g-2
+                        div.col-6
+                            button.btn.btn-primary.w-100(type='submit')
+                                i.bi.bi-eye.me-1
+                                | Preview
+                        div.col-6
+                            button.btn.btn-outline-secondary.w-100(type='button', onclick="window.location.href='/home'")
+                                i.bi.bi-x.me-1
+                                | Cancel


### PR DESCRIPTION
## Summary
- SuperUser-only "Preview As" flow (`/preview-as`): pick a Role + Location and the session's Role/location_code/menu access temporarily switch to match, since menu/permission checks are Role+Location scoped rather than per-person.
- Site-wide banner while previewing, with Switch and Exit Preview actions; exit fully restores the real SuperUser session.
- Fixes two things that would've fought this: the dev SKIP_LOGIN bypass resetting the session every request, and the location-switcher resolving against the real person's own access mid-preview.

## Why
Verifying menu-access changes (e.g. granting Digital Reconciliation to GAC2's Admin role) previously required either trusting the config or asking the actual user to check live. This lets a SuperUser confirm it directly.

## Test plan
- [ ] Log in as SuperUser, click "Preview As..." in the sidebar
- [ ] Preview as Admin @ GAC2, confirm Digital Reconciliation now appears in the sidebar
- [ ] Confirm the purple banner shows and "Exit Preview" restores the SuperUser sidebar/location
- [ ] Confirm a non-SuperUser hitting /preview-as directly gets a 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)