### PR TITLE
Fix static ledger map: last_txn_date format bug

### DIFF
--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -1044,6 +1044,12 @@ router.get('/static-ledger-map', [isLoginEnsured, security.isAdmin()], async fun
             `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT })
         ]);
 
+        rows.forEach(r => {
+            r.last_txn_date_display = r.last_txn_date
+                ? String(r.last_txn_date).substring(0, 10)
+                : null;
+        });
+
         res.render('gl-static-ledger-map', {
             title:  'Static Ledger Map',
             user:   req.user,

--- a/views/gl-static-ledger-map.pug
+++ b/views/gl-static-ledger-map.pug
@@ -43,7 +43,7 @@ block content
                         tr(class=(!r.treatment ? 'table-warning' : ''))
                             td.small= r.ledger_name
                             td.text-center.small= r.txn_count
-                            td.text-center.small= r.last_txn_date ? r.last_txn_date.toISOString().substring(0,10) : '—'
+                            td.text-center.small= r.last_txn_date_display || '—'
                             td.text-center
                                 if r.treatment === 'POST'
                                     span.badge.badge-success Post


### PR DESCRIPTION
## Summary
- Fixes a 500 error on /gl/static-ledger-map — `last_txn_date` comes back from the raw sequelize query as a string under this driver config, not a Date object, so `.toISOString()` in the pug template threw. Formats it once in the route instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)