### PR TITLE
Add read-only Employee Ledger Report access for Manager role at SFS

### DIFF
--- a/controllers/employee-controller.js
+++ b/controllers/employee-controller.js
@@ -1,6 +1,7 @@
 const EmployeeDao     = require('../dao/employee-dao');
 const LookupDao       = require('../dao/lookup-dao');
 const DocumentStoreDao = require('../dao/document-store-dao');
+const RolePermissionsDao = require('../dao/role-permissions-dao');
 const { getLocationConfigValue } = require('../utils/location-config');
 const dateFormat      = require('dateformat');
 const db              = require('../db/db-connection');
@@ -360,12 +361,19 @@ module.exports.getReportPage = async (req, res) => {
                             .toISOString().slice(0, 10);
         const toDate   = today.toISOString().slice(0, 10);
 
+        // Report-only users (e.g. VIEW_EMPLOYEE_REPORT without VIEW_EMPLOYEE) don't have
+        // access to the full employee list page, so don't link the breadcrumb to it.
+        const canViewEmployeeList = await RolePermissionsDao.hasPermission(
+            req.user.Role, locationCode, 'VIEW_EMPLOYEE'
+        );
+
         res.render('employee/employee-report', {
             title:     'Employee Report',
             user:      req.user,
             employees: employees.map(e => ({ employee_id: e.employee_id, name: e.name, employee_code: e.employee_code })),
             fromDate,
-            toDate
+            toDate,
+            canViewEmployeeList
         });
     } catch (err) {
         console.error('employee getReportPage error:', err);

--- a/db/migrations/employee-ledger-report-manager-access.sql
+++ b/db/migrations/employee-ledger-report-manager-access.sql
@@ -1,0 +1,48 @@
+-- ============================================================
+-- Employee Ledger Report — read-only access for Manager role at SFS
+-- Owner request: SFS managers should be able to see employee balances
+-- (Statement + Spending Summary) without full employee master access
+-- (no add/edit/disable/ledger-entry/salary-generation rights).
+-- Safe to re-run: uses INSERT IGNORE / idempotent UPDATE throughout.
+-- ============================================================
+
+-- ── Permission: VIEW_EMPLOYEE_REPORT — read-only report access ────────────────
+-- Distinct from VIEW_EMPLOYEE (which also unlocks the full employee list/detail
+-- pages, where edit/ledger/salary buttons are shown based on isAdmin — Manager
+-- is already an admin role app-wide, so granting VIEW_EMPLOYEE there would
+-- surface edit controls that then 403 on click). Scoped to SFS only.
+-- can_reset_role_id is NOT NULL with no default; existing non-PASSWORD_RESET
+-- grants set it to the same value as role_id (see VIEW_EMPLOYEE rows for
+-- Admin/SuperUser) — following that established convention here.
+INSERT IGNORE INTO m_role_permissions
+    (role_id, can_reset_role_id, permission_type, location_specific, effective_start_date, effective_end_date, location_code)
+SELECT r.role_id, r.role_id, 'VIEW_EMPLOYEE_REPORT', 1, CURDATE(), '9999-12-31', 'SFS'
+FROM m_roles r WHERE r.role_name = 'Manager';
+
+-- ── Menu access — reuse the existing "Employee Report" menu item ──────────────
+-- (menu_code EMPLOYEE_REPORT, /employees/report, created 2026-03-27) rather than
+-- adding a duplicate. Manager/SFS only.
+INSERT IGNORE INTO m_menu_access_override
+    (role, location_code, menu_code, allowed, effective_start_date, effective_end_date, created_by)
+VALUES
+    ('Manager', 'SFS', 'EMPLOYEE_REPORT', 1, CURDATE(), '9999-12-31', 'system');
+
+-- ── Cleanup: remove the duplicate menu item this migration mistakenly created
+--    on its first run (EMPLOYEE_LEDGER_REPORT duplicated EMPLOYEE_REPORT) ─────
+DELETE FROM m_menu_access_override WHERE menu_code = 'EMPLOYEE_LEDGER_REPORT';
+DELETE FROM m_menu_items WHERE menu_code = 'EMPLOYEE_LEDGER_REPORT';
+
+-- ── Deactivate pre-existing Manager/SFS overrides that link to the full
+--    editable /employees screen (EMPLOYEES, EMPLOYEE_LEDGER menu codes) ───────
+-- Manager should only reach the read-only report, not the edit-capable
+-- master/ledger screen (those links currently 403 anyway since Manager lacks
+-- VIEW_EMPLOYEE, but leaving them live is misleading and a latent risk if
+-- VIEW_EMPLOYEE is ever granted to Manager for an unrelated reason later).
+UPDATE m_menu_access_override
+SET effective_end_date = CURDATE() - INTERVAL 1 DAY, updated_by = 'system'
+WHERE role = 'Manager' AND location_code = 'SFS' AND menu_code IN ('EMPLOYEES', 'EMPLOYEE_LEDGER')
+  AND (effective_end_date IS NULL OR effective_end_date >= CURDATE());
+
+CALL RefreshMenuCache();
+
+SELECT 'Employee Ledger Report access granted to Manager role at SFS (read-only, dedup + old links removed).' AS status;

--- a/routes/employee-routes.js
+++ b/routes/employee-routes.js
@@ -45,19 +45,23 @@ router.post('/',
 );
 
 // ── Report page ───────────────────────────────────────────────────────────────
+// Accepts VIEW_EMPLOYEE (full employee section) OR VIEW_EMPLOYEE_REPORT
+// (read-only report access, e.g. granted to Manager role at specific locations)
+const canViewReport = security.hasAnyPermission(['VIEW_EMPLOYEE', 'VIEW_EMPLOYEE_REPORT']);
+
 router.get('/report',
-    [isLoginEnsured, security.hasPermission('VIEW_EMPLOYEE')],
+    [isLoginEnsured, canViewReport],
     ctrl.getReportPage
 );
 
 // ── Report APIs ───────────────────────────────────────────────────────────────
 router.get('/api/report/statement',
-    [isLoginEnsured, security.hasPermission('VIEW_EMPLOYEE')],
+    [isLoginEnsured, canViewReport],
     ctrl.getStatementData
 );
 
 router.get('/api/report/summary',
-    [isLoginEnsured, security.hasPermission('VIEW_EMPLOYEE')],
+    [isLoginEnsured, canViewReport],
     ctrl.getSummaryData
 );
 

--- a/utils/app-security.js
+++ b/utils/app-security.js
@@ -62,7 +62,31 @@ module.exports = {
         };
     },
 
-    
+    // 🔹 Permission-based access — passes if the user has ANY of the given permissions
+    hasAnyPermission: (permissionTypes) => {
+        return async (req, res, next) => {
+            try {
+                const userRole = req.user?.Role;
+                const userLocation = req.user?.location_code;
+                if (!userRole || !userLocation) {
+                    return res.status(403).send('Access Denied: Invalid user session.');
+                }
+                for (const permissionType of permissionTypes) {
+                    const hasPermission = await rolePermissionsDao.hasPermission(
+                        userRole,
+                        userLocation,
+                        permissionType
+                    );
+                    if (hasPermission) return next();
+                }
+                res.status(403).send(`Access Denied: You do not have permission for ${permissionTypes.join(' or ')}.`);
+            } catch (error) {
+                console.error(`Error checking permissions ${permissionTypes.join(', ')}:`, error);
+                res.status(500).send('Internal server error while checking permissions.');
+            }
+        };
+    },
+
    // 🔹 Global app hardening middleware
     secureApp: (app) => {
         // Hide Express fingerprint

--- a/views/employee/employee-report.pug
+++ b/views/employee/employee-report.pug
@@ -9,7 +9,10 @@ block content
                     | Employee Report
                 nav(aria-label="breadcrumb")
                     ol.breadcrumb.mb-0
-                        li.breadcrumb-item: a(href="/employees") Employees
+                        if canViewEmployeeList
+                            li.breadcrumb-item: a(href="/employees") Employees
+                        else
+                            li.breadcrumb-item Employees
                         li.breadcrumb-item.active Employee Report
 
         //- ── Tabs ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- SFS owner requested managers be able to view employee balances (ledger) without full employee master edit access.
- Adds a new `VIEW_EMPLOYEE_REPORT` permission, distinct from `VIEW_EMPLOYEE` (which also gates the editable employee list/detail pages), granted to the Manager role scoped to SFS only.
- `/employees/report` and its two APIs now accept either `VIEW_EMPLOYEE` or `VIEW_EMPLOYEE_REPORT`.
- Report breadcrumb no longer links to the full employee list for report-only users (avoids a 403).
- Migration `db/migrations/employee-ledger-report-manager-access.sql` also removes two stale Manager/SFS menu overrides that pointed at the editable `/employees` screen, and dedupes against the pre-existing `EMPLOYEE_REPORT` menu item instead of creating a new one.
- Already run and verified against the dev DB.

## Test plan
- [ ] Log in as a Manager at SFS, confirm "Employee Report" menu entry appears and loads Statement/Summary tabs
- [ ] Confirm Manager cannot reach `/employees` (full list) or edit/add-ledger actions
- [ ] Confirm Admin/SuperUser employee list/detail/report pages still work unchanged

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>