### PR TITLE
Fix Preview As link contrast in sidebar header

### DIFF
--- a/views/layout.pug
+++ b/views/layout.pug
@@ -100,7 +100,7 @@ html
               span(style='background-color: orange; color: white; font-size: 0.6rem; padding: 1px 3px; border-radius: 2px;') CANARY
             if user.Role === 'SuperUser' && !isPreviewing
               br
-              a(href="/preview-as" style="font-size: 0.8rem;")
+              a(href="/preview-as" title="Preview app as another Role/Location" style="font-size: 0.8rem; color: rgba(6, 6, 6, 0.75); text-decoration: underline;")
                 i.bi.bi-eye.me-1
                 | Preview As...
 


### PR DESCRIPTION
## Summary
- The "Preview As..." link added in #778 rendered in default anchor-blue, which is nearly invisible against both the yellow (prod) and blue/canary (beta) sidebar-header gradients.
- Switched to the same dark tone used by the surrounding "Logged in as" text, plus an underline so it still reads as clickable.

## Test plan
- [ ] Confirm "Preview As..." is visibly legible in the sidebar header on beta (blue background)
- [ ] Confirm it would also be legible on prod's yellow background (visual check, no prod deploy yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)