### PR TITLE
GL accounting: explicit Static ledger mapping + review screen

### DIFF
--- a/db/migrations/gl-static-ledger-map-menu.sql
+++ b/db/migrations/gl-static-ledger-map-menu.sql
@@ -1,0 +1,22 @@
+-- ============================================================
+-- Static Ledger Map — Menu Item & Access
+-- Generated: 2026-08-15
+--
+-- Adds the Static Ledger Map review screen under the ACCOUNTING group.
+-- ============================================================
+
+INSERT INTO m_menu_items
+    (menu_code, menu_name, icon, url_path, parent_code, sequence, effective_start_date, created_by, updated_by, group_code)
+VALUES
+    ('GL_STATIC_LEDGER_MAP', 'Static Ledger Map', 'bi-signpost-split', '/gl/static-ledger-map', NULL, 11, '2026-08-15', 'ADMIN', 'ADMIN', 'ACCOUNTING');
+
+INSERT INTO m_menu_access_global
+    (role, menu_code, allowed, effective_start_date, created_by, updated_by)
+VALUES
+    ('SuperUser', 'GL_STATIC_LEDGER_MAP', 1, '2026-08-15', 'ADMIN', 'ADMIN');
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SELECT menu_code, menu_name, sequence, group_code
+FROM m_menu_items
+WHERE group_code = 'ACCOUNTING'
+ORDER BY sequence;

--- a/db/migrations/gl-static-ledger-map.sql
+++ b/db/migrations/gl-static-ledger-map.sql
@@ -1,0 +1,89 @@
+-- ============================================================
+-- GL Accounting: explicit mapping for Static bank/SOA ledger labels
+-- Generated: 2026-08-15
+--
+-- Replaces exact-name matching between t_bank_transaction.ledger_name
+-- (a free-text label a user typed into the bank-reconciliation "ledger
+-- rules" screen — a feature that predates the GL engine) and gl_ledgers.
+-- Name-matching is fragile: two different users can create differently
+-- named Static labels for the same real ledger, or a label can drift
+-- from / coincidentally collide with an unrelated GL ledger name, and
+-- nothing would catch it before money posts to the wrong place.
+--
+-- gl_static_ledger_map makes the mapping an explicit, reviewed decision
+-- instead: many Static labels -> one GL ledger is fine (enforced by
+-- gl_ledger_id having no uniqueness constraint), the reverse is not
+-- (enforced by the UNIQUE(location_code, ledger_name) key — one label
+-- always means exactly one thing). Unreviewed labels never block
+-- processing and never guess — they post to a visible per-location
+-- "Unclassified Bank Transaction" ledger until reviewed.
+-- ============================================================
+
+
+-- ── Step 1: Mapping table ──────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS gl_static_ledger_map (
+    map_id          INT NOT NULL AUTO_INCREMENT,
+    location_code   VARCHAR(50)  NOT NULL,
+    ledger_name     VARCHAR(250) NOT NULL COMMENT 'The Static label as it appears in t_bank_transaction.ledger_name',
+    treatment       ENUM('POST', 'SKIP') NULL COMMENT 'NULL = not yet reviewed',
+    gl_ledger_id    INT NULL COMMENT 'Required when treatment=POST',
+    skip_reason     VARCHAR(255) NULL COMMENT 'Required when treatment=SKIP, e.g. "Duplicate of TANK_INVOICE purchase — SOA mirror line"',
+    created_by      VARCHAR(45),
+    updated_by      VARCHAR(45),
+    creation_date   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updation_date   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (map_id),
+    UNIQUE KEY uq_gl_static_ledger_map (location_code, ledger_name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+
+-- ── Step 2: "Unclassified Bank Transaction" fallback ledger per location ──────
+-- Only for locations that already have GL set up. Safe to re-run.
+
+INSERT INTO gl_ledgers (location_code, ledger_name, group_id, source_type, active_flag, created_by, updated_by)
+SELECT DISTINCT loc.location_code, 'Unclassified Bank Transaction', g.group_id, 'STATIC', 'Y', 'MIGRATION', 'MIGRATION'
+FROM (SELECT DISTINCT location_code FROM gl_ledgers) loc
+JOIN gl_ledger_groups g ON g.location_code = loc.location_code AND g.group_name = 'Suspense A/c'
+WHERE NOT EXISTS (
+    SELECT 1 FROM gl_ledgers x WHERE x.location_code = loc.location_code AND x.ledger_name = 'Unclassified Bank Transaction'
+);
+
+
+-- ── Step 3: Seed the map with every distinct Static label already in use ─────
+-- Unreviewed (treatment=NULL) by default — gives whoever reviews this a
+-- concrete checklist instead of a blank table. Covers both the main
+-- transaction table and split legs, since either can carry a Static label.
+
+INSERT IGNORE INTO gl_static_ledger_map (location_code, ledger_name, created_by, updated_by)
+SELECT DISTINCT mb.location_code, tbt.ledger_name, 'MIGRATION', 'MIGRATION'
+FROM t_bank_transaction tbt
+JOIN m_bank mb ON mb.bank_id = tbt.bank_id
+WHERE tbt.ledger_name IS NOT NULL
+  AND (LOWER(tbt.external_source) = 'static' OR tbt.external_source IS NULL)
+  AND tbt.ledger_name <> 'Others';
+
+INSERT IGNORE INTO gl_static_ledger_map (location_code, ledger_name, created_by, updated_by)
+SELECT DISTINCT mb.location_code, tbs.ledger_name, 'MIGRATION', 'MIGRATION'
+FROM t_bank_transaction_splits tbs
+JOIN t_bank_transaction tbt ON tbt.t_bank_id = tbs.t_bank_id
+JOIN m_bank mb ON mb.bank_id = tbt.bank_id
+WHERE tbs.ledger_name IS NOT NULL
+  AND LOWER(tbs.external_source) = 'static';
+
+
+-- ── Step 4: SFS — pre-reviewed during this session, confirmed against real data ─
+-- Both are SOA invoice-debit mirrors of tank invoices already journaled via
+-- TANK_INVOICE (dates/amounts checked to match exactly) — correctly SKIP.
+
+UPDATE gl_static_ledger_map
+SET treatment = 'SKIP',
+    skip_reason = 'Duplicate of TANK_INVOICE purchase — BPCL SOA mirror line, amounts/dates confirmed matching real tank invoices',
+    updated_by = 'ADMIN'
+WHERE location_code = 'SFS' AND ledger_name IN ('PURCHASE DIESEL', 'PURCHASE OTHERS');
+
+
+-- ── Verify ──────────────────────────────────────────────────────────────────
+SELECT location_code, ledger_name, treatment, skip_reason
+FROM gl_static_ledger_map
+ORDER BY location_code, (treatment IS NULL) DESC, ledger_name;

--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -1005,6 +1005,99 @@ router.put('/api/ledger/:id', [isLoginEnsured, security.isAdmin()], async functi
     }
 });
 
+// ── Static Ledger Map ───────────────────────────────────────────────────────
+// GET /gl/static-ledger-map
+// Review screen for Static bank/SOA ledger_name labels (see resolveStaticLedger
+// in create-accounting-service.js) — an accountant marks each label POST
+// (pick the real GL ledger) or SKIP (with a reason), instead of the engine
+// guessing off an exact-name match.
+
+router.get('/static-ledger-map', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    try {
+        const [rows, ledgers] = await Promise.all([
+            db.sequelize.query(`
+                SELECT m.map_id, m.ledger_name, m.treatment, m.gl_ledger_id, m.skip_reason,
+                       m.updated_by, m.updation_date,
+                       l.ledger_name AS target_ledger_name,
+                       g.group_name  AS target_group_name,
+                       (SELECT COUNT(*) FROM t_bank_transaction tbt
+                          JOIN m_bank mb ON mb.bank_id = tbt.bank_id
+                         WHERE mb.location_code = m.location_code
+                           AND tbt.ledger_name = m.ledger_name) AS txn_count,
+                       (SELECT MAX(tbt.trans_date) FROM t_bank_transaction tbt
+                          JOIN m_bank mb ON mb.bank_id = tbt.bank_id
+                         WHERE mb.location_code = m.location_code
+                           AND tbt.ledger_name = m.ledger_name) AS last_txn_date
+                FROM gl_static_ledger_map m
+                LEFT JOIN gl_ledgers l ON l.ledger_id = m.gl_ledger_id
+                LEFT JOIN gl_ledger_groups g ON g.group_id = l.group_id
+                WHERE m.location_code = :locationCode
+                ORDER BY (m.treatment IS NULL) DESC, txn_count DESC, m.ledger_name
+            `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT }),
+            db.sequelize.query(`
+                SELECT l.ledger_id, l.ledger_name, g.group_name
+                FROM gl_ledgers l
+                JOIN gl_ledger_groups g ON g.group_id = l.group_id
+                WHERE l.location_code = :locationCode AND l.active_flag = 'Y'
+                ORDER BY l.ledger_name
+            `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT })
+        ]);
+
+        res.render('gl-static-ledger-map', {
+            title:  'Static Ledger Map',
+            user:   req.user,
+            config: require('../config/app-config').APP_CONFIGS,
+            rows,
+            ledgers,
+            messages: req.flash()
+        });
+    } catch (err) {
+        console.error('Static ledger map error:', err);
+        req.flash('error', err.message);
+        res.redirect('/gl/control');
+    }
+});
+
+router.put('/api/static-ledger-map/:id', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const mapId = parseInt(req.params.id);
+    const { treatment, gl_ledger_id, skip_reason } = req.body;
+    const user = req.user.username || String(req.user.Person_id);
+
+    if (treatment !== 'POST' && treatment !== 'SKIP') {
+        return res.status(400).json({ success: false, error: "treatment must be 'POST' or 'SKIP'" });
+    }
+    if (treatment === 'POST' && !gl_ledger_id) {
+        return res.status(400).json({ success: false, error: 'gl_ledger_id is required when treatment=POST' });
+    }
+    if (treatment === 'SKIP' && !skip_reason?.trim()) {
+        return res.status(400).json({ success: false, error: 'skip_reason is required when treatment=SKIP' });
+    }
+
+    try {
+        await db.sequelize.query(`
+            UPDATE gl_static_ledger_map
+            SET treatment    = :treatment,
+                gl_ledger_id = :gl_ledger_id,
+                skip_reason  = :skip_reason,
+                updated_by   = :user
+            WHERE map_id = :mapId AND location_code = :locationCode
+        `, {
+            replacements: {
+                mapId, locationCode, treatment, user,
+                gl_ledger_id: treatment === 'POST' ? parseInt(gl_ledger_id) : null,
+                skip_reason:  treatment === 'SKIP' ? skip_reason.trim() : null
+            },
+            type: db.Sequelize.QueryTypes.UPDATE
+        });
+        res.json({ success: true });
+    } catch (err) {
+        console.error('Static ledger map update error:', err);
+        res.status(500).json({ success: false, error: err.message });
+    }
+});
+
 // ── Tally Import ──────────────────────────────────────────────────────────────
 // GET  /gl/tally-import  — upload page
 // POST /gl/tally-import  — parse file, return reconcile data as JSON

--- a/services/create-accounting-service.js
+++ b/services/create-accounting-service.js
@@ -1375,14 +1375,12 @@ async function resolveCounterpartLedger(txn, locationCode, eventId, processedBy)
     const external_source = txn.external_source ? txn.external_source.toLowerCase() : null;
 
     if (external_source === 'static' || (!external_source && ledger_name)) {
-        const info = await resolveLedgerByName(locationCode, ledger_name);
-        if (!info) throw new Error(`GL ledger '${ledger_name}' not found for location ${locationCode}`);
-        if (info.group_name === 'Purchase Accounts') {
-            // Purchase invoices are journaled by the PURCHASE_INVOICE handler — skip here
+        const { treatment, ledgerId } = await resolveStaticLedger(locationCode, ledger_name);
+        if (treatment === 'SKIP') {
             await markEventProcessed(eventId, null, processedBy);
             return null;
         }
-        return info.ledger_id;
+        return ledgerId;
     }
 
     if (external_source === 'credit') {
@@ -1447,9 +1445,12 @@ async function resolveSplitCounterLedger(split, locationCode) {
     const errCtx = `split_id=${split_id}`;
 
     if (external_source === 'Static') {
-        const info = await resolveLedgerByName(locationCode, ledger_name);
-        if (!info) throw new Error(`Static GL ledger '${ledger_name}' not found for ${errCtx}`);
-        return info.ledger_id;
+        // allowSkip=false — a split leg is one piece of a multi-line voucher that
+        // must balance against the bank total, so it can never be silently
+        // dropped the way a whole (non-split) transaction can; a SKIP-mapped
+        // label still lands in Unclassified here instead.
+        const { ledgerId } = await resolveStaticLedger(locationCode, ledger_name, false);
+        return ledgerId;
     }
     if (external_source === 'Credit') {
         const id = await resolveLedger(locationCode, 'CREDIT', external_id);
@@ -1650,6 +1651,44 @@ async function resolveLedgerByName(locationCode, ledgerName) {
         type: QueryTypes.SELECT
     });
     return rows[0] || null;
+}
+
+// Resolves a Static (free-text) bank-transaction ledger_name via the explicit
+// gl_static_ledger_map — deliberately does NOT match ledger_name against
+// gl_ledgers by name. These labels are typed by whoever sets up a bank
+// "ledger rule" (a feature that predates the GL engine), so two labels can
+// mean the same real ledger, or a label can coincidentally collide with an
+// unrelated GL ledger name — exact-name matching would silently post to the
+// wrong place with no review. Unmapped/unreviewed labels never block and
+// never guess: they land in "Unclassified Bank Transaction" until reviewed.
+// allowSkip=false (used for split legs) treats a SKIP-mapped label as
+// Unclassified instead, since one leg of a split can't be silently dropped
+// without unbalancing the voucher.
+async function resolveStaticLedger(locationCode, ledgerName, allowSkip = true) {
+    const rows = await db.sequelize.query(`
+        SELECT treatment, gl_ledger_id FROM gl_static_ledger_map
+        WHERE location_code = :locationCode AND ledger_name = :ledgerName
+        LIMIT 1
+    `, { replacements: { locationCode, ledgerName }, type: QueryTypes.SELECT });
+
+    let mapped = rows[0];
+    if (!mapped) {
+        // Never-seen-before label — register it (unreviewed) so it shows up
+        // on the review screen going forward, not just for labels present
+        // at migration time. INSERT IGNORE handles the race safely since
+        // (location_code, ledger_name) is unique.
+        await db.sequelize.query(`
+            INSERT IGNORE INTO gl_static_ledger_map (location_code, ledger_name, created_by, updated_by)
+            VALUES (:locationCode, :ledgerName, 'ENGINE', 'ENGINE')
+        `, { replacements: { locationCode, ledgerName }, type: QueryTypes.INSERT });
+        mapped = null;
+    }
+    if (allowSkip && mapped?.treatment === 'SKIP') return { treatment: 'SKIP', ledgerId: null };
+    if (mapped?.treatment === 'POST' && mapped.gl_ledger_id) return { treatment: 'POST', ledgerId: mapped.gl_ledger_id };
+
+    const fallback = await resolveLedgerByName(locationCode, 'Unclassified Bank Transaction');
+    if (!fallback) throw new Error(`No 'Unclassified Bank Transaction' ledger set up for location ${locationCode} — run db/migrations/gl-static-ledger-map.sql`);
+    return { treatment: 'POST', ledgerId: fallback.ledger_id };
 }
 
 async function resolveCashLedger(locationCode) {

--- a/views/gl-static-ledger-map.pug
+++ b/views/gl-static-ledger-map.pug
@@ -1,0 +1,153 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        h4.mb-1 Static Ledger Map
+        p.text-muted.small.mb-3
+            | Bank/SOA transactions categorized with a free-text "Static" label (set on the
+            strong  Ledger Rules
+            |  screen) resolve here instead of matching against Ledgers by name. Review each label once —
+            strong  Post
+            |  it to the real GL ledger, or
+            strong  Skip
+            |  it if it's already covered elsewhere (e.g. a purchase invoice that also appears on the oil-company SOA). Unreviewed labels post to
+            code Unclassified Bank Transaction
+            |  until you decide.
+
+        if messages && messages.error && messages.error.length
+            .alert.alert-danger.py-2= messages.error[0]
+
+        - const unreviewed = rows.filter(r => !r.treatment)
+        - const reviewed = rows.filter(r => r.treatment)
+
+        if unreviewed.length
+            .alert.alert-warning.py-2.small.mb-3
+                i.bi.bi-exclamation-triangle.mr-1
+                strong= unreviewed.length
+                |  label(s) not yet reviewed — posting to Unclassified Bank Transaction in the meantime.
+
+        .table-responsive
+            table.table.table-sm.table-bordered.table-hover
+                thead.thead-light
+                    tr
+                        th Label (from Ledger Rules)
+                        th.text-center(style="width:90px") Txns
+                        th.text-center(style="width:110px") Last Seen
+                        th.text-center(style="width:100px") Status
+                        th Resolution
+                        th.text-center(style="width:80px")
+                tbody
+                    each r in unreviewed.concat(reviewed)
+                        tr(class=(!r.treatment ? 'table-warning' : ''))
+                            td.small= r.ledger_name
+                            td.text-center.small= r.txn_count
+                            td.text-center.small= r.last_txn_date ? r.last_txn_date.toISOString().substring(0,10) : '—'
+                            td.text-center
+                                if r.treatment === 'POST'
+                                    span.badge.badge-success Post
+                                else if r.treatment === 'SKIP'
+                                    span.badge.badge-secondary Skip
+                                else
+                                    span.badge.badge-warning Unreviewed
+                            td.small
+                                if r.treatment === 'POST'
+                                    span= r.target_ledger_name
+                                    span.text-muted  (#{r.target_group_name})
+                                else if r.treatment === 'SKIP'
+                                    span.text-muted.font-italic= r.skip_reason
+                                else
+                                    span.text-muted.font-italic → Unclassified Bank Transaction (temporary)
+                            td.text-center
+                                button.btn.btn-outline-primary.btn-sm.btn-edit-map(
+                                    data-id=r.map_id
+                                    data-name=r.ledger_name
+                                    data-treatment=r.treatment || ''
+                                    data-ledger=r.gl_ledger_id || ''
+                                    data-reason=r.skip_reason || ''
+                                    title="Review")
+                                    i.bi.bi-pencil
+
+    //- ── Modal ────────────────────────────────────────────────────────────────
+    .modal.fade#mapModal(tabindex="-1")
+        .modal-dialog
+            .modal-content
+                .modal-header
+                    h5.modal-title Review Label
+                    button.close(data-dismiss="modal" aria-label="Close")
+                        span &times;
+                .modal-body
+                    p.small.mb-3
+                        | Label:
+                        strong.ml-1#mLabelName
+
+                    .form-group
+                        .form-check.form-check-inline
+                            input.form-check-input#mTreatmentPost(type="radio" name="mTreatment" value="POST")
+                            label.form-check-label.small(for="mTreatmentPost") Post to a ledger
+                        .form-check.form-check-inline
+                            input.form-check-input#mTreatmentSkip(type="radio" name="mTreatment" value="SKIP")
+                            label.form-check-label.small(for="mTreatmentSkip") Skip (already covered elsewhere)
+
+                    .form-group#mPostFields
+                        label.small Target Ledger *
+                        select.form-control.form-control-sm#mLedger
+                            option(value="") — select —
+                            each l in ledgers
+                                option(value=l.ledger_id data-group=l.group_name)= l.ledger_name + ' (' + l.group_name + ')'
+
+                    .form-group#mSkipFields(style="display:none")
+                        label.small Reason *
+                        textarea.form-control.form-control-sm#mReason(rows="2" placeholder="e.g. Duplicate of TANK_INVOICE purchase — SOA mirror line")
+
+                .modal-footer
+                    button.btn.btn-secondary.btn-sm(data-dismiss="modal") Cancel
+                    button.btn.btn-primary.btn-sm#btnSaveMap Save
+
+    script.
+        let editingMapId = null;
+
+        function showTreatmentFields(treatment) {
+            document.getElementById('mPostFields').style.display = treatment === 'POST' ? '' : 'none';
+            document.getElementById('mSkipFields').style.display = treatment === 'SKIP' ? '' : 'none';
+        }
+        document.getElementById('mTreatmentPost').addEventListener('change', function() { showTreatmentFields('POST'); });
+        document.getElementById('mTreatmentSkip').addEventListener('change', function() { showTreatmentFields('SKIP'); });
+
+        document.querySelectorAll('.btn-edit-map').forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                editingMapId = this.dataset.id;
+                document.getElementById('mLabelName').textContent = this.dataset.name;
+                const treatment = this.dataset.treatment || 'POST';
+                document.getElementById('mTreatmentPost').checked = treatment !== 'SKIP';
+                document.getElementById('mTreatmentSkip').checked = treatment === 'SKIP';
+                document.getElementById('mLedger').value = this.dataset.ledger || '';
+                document.getElementById('mReason').value = this.dataset.reason || '';
+                showTreatmentFields(treatment === 'SKIP' ? 'SKIP' : 'POST');
+                $('#mapModal').modal('show');
+                setTimeout(function() {
+                    $('#mLedger').select2({ width: '100%', dropdownParent: $('#mapModal') });
+                }, 50);
+            });
+        });
+
+        document.getElementById('btnSaveMap').addEventListener('click', async function() {
+            const treatment = document.querySelector('input[name="mTreatment"]:checked').value;
+            const gl_ledger_id = document.getElementById('mLedger').value;
+            const skip_reason = document.getElementById('mReason').value.trim();
+
+            if (treatment === 'POST' && !gl_ledger_id) { alert('Select a target ledger.'); return; }
+            if (treatment === 'SKIP' && !skip_reason) { alert('Enter a reason.'); return; }
+
+            this.disabled = true;
+            try {
+                const resp = await fetch('/gl/api/static-ledger-map/' + editingMapId, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ treatment, gl_ledger_id, skip_reason })
+                });
+                const data = await resp.json();
+                if (data.success) { location.reload(); } else { alert('Error: ' + data.error); this.disabled = false; }
+            } catch (e) { alert('Network error.'); this.disabled = false; }
+        });


### PR DESCRIPTION
## Summary
- New `gl_static_ledger_map` table replaces exact-name matching between `t_bank_transaction.ledger_name` (Static labels from the pre-GL-engine "Ledger Rules" screen) and `gl_ledgers`.
- `resolveStaticLedger()` in `create-accounting-service.js` resolves via the explicit map (POST to a chosen ledger, or SKIP with a reason); unreviewed/unmapped labels post to a new "Unclassified Bank Transaction" ledger instead of guessing or erroring. Auto-registers any never-before-seen label so the review backlog stays current.
- New `/gl/static-ledger-map` screen (added to the Accounting menu) — lists every Static label with transaction count/last-seen date, unreviewed-first, with a Post/Skip review modal.
- Migration seeds the map from every distinct Static label currently in use, and pre-marks SFS's two known SOA-mirror labels ("PURCHASE DIESEL"/"PURCHASE OTHERS") as SKIP with the confirmed reason.

## Test plan
- [x] `node --check` on both changed JS files
- [ ] Run both migrations on beta, confirm ledgers/table/menu item created
- [ ] Load `/gl/static-ledger-map` on beta, confirm SFS's two pre-marked SKIP rows show correctly and the review modal saves
- [ ] Re-run Create Accounting for SFS, confirm the 52 previously-erroring BANK_TXN events now resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)