### PR TITLE
Fix bowser closing quick-add vehicle not saving after duplicate warning

### DIFF
--- a/views/bowser/bowser-closing.pug
+++ b/views/bowser/bowser-closing.pug
@@ -700,7 +700,7 @@ block content
             $('#bowserQuickAddVehicleModal').modal('show');
         }
 
-        function quickSaveBowserVehicle() {
+        function quickSaveBowserVehicle(force) {
             if (!bc_quickAddContext) return;
 
             const vehicleNumber = document.getElementById('bowserQuickVehicleNumber').value.trim().toUpperCase();
@@ -721,12 +721,25 @@ block content
                 body: JSON.stringify({
                     creditlist_id: bc_quickAddContext.creditListId,
                     vehicle_number: vehicleNumber,
-                    vehicle_type: vehicleType
+                    vehicle_type: vehicleType,
+                    force: !!force
                 })
             })
             .then(async (response) => ({ ok: response.ok, data: await response.json() }))
             .then(({ ok, data }) => {
                 if (!ok || !data.success) {
+                    if (data.warning) {
+                        saveBtn.disabled = false;
+                        saveBtn.textContent = 'Add Vehicle';
+                        const proceed = confirm(
+                            (data.error || 'A similar vehicle already exists for this customer.') +
+                            `\n\nAre you sure "${vehicleNumber}" is a different vehicle? Click OK to add it anyway.`
+                        );
+                        if (proceed) {
+                            quickSaveBowserVehicle(true);
+                        }
+                        return;
+                    }
                     if ((data.error || '').includes('already exists')) {
                         document.getElementById('bowserQuickVehicleDupMsg').classList.remove('d-none');
                     } else {


### PR DESCRIPTION
## Summary
- Bowser closing has its own separate copy of the quick-add-vehicle JS, which was never updated when the credit-tab version added a similar-vehicle warning + confirm-to-force-save flow.
- It showed a bare alert on a warning and never sent `force`, so the vehicle was never actually saved.
- Mirrors the confirm()+retry-with-force pattern from the credit-tab implementation.

## Test plan
- [ ] On bowser closing credit tab, add a vehicle number similar to an existing one for that customer
- [ ] Confirm the warning dialog appears with OK/Cancel
- [ ] Click OK and confirm the vehicle is actually saved and selected in the dropdown
- [ ] Click Cancel and confirm nothing is saved