### PR TITLE
Fix missing rupee glyph in invoice PDF

### DIFF
--- a/views/platform-billing/invoice-print.pug
+++ b/views/platform-billing/invoice-print.pug
@@ -102,7 +102,7 @@ html(lang='en')
                 thead
                     tr
                         th Description
-                        th.amount Amount (₹)
+                        th.amount Amount (Rs.)
                 tbody
                     each it in invoice.items
                         tr
@@ -111,7 +111,7 @@ html(lang='en')
                 tfoot
                     tr
                         td Net Amount
-                        td.amount ₹#{Number(invoice.net_amount).toLocaleString('en-IN', {minimumFractionDigits: 2})}
+                        td.amount Rs. #{Number(invoice.net_amount).toLocaleString('en-IN', {minimumFractionDigits: 2})}
 
             .remittance-block
                 .remittance-label Remittance Details


### PR DESCRIPTION
## Summary
- The invoice PDF's rupee symbol (₹) rendered as a missing-glyph box on beta — verified directly on the server that none of the installed fonts (Arial/Liberation Sans/generic sans-serif) contain the U+20B9 glyph. Switched to plain "Rs." text, which has no font dependency.

## Test plan
- [ ] Download an invoice PDF on beta, confirm "Rs." now shows correctly instead of a box