### PR TITLE
GL accounting: cashflow/adjustment handlers, tank invoice charge fix, Static ledger map

### DIFF
--- a/db/migrations/gl-cashflow-adjustments-triggers.sql
+++ b/db/migrations/gl-cashflow-adjustments-triggers.sql
@@ -1,0 +1,407 @@
+-- ============================================================
+-- GL Accounting: CASHFLOW_TXN + ADJUSTMENT event types
+-- Generated: 2026-08-14
+--
+-- Adds GL coverage for the two gaps identified while scoping the
+-- SFS P&L / FY2025-26 Tally export:
+--   1. t_cashflow_transaction rows with calc_flag='N' (typed directly
+--      into the cashflow-close screen — NOT a rollup of shift data,
+--      so not already covered by CREDIT_SALE/CASH_SALE/DAY_BILL).
+--   2. t_adjustments (customer/digital-vendor/supplier/bank corrections
+--      and opening balances) — had zero GL wiring at all.
+--
+-- Does not touch any existing transaction data. Purely additive:
+-- one new mapping table, five new ledgers (created only where GL is
+-- already set up for a location), and gated triggers matching the
+-- existing is_gl_accounting_enabled() pattern.
+-- ============================================================
+
+
+-- ── Step 1: Cashflow-type → ledger override table ─────────────────────────────
+-- Optional. Most cashflow types resolve automatically by exact ledger-name
+-- match (same convention as TANK_INVOICE charge_type). This table is only
+-- needed for:
+--   (a) bank deposit/withdrawal types, where the cashflow type name (e.g.
+--       "To Bank CUB-7808") doesn't match any ledger name — set bank_id to
+--       point at the m_bank row; the engine resolves that bank's own GL
+--       ledger via the existing source_type='BANK' link.
+--   (b) any type an accountant wants redirected to a specific ledger that
+--       isn't named identically.
+-- A type with no row here, and no exact-name-matching ledger, posts to the
+-- per-location "Unclassified Cashflow" ledger (Step 2) instead of erroring —
+-- so a non-accountant adding a new cashflow type never blocks processing.
+
+CREATE TABLE IF NOT EXISTS gl_cashflow_ledger_map (
+    map_id          INT NOT NULL AUTO_INCREMENT,
+    location_code   VARCHAR(50)  NOT NULL,
+    cashflow_type   VARCHAR(45)  NOT NULL COMMENT 'Matches m_lookup.description for lookup_type=CashFlow / t_cashflow_transaction.type',
+    ledger_id       INT NULL COMMENT 'Explicit override target ledger. NULL if using bank_id instead.',
+    bank_id         INT NULL COMMENT 'For bank deposit/withdrawal types — resolves via gl_ledgers.source_type=BANK/source_id=bank_id',
+    created_by      VARCHAR(45),
+    updated_by      VARCHAR(45),
+    creation_date   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updation_date   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (map_id),
+    UNIQUE KEY uq_gl_cashflow_ledger_map (location_code, cashflow_type)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+
+-- ── Step 2: Auto-create fallback / fixed ledgers per location ─────────────────
+-- Only for locations that already have GL set up (i.e. already have at least
+-- one row in gl_ledgers) — locations that don't use GL yet get nothing here.
+-- INSERT ... WHERE NOT EXISTS makes this safe to re-run.
+
+-- "Unclassified Cashflow" (Suspense A/c) — landing spot for calc_flag='N'
+-- cashflow types with no ledger mapping yet. Sits on the Balance Sheet, not
+-- the P&L, and is fully traceable back to the original transaction (and
+-- reprocessable once mapped) via gl_journal_headers.source_type/source_id.
+INSERT INTO gl_ledgers (location_code, ledger_name, group_id, source_type, active_flag, created_by, updated_by)
+SELECT DISTINCT loc.location_code, 'Unclassified Cashflow', g.group_id, 'STATIC', 'Y', 'MIGRATION', 'MIGRATION'
+FROM (SELECT DISTINCT location_code FROM gl_ledgers) loc
+JOIN gl_ledger_groups g ON g.location_code = loc.location_code AND g.group_name = 'Suspense A/c'
+WHERE NOT EXISTS (
+    SELECT 1 FROM gl_ledgers x WHERE x.location_code = loc.location_code AND x.ledger_name = 'Unclassified Cashflow'
+);
+
+-- "General Adjustment" (Suspense A/c) — same role as above, for
+-- t_adjustments rows whose adjustment_type has no matching ledger
+-- (covers adjustment_type='REVERSAL' and any future unmapped type code).
+INSERT INTO gl_ledgers (location_code, ledger_name, group_id, source_type, active_flag, created_by, updated_by)
+SELECT DISTINCT loc.location_code, 'General Adjustment', g.group_id, 'STATIC', 'Y', 'MIGRATION', 'MIGRATION'
+FROM (SELECT DISTINCT location_code FROM gl_ledgers) loc
+JOIN gl_ledger_groups g ON g.location_code = loc.location_code AND g.group_name = 'Suspense A/c'
+WHERE NOT EXISTS (
+    SELECT 1 FROM gl_ledgers x WHERE x.location_code = loc.location_code AND x.ledger_name = 'General Adjustment'
+);
+
+-- "Opening Balance Equity" (Capital Account) — adjustment_type=201 (Opening
+-- Balance Entry). Keeps historical opening positions off the P&L.
+INSERT INTO gl_ledgers (location_code, ledger_name, group_id, source_type, active_flag, created_by, updated_by)
+SELECT DISTINCT loc.location_code, 'Opening Balance Equity', g.group_id, 'STATIC', 'Y', 'MIGRATION', 'MIGRATION'
+FROM (SELECT DISTINCT location_code FROM gl_ledgers) loc
+JOIN gl_ledger_groups g ON g.location_code = loc.location_code AND g.group_name = 'Capital Account'
+WHERE NOT EXISTS (
+    SELECT 1 FROM gl_ledgers x WHERE x.location_code = loc.location_code AND x.ledger_name = 'Opening Balance Equity'
+);
+
+-- adjustment_type=205 "Digital Vendor Charges" (Indirect Expenses)
+INSERT INTO gl_ledgers (location_code, ledger_name, group_id, source_type, active_flag, created_by, updated_by)
+SELECT DISTINCT loc.location_code, 'Digital Vendor Charges', g.group_id, 'STATIC', 'Y', 'MIGRATION', 'MIGRATION'
+FROM (SELECT DISTINCT location_code FROM gl_ledgers) loc
+JOIN gl_ledger_groups g ON g.location_code = loc.location_code AND g.group_name = 'Indirect Expenses'
+WHERE NOT EXISTS (
+    SELECT 1 FROM gl_ledgers x WHERE x.location_code = loc.location_code AND x.ledger_name = 'Digital Vendor Charges'
+);
+
+-- adjustment_type=207 "POS Rental Charges" (Indirect Expenses)
+INSERT INTO gl_ledgers (location_code, ledger_name, group_id, source_type, active_flag, created_by, updated_by)
+SELECT DISTINCT loc.location_code, 'POS Rental Charges', g.group_id, 'STATIC', 'Y', 'MIGRATION', 'MIGRATION'
+FROM (SELECT DISTINCT location_code FROM gl_ledgers) loc
+JOIN gl_ledger_groups g ON g.location_code = loc.location_code AND g.group_name = 'Indirect Expenses'
+WHERE NOT EXISTS (
+    SELECT 1 FROM gl_ledgers x WHERE x.location_code = loc.location_code AND x.ledger_name = 'POS Rental Charges'
+);
+
+
+-- ── Step 3: CASHFLOW_TXN triggers on t_cashflow_transaction ───────────────────
+-- Only calc_flag='N' rows raise events — calc_flag='Y' rows are a rollup of
+-- shift data already covered by CREDIT_SALE/CASH_SALE/DAY_BILL.
+-- Gated by is_gl_accounting_enabled(), same as every other trigger except
+-- the (separately flagged, still-open) BANK_TXN gap.
+
+DROP TRIGGER IF EXISTS trg_cashflow_txn_gl_insert;
+DROP TRIGGER IF EXISTS trg_cashflow_txn_gl_update;
+DROP TRIGGER IF EXISTS trg_cashflow_txn_gl_delete;
+
+DELIMITER $$
+
+CREATE TRIGGER trg_cashflow_txn_gl_insert
+AFTER INSERT ON t_cashflow_transaction
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+    DECLARE v_cf_date       DATE;
+    DECLARE v_fy_id         INT;
+
+    IF NEW.calc_flag = 'N' THEN
+        SELECT tcc.location_code, tcc.cashflow_date
+        INTO   v_location_code, v_cf_date
+        FROM   t_cashflow_closing tcc
+        WHERE  tcc.cashflow_id = NEW.cashflow_id;
+
+        IF v_location_code IS NOT NULL AND is_gl_accounting_enabled(v_location_code) THEN
+            SELECT fy.fy_id INTO v_fy_id
+            FROM   gl_financial_years fy
+            WHERE  fy.location_code = v_location_code
+              AND  v_cf_date BETWEEN fy.start_date AND fy.end_date
+            LIMIT 1;
+
+            IF v_fy_id IS NOT NULL THEN
+                INSERT INTO gl_accounting_events
+                    (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                VALUES
+                    (v_location_code, v_fy_id, 'CASHFLOW_TXN', NEW.transaction_id, 'CREATE', v_cf_date, 'UNPROCESSED', 'TRIGGER');
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+CREATE TRIGGER trg_cashflow_txn_gl_update
+AFTER UPDATE ON t_cashflow_transaction
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_cf_date         DATE;
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    IF NEW.calc_flag = 'N' THEN
+        IF NOT (NEW.amount      <=> OLD.amount)
+        OR NOT (NEW.type        <=> OLD.type)
+        OR NOT (NEW.description <=> OLD.description)
+        OR NOT (OLD.calc_flag   <=> NEW.calc_flag)
+        THEN
+            SELECT tcc.location_code, tcc.cashflow_date
+            INTO   v_location_code, v_cf_date
+            FROM   t_cashflow_closing tcc
+            WHERE  tcc.cashflow_id = NEW.cashflow_id;
+
+            IF v_location_code IS NOT NULL AND is_gl_accounting_enabled(v_location_code) THEN
+                SELECT fy.fy_id INTO v_fy_id
+                FROM   gl_financial_years fy
+                WHERE  fy.location_code = v_location_code
+                  AND  v_cf_date BETWEEN fy.start_date AND fy.end_date
+                LIMIT 1;
+
+                IF v_fy_id IS NOT NULL THEN
+                    SELECT COUNT(*) INTO v_processed_count
+                    FROM   gl_accounting_events
+                    WHERE  source_type = 'CASHFLOW_TXN' AND source_id = NEW.transaction_id AND event_status = 'PROCESSED';
+
+                    SELECT COUNT(*) INTO v_pending_count
+                    FROM   gl_accounting_events
+                    WHERE  source_type = 'CASHFLOW_TXN' AND source_id = NEW.transaction_id AND event_status = 'UNPROCESSED';
+
+                    IF v_processed_count > 0 THEN
+                        INSERT INTO gl_accounting_events
+                            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                        VALUES
+                            (v_location_code, v_fy_id, 'CASHFLOW_TXN', NEW.transaction_id, 'UPDATE', v_cf_date, 'UNPROCESSED', 'TRIGGER');
+                    ELSEIF v_pending_count > 0 THEN
+                        UPDATE gl_accounting_events
+                        SET    event_type = 'UPDATE'
+                        WHERE  source_type = 'CASHFLOW_TXN' AND source_id = NEW.transaction_id AND event_status = 'UNPROCESSED';
+                    ELSE
+                        INSERT INTO gl_accounting_events
+                            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                        VALUES
+                            (v_location_code, v_fy_id, 'CASHFLOW_TXN', NEW.transaction_id, 'CREATE', v_cf_date, 'UNPROCESSED', 'TRIGGER');
+                    END IF;
+                END IF;
+            END IF;
+        END IF;
+    ELSE
+        -- calc_flag flipped away from 'N' (e.g. corrected to a rollup row) —
+        -- clean up: reverse if already posted, drop if still pending.
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'CASHFLOW_TXN' AND source_id = NEW.transaction_id AND event_status = 'PROCESSED';
+
+        IF v_processed_count > 0 THEN
+            SELECT location_code, fy_id, event_date INTO v_location_code, v_fy_id, v_cf_date
+            FROM   gl_accounting_events
+            WHERE  source_type = 'CASHFLOW_TXN' AND source_id = NEW.transaction_id AND event_status = 'PROCESSED'
+            ORDER BY event_id DESC LIMIT 1;
+
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'CASHFLOW_TXN', NEW.transaction_id, 'DELETE', v_cf_date, 'UNPROCESSED', 'TRIGGER');
+        ELSE
+            DELETE FROM gl_accounting_events
+            WHERE  source_type = 'CASHFLOW_TXN' AND source_id = NEW.transaction_id AND event_status = 'UNPROCESSED';
+        END IF;
+    END IF;
+END$$
+
+CREATE TRIGGER trg_cashflow_txn_gl_delete
+AFTER DELETE ON t_cashflow_transaction
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code   VARCHAR(50);
+    DECLARE v_fy_id           INT;
+    DECLARE v_event_date      DATE;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    SELECT location_code, fy_id, event_date
+    INTO   v_location_code, v_fy_id, v_event_date
+    FROM   gl_accounting_events
+    WHERE  source_type = 'CASHFLOW_TXN' AND source_id = OLD.transaction_id
+    ORDER BY event_id DESC LIMIT 1;
+
+    IF v_location_code IS NOT NULL AND is_gl_accounting_enabled(v_location_code) THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'CASHFLOW_TXN' AND source_id = OLD.transaction_id AND event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type = 'CASHFLOW_TXN' AND source_id = OLD.transaction_id AND event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (v_location_code, v_fy_id, 'CASHFLOW_TXN', OLD.transaction_id, 'DELETE', v_event_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+DELIMITER ;
+
+
+-- ── Step 4: ADJUSTMENT triggers on t_adjustments ───────────────────────────────
+-- Only status='ACTIVE' rows raise/keep events.
+
+DROP TRIGGER IF EXISTS trg_adjustment_gl_insert;
+DROP TRIGGER IF EXISTS trg_adjustment_gl_update;
+DROP TRIGGER IF EXISTS trg_adjustment_gl_delete;
+
+DELIMITER $$
+
+CREATE TRIGGER trg_adjustment_gl_insert
+AFTER INSERT ON t_adjustments
+FOR EACH ROW
+BEGIN
+    DECLARE v_fy_id INT;
+
+    IF NEW.status = 'ACTIVE' AND is_gl_accounting_enabled(NEW.location_code) THEN
+        SELECT fy.fy_id INTO v_fy_id
+        FROM   gl_financial_years fy
+        WHERE  fy.location_code = NEW.location_code
+          AND  NEW.adjustment_date BETWEEN fy.start_date AND fy.end_date
+        LIMIT 1;
+
+        IF v_fy_id IS NOT NULL THEN
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (NEW.location_code, v_fy_id, 'ADJUSTMENT', NEW.adjustment_id, 'CREATE', NEW.adjustment_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+CREATE TRIGGER trg_adjustment_gl_update
+AFTER UPDATE ON t_adjustments
+FOR EACH ROW
+BEGIN
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+    DECLARE v_pending_count   INT DEFAULT 0;
+
+    IF NEW.status = 'ACTIVE' AND is_gl_accounting_enabled(NEW.location_code) THEN
+        IF NOT (NEW.debit_amount    <=> OLD.debit_amount)
+        OR NOT (NEW.credit_amount   <=> OLD.credit_amount)
+        OR NOT (NEW.external_id     <=> OLD.external_id)
+        OR NOT (NEW.external_source <=> OLD.external_source)
+        OR NOT (NEW.adjustment_type <=> OLD.adjustment_type)
+        OR NOT (OLD.status          <=> NEW.status)
+        THEN
+            SELECT fy.fy_id INTO v_fy_id
+            FROM   gl_financial_years fy
+            WHERE  fy.location_code = NEW.location_code
+              AND  NEW.adjustment_date BETWEEN fy.start_date AND fy.end_date
+            LIMIT 1;
+
+            IF v_fy_id IS NOT NULL THEN
+                SELECT COUNT(*) INTO v_processed_count
+                FROM   gl_accounting_events
+                WHERE  source_type = 'ADJUSTMENT' AND source_id = NEW.adjustment_id AND event_status = 'PROCESSED';
+
+                SELECT COUNT(*) INTO v_pending_count
+                FROM   gl_accounting_events
+                WHERE  source_type = 'ADJUSTMENT' AND source_id = NEW.adjustment_id AND event_status = 'UNPROCESSED';
+
+                IF v_processed_count > 0 THEN
+                    INSERT INTO gl_accounting_events
+                        (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                    VALUES
+                        (NEW.location_code, v_fy_id, 'ADJUSTMENT', NEW.adjustment_id, 'UPDATE', NEW.adjustment_date, 'UNPROCESSED', 'TRIGGER');
+                ELSEIF v_pending_count > 0 THEN
+                    UPDATE gl_accounting_events
+                    SET    event_type = 'UPDATE'
+                    WHERE  source_type = 'ADJUSTMENT' AND source_id = NEW.adjustment_id AND event_status = 'UNPROCESSED';
+                ELSE
+                    INSERT INTO gl_accounting_events
+                        (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+                    VALUES
+                        (NEW.location_code, v_fy_id, 'ADJUSTMENT', NEW.adjustment_id, 'CREATE', NEW.adjustment_date, 'UNPROCESSED', 'TRIGGER');
+                END IF;
+            END IF;
+        END IF;
+    ELSEIF is_gl_accounting_enabled(NEW.location_code) THEN
+        -- status moved away from ACTIVE (e.g. cancelled) — reverse if posted, drop if pending
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'ADJUSTMENT' AND source_id = NEW.adjustment_id AND event_status = 'PROCESSED';
+
+        IF v_processed_count > 0 THEN
+            SELECT fy_id INTO v_fy_id
+            FROM   gl_accounting_events
+            WHERE  source_type = 'ADJUSTMENT' AND source_id = NEW.adjustment_id AND event_status = 'PROCESSED'
+            ORDER BY event_id DESC LIMIT 1;
+
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (NEW.location_code, v_fy_id, 'ADJUSTMENT', NEW.adjustment_id, 'DELETE', NEW.adjustment_date, 'UNPROCESSED', 'TRIGGER');
+        ELSE
+            DELETE FROM gl_accounting_events
+            WHERE  source_type = 'ADJUSTMENT' AND source_id = NEW.adjustment_id AND event_status = 'UNPROCESSED';
+        END IF;
+    END IF;
+END$$
+
+CREATE TRIGGER trg_adjustment_gl_delete
+AFTER DELETE ON t_adjustments
+FOR EACH ROW
+BEGIN
+    DECLARE v_fy_id           INT;
+    DECLARE v_processed_count INT DEFAULT 0;
+
+    IF is_gl_accounting_enabled(OLD.location_code) THEN
+        SELECT COUNT(*) INTO v_processed_count
+        FROM   gl_accounting_events
+        WHERE  source_type = 'ADJUSTMENT' AND source_id = OLD.adjustment_id AND event_status = 'PROCESSED';
+
+        DELETE FROM gl_accounting_events
+        WHERE  source_type = 'ADJUSTMENT' AND source_id = OLD.adjustment_id AND event_status IN ('UNPROCESSED', 'ERROR');
+
+        IF v_processed_count > 0 THEN
+            SELECT fy_id INTO v_fy_id
+            FROM   gl_financial_years
+            WHERE  location_code = OLD.location_code
+              AND  OLD.adjustment_date BETWEEN start_date AND end_date
+            LIMIT 1;
+
+            INSERT INTO gl_accounting_events
+                (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+            VALUES
+                (OLD.location_code, v_fy_id, 'ADJUSTMENT', OLD.adjustment_id, 'DELETE', OLD.adjustment_date, 'UNPROCESSED', 'TRIGGER');
+        END IF;
+    END IF;
+END$$
+
+DELIMITER ;
+
+
+-- ── Verify ──────────────────────────────────────────────────────────────────
+SELECT 'Ledger' AS object_type, location_code, ledger_name
+FROM   gl_ledgers
+WHERE  ledger_name IN ('Unclassified Cashflow', 'General Adjustment', 'Opening Balance Equity', 'Digital Vendor Charges', 'POS Rental Charges')
+UNION ALL
+SELECT 'Trigger', NULL, trigger_name
+FROM   information_schema.TRIGGERS
+WHERE  trigger_schema = DATABASE()
+  AND  (trigger_name LIKE 'trg_cashflow_txn_gl_%' OR trigger_name LIKE 'trg_adjustment_gl_%')
+ORDER BY object_type, location_code, ledger_name;

--- a/db/migrations/gl-static-ledger-map-menu.sql
+++ b/db/migrations/gl-static-ledger-map-menu.sql
@@ -1,0 +1,22 @@
+-- ============================================================
+-- Static Ledger Map — Menu Item & Access
+-- Generated: 2026-08-15
+--
+-- Adds the Static Ledger Map review screen under the ACCOUNTING group.
+-- ============================================================
+
+INSERT INTO m_menu_items
+    (menu_code, menu_name, icon, url_path, parent_code, sequence, effective_start_date, created_by, updated_by, group_code)
+VALUES
+    ('GL_STATIC_LEDGER_MAP', 'Static Ledger Map', 'bi-signpost-split', '/gl/static-ledger-map', NULL, 11, '2026-08-15', 'ADMIN', 'ADMIN', 'ACCOUNTING');
+
+INSERT INTO m_menu_access_global
+    (role, menu_code, allowed, effective_start_date, created_by, updated_by)
+VALUES
+    ('SuperUser', 'GL_STATIC_LEDGER_MAP', 1, '2026-08-15', 'ADMIN', 'ADMIN');
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SELECT menu_code, menu_name, sequence, group_code
+FROM m_menu_items
+WHERE group_code = 'ACCOUNTING'
+ORDER BY sequence;

--- a/db/migrations/gl-static-ledger-map.sql
+++ b/db/migrations/gl-static-ledger-map.sql
@@ -1,0 +1,89 @@
+-- ============================================================
+-- GL Accounting: explicit mapping for Static bank/SOA ledger labels
+-- Generated: 2026-08-15
+--
+-- Replaces exact-name matching between t_bank_transaction.ledger_name
+-- (a free-text label a user typed into the bank-reconciliation "ledger
+-- rules" screen — a feature that predates the GL engine) and gl_ledgers.
+-- Name-matching is fragile: two different users can create differently
+-- named Static labels for the same real ledger, or a label can drift
+-- from / coincidentally collide with an unrelated GL ledger name, and
+-- nothing would catch it before money posts to the wrong place.
+--
+-- gl_static_ledger_map makes the mapping an explicit, reviewed decision
+-- instead: many Static labels -> one GL ledger is fine (enforced by
+-- gl_ledger_id having no uniqueness constraint), the reverse is not
+-- (enforced by the UNIQUE(location_code, ledger_name) key — one label
+-- always means exactly one thing). Unreviewed labels never block
+-- processing and never guess — they post to a visible per-location
+-- "Unclassified Bank Transaction" ledger until reviewed.
+-- ============================================================
+
+
+-- ── Step 1: Mapping table ──────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS gl_static_ledger_map (
+    map_id          INT NOT NULL AUTO_INCREMENT,
+    location_code   VARCHAR(50)  NOT NULL,
+    ledger_name     VARCHAR(250) NOT NULL COMMENT 'The Static label as it appears in t_bank_transaction.ledger_name',
+    treatment       ENUM('POST', 'SKIP') NULL COMMENT 'NULL = not yet reviewed',
+    gl_ledger_id    INT NULL COMMENT 'Required when treatment=POST',
+    skip_reason     VARCHAR(255) NULL COMMENT 'Required when treatment=SKIP, e.g. "Duplicate of TANK_INVOICE purchase — SOA mirror line"',
+    created_by      VARCHAR(45),
+    updated_by      VARCHAR(45),
+    creation_date   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updation_date   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (map_id),
+    UNIQUE KEY uq_gl_static_ledger_map (location_code, ledger_name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+
+-- ── Step 2: "Unclassified Bank Transaction" fallback ledger per location ──────
+-- Only for locations that already have GL set up. Safe to re-run.
+
+INSERT INTO gl_ledgers (location_code, ledger_name, group_id, source_type, active_flag, created_by, updated_by)
+SELECT DISTINCT loc.location_code, 'Unclassified Bank Transaction', g.group_id, 'STATIC', 'Y', 'MIGRATION', 'MIGRATION'
+FROM (SELECT DISTINCT location_code FROM gl_ledgers) loc
+JOIN gl_ledger_groups g ON g.location_code = loc.location_code AND g.group_name = 'Suspense A/c'
+WHERE NOT EXISTS (
+    SELECT 1 FROM gl_ledgers x WHERE x.location_code = loc.location_code AND x.ledger_name = 'Unclassified Bank Transaction'
+);
+
+
+-- ── Step 3: Seed the map with every distinct Static label already in use ─────
+-- Unreviewed (treatment=NULL) by default — gives whoever reviews this a
+-- concrete checklist instead of a blank table. Covers both the main
+-- transaction table and split legs, since either can carry a Static label.
+
+INSERT IGNORE INTO gl_static_ledger_map (location_code, ledger_name, created_by, updated_by)
+SELECT DISTINCT mb.location_code, tbt.ledger_name, 'MIGRATION', 'MIGRATION'
+FROM t_bank_transaction tbt
+JOIN m_bank mb ON mb.bank_id = tbt.bank_id
+WHERE tbt.ledger_name IS NOT NULL
+  AND (LOWER(tbt.external_source) = 'static' OR tbt.external_source IS NULL)
+  AND tbt.ledger_name <> 'Others';
+
+INSERT IGNORE INTO gl_static_ledger_map (location_code, ledger_name, created_by, updated_by)
+SELECT DISTINCT mb.location_code, tbs.ledger_name, 'MIGRATION', 'MIGRATION'
+FROM t_bank_transaction_splits tbs
+JOIN t_bank_transaction tbt ON tbt.t_bank_id = tbs.t_bank_id
+JOIN m_bank mb ON mb.bank_id = tbt.bank_id
+WHERE tbs.ledger_name IS NOT NULL
+  AND LOWER(tbs.external_source) = 'static';
+
+
+-- ── Step 4: SFS — pre-reviewed during this session, confirmed against real data ─
+-- Both are SOA invoice-debit mirrors of tank invoices already journaled via
+-- TANK_INVOICE (dates/amounts checked to match exactly) — correctly SKIP.
+
+UPDATE gl_static_ledger_map
+SET treatment = 'SKIP',
+    skip_reason = 'Duplicate of TANK_INVOICE purchase — BPCL SOA mirror line, amounts/dates confirmed matching real tank invoices',
+    updated_by = 'ADMIN'
+WHERE location_code = 'SFS' AND ledger_name IN ('PURCHASE DIESEL', 'PURCHASE OTHERS');
+
+
+-- ── Verify ──────────────────────────────────────────────────────────────────
+SELECT location_code, ledger_name, treatment, skip_reason
+FROM gl_static_ledger_map
+ORDER BY location_code, (treatment IS NULL) DESC, ledger_name;

--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -1044,6 +1044,12 @@ router.get('/static-ledger-map', [isLoginEnsured, security.isAdmin()], async fun
             `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT })
         ]);
 
+        rows.forEach(r => {
+            r.last_txn_date_display = r.last_txn_date
+                ? String(r.last_txn_date).substring(0, 10)
+                : null;
+        });
+
         res.render('gl-static-ledger-map', {
             title:  'Static Ledger Map',
             user:   req.user,

--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -1005,6 +1005,99 @@ router.put('/api/ledger/:id', [isLoginEnsured, security.isAdmin()], async functi
     }
 });
 
+// ── Static Ledger Map ───────────────────────────────────────────────────────
+// GET /gl/static-ledger-map
+// Review screen for Static bank/SOA ledger_name labels (see resolveStaticLedger
+// in create-accounting-service.js) — an accountant marks each label POST
+// (pick the real GL ledger) or SKIP (with a reason), instead of the engine
+// guessing off an exact-name match.
+
+router.get('/static-ledger-map', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    try {
+        const [rows, ledgers] = await Promise.all([
+            db.sequelize.query(`
+                SELECT m.map_id, m.ledger_name, m.treatment, m.gl_ledger_id, m.skip_reason,
+                       m.updated_by, m.updation_date,
+                       l.ledger_name AS target_ledger_name,
+                       g.group_name  AS target_group_name,
+                       (SELECT COUNT(*) FROM t_bank_transaction tbt
+                          JOIN m_bank mb ON mb.bank_id = tbt.bank_id
+                         WHERE mb.location_code = m.location_code
+                           AND tbt.ledger_name = m.ledger_name) AS txn_count,
+                       (SELECT MAX(tbt.trans_date) FROM t_bank_transaction tbt
+                          JOIN m_bank mb ON mb.bank_id = tbt.bank_id
+                         WHERE mb.location_code = m.location_code
+                           AND tbt.ledger_name = m.ledger_name) AS last_txn_date
+                FROM gl_static_ledger_map m
+                LEFT JOIN gl_ledgers l ON l.ledger_id = m.gl_ledger_id
+                LEFT JOIN gl_ledger_groups g ON g.group_id = l.group_id
+                WHERE m.location_code = :locationCode
+                ORDER BY (m.treatment IS NULL) DESC, txn_count DESC, m.ledger_name
+            `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT }),
+            db.sequelize.query(`
+                SELECT l.ledger_id, l.ledger_name, g.group_name
+                FROM gl_ledgers l
+                JOIN gl_ledger_groups g ON g.group_id = l.group_id
+                WHERE l.location_code = :locationCode AND l.active_flag = 'Y'
+                ORDER BY l.ledger_name
+            `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT })
+        ]);
+
+        res.render('gl-static-ledger-map', {
+            title:  'Static Ledger Map',
+            user:   req.user,
+            config: require('../config/app-config').APP_CONFIGS,
+            rows,
+            ledgers,
+            messages: req.flash()
+        });
+    } catch (err) {
+        console.error('Static ledger map error:', err);
+        req.flash('error', err.message);
+        res.redirect('/gl/control');
+    }
+});
+
+router.put('/api/static-ledger-map/:id', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const mapId = parseInt(req.params.id);
+    const { treatment, gl_ledger_id, skip_reason } = req.body;
+    const user = req.user.username || String(req.user.Person_id);
+
+    if (treatment !== 'POST' && treatment !== 'SKIP') {
+        return res.status(400).json({ success: false, error: "treatment must be 'POST' or 'SKIP'" });
+    }
+    if (treatment === 'POST' && !gl_ledger_id) {
+        return res.status(400).json({ success: false, error: 'gl_ledger_id is required when treatment=POST' });
+    }
+    if (treatment === 'SKIP' && !skip_reason?.trim()) {
+        return res.status(400).json({ success: false, error: 'skip_reason is required when treatment=SKIP' });
+    }
+
+    try {
+        await db.sequelize.query(`
+            UPDATE gl_static_ledger_map
+            SET treatment    = :treatment,
+                gl_ledger_id = :gl_ledger_id,
+                skip_reason  = :skip_reason,
+                updated_by   = :user
+            WHERE map_id = :mapId AND location_code = :locationCode
+        `, {
+            replacements: {
+                mapId, locationCode, treatment, user,
+                gl_ledger_id: treatment === 'POST' ? parseInt(gl_ledger_id) : null,
+                skip_reason:  treatment === 'SKIP' ? skip_reason.trim() : null
+            },
+            type: db.Sequelize.QueryTypes.UPDATE
+        });
+        res.json({ success: true });
+    } catch (err) {
+        console.error('Static ledger map update error:', err);
+        res.status(500).json({ success: false, error: err.message });
+    }
+});
+
 // ── Tally Import ──────────────────────────────────────────────────────────────
 // GET  /gl/tally-import  — upload page
 // POST /gl/tally-import  — parse file, return reconcile data as JSON

--- a/services/create-accounting-service.js
+++ b/services/create-accounting-service.js
@@ -11,6 +11,16 @@
 //   BOWSER_DIGITAL_SALE (source_id = digital_id)       — Vendor DR / Sales CR
 //   LUBES_INVOICE       (source_id = lubes_hdr_id)     — Purchase DR + Input CGST/SGST DR / Supplier CR
 //   TANK_INVOICE        (source_id = t_tank_invoice.id)— Purchase DR + Charges DR / Supplier CR
+//   CASHFLOW_TXN        (source_id = transaction_id)   — calc_flag='N' cashflow-close lines only.
+//                                                         Ledger resolved by (in order): explicit
+//                                                         gl_cashflow_ledger_map row, exact ledger-name
+//                                                         match on the cashflow type, else falls back to
+//                                                         the per-location "Unclassified Cashflow" ledger
+//                                                         (never blocks processing — see resolveCashflowLedger).
+//   ADJUSTMENT          (source_id = adjustment_id)    — customer/vendor/bank corrections + opening
+//                                                         balances (adjustment_type=201 → "Opening Balance
+//                                                         Equity", off the P&L; other types resolve by
+//                                                         their own lookup name, else "General Adjustment").
 //
 // Raised automatically by DB triggers on source tables.
 // UPDATE events reverse existing vouchers and regenerate fresh ones.
@@ -294,6 +304,41 @@ async function generateMissingEvents(locationCode, fromDate, toDate, createdBy, 
           )
     `);
 
+    await run('CASHFLOW_TXN', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT tcc.location_code, fy.fy_id, 'CASHFLOW_TXN', tct.transaction_id, 'CREATE',
+               tcc.cashflow_date, 'UNPROCESSED', :createdBy
+        FROM t_cashflow_transaction tct
+        JOIN t_cashflow_closing tcc ON tcc.cashflow_id = tct.cashflow_id
+        JOIN gl_financial_years fy ON fy.location_code = tcc.location_code
+            AND tcc.cashflow_date BETWEEN fy.start_date AND fy.end_date
+        WHERE tcc.location_code = :locationCode
+          AND tct.calc_flag = 'N'
+          AND tcc.cashflow_date BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'CASHFLOW_TXN' AND e.source_id = tct.transaction_id
+          )
+    `);
+
+    await run('ADJUSTMENT', `
+        INSERT INTO gl_accounting_events
+            (location_code, fy_id, source_type, source_id, event_type, event_date, event_status, created_by)
+        SELECT adj.location_code, fy.fy_id, 'ADJUSTMENT', adj.adjustment_id, 'CREATE',
+               adj.adjustment_date, 'UNPROCESSED', :createdBy
+        FROM t_adjustments adj
+        JOIN gl_financial_years fy ON fy.location_code = adj.location_code
+            AND adj.adjustment_date BETWEEN fy.start_date AND fy.end_date
+        WHERE adj.location_code = :locationCode
+          AND adj.status = 'ACTIVE'
+          AND adj.adjustment_date BETWEEN :fromDate AND :toDate
+          AND NOT EXISTS (
+              SELECT 1 FROM gl_accounting_events e
+              WHERE e.source_type = 'ADJUSTMENT' AND e.source_id = adj.adjustment_id
+          )
+    `);
+
     log.info(`Generate Events done — total inserted=${total}` +
         (total > 0 ? (' (' + Object.entries(counts).filter(([,v])=>v>0).map(([k,v])=>`${k}:${v}`).join(' ') + ')') : ''));
 
@@ -322,6 +367,8 @@ async function processEvent(event, processedBy) {
         case 'BOWSER_DIGITAL_SALE': return await processBowserDigitalSaleEvent(event, processedBy);
         case 'LUBES_INVOICE':       return await processLubesInvoiceEvent(event, processedBy);
         case 'TANK_INVOICE':        return await processTankInvoiceEvent(event, processedBy);
+        case 'CASHFLOW_TXN':        return await processCashflowTxnEvent(event, processedBy);
+        case 'ADJUSTMENT':          return await processAdjustmentEvent(event, processedBy);
         default:
             throw new Error(`Unhandled source_type: ${event.source_type}`);
     }
@@ -651,8 +698,8 @@ async function processBankTxnEvent(event, processedBy) {
     if (!rows.length) throw new Error(`Bank transaction not found: t_bank_id=${tBankId}`);
     const txn = rows[0];
 
-    // Skip: transaction not yet classified (no ledger assigned)
-    if (!txn.ledger_name) {
+    // Skip: not yet classified (no ledger) or placeholder 'Others' — reclassify to reprocess
+    if (!txn.ledger_name || txn.ledger_name === 'Others') {
         await markEventProcessed(event.event_id, null, processedBy);
         return { voucherCount: 0 };
     }
@@ -667,16 +714,17 @@ async function processBankTxnEvent(event, processedBy) {
     }
 
     const isOilCo = txn.is_oil_company === 'Y';
+    const extSrc   = txn.external_source ? txn.external_source.toLowerCase() : null;
 
     // Skip: all external_source='Bank' lines on oil-company SOA (our payment receipt lines —
     // the real bank statement already journals the payment)
-    if (isOilCo && txn.external_source === 'Bank') {
+    if (isOilCo && extSrc === 'bank') {
         await markEventProcessed(event.event_id, null, processedBy);
         return { voucherCount: 0 };
     }
 
     // Skip: receiving side of a contra between real banks
-    if (!isOilCo && txn.external_source === 'Bank' && creditAmt > 0) {
+    if (!isOilCo && extSrc === 'bank' && creditAmt > 0) {
         await markEventProcessed(event.event_id, null, processedBy);
         return { voucherCount: 0 };
     }
@@ -1106,6 +1154,222 @@ async function processTankInvoiceEvent(event, processedBy) {
     return { voucherCount: 1 };
 }
 
+// ─── CASHFLOW_TXN Handler ─────────────────────────────────────────────────────
+// Only calc_flag='N' rows reach this handler (calc_flag='Y' rows never raise an
+// event — see trg_cashflow_txn_gl_insert). tag='OUT' → cash left the drawer
+// (DR resolved ledger / CR Cash-in-Hand). tag='IN' → cash came in (reverse).
+// See resolveCashflowLedger for how the counterpart ledger is resolved.
+
+async function processCashflowTxnEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: transactionId, event_date } = event;
+
+    const rows = await db.sequelize.query(`
+        SELECT tct.transaction_id, tct.type, tct.description, tct.amount, tct.calc_flag
+        FROM t_cashflow_transaction tct
+        WHERE tct.transaction_id = :transactionId
+    `, { replacements: { transactionId }, type: QueryTypes.SELECT });
+
+    if (!rows.length) throw new Error(`Cashflow transaction not found: transaction_id=${transactionId}`);
+    const row = rows[0];
+
+    // Defensive — trigger already filters this, but calc_flag can flip on a later UPDATE
+    if (row.calc_flag !== 'N') {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const amount = parseFloat(row.amount || 0);
+    if (amount <= 0) {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const tagRows = await db.sequelize.query(`
+        SELECT tag FROM m_lookup
+        WHERE lookup_type = 'CashFlow' AND description = :type
+          AND (location_code = :locationCode OR location_code IS NULL)
+        ORDER BY (location_code = :locationCode) DESC
+        LIMIT 1
+    `, { replacements: { type: row.type, locationCode: location_code }, type: QueryTypes.SELECT });
+
+    if (!tagRows.length) throw new Error(`Cashflow type '${row.type}' has no matching m_lookup CashFlow entry — cannot determine IN/OUT direction`);
+    const tag = tagRows[0].tag;
+    if (tag !== 'IN' && tag !== 'OUT') throw new Error(`Cashflow type '${row.type}' has an unexpected tag '${tag}' (expected IN/OUT)`);
+
+    const cashLedgerId = await resolveCashLedger(location_code);
+    if (!cashLedgerId) throw new Error(`Cash-in-Hand ledger not found for location ${location_code}`);
+
+    const { ledgerId: counterLedgerId, isContra } = await resolveCashflowLedger(location_code, row.type, processedBy);
+
+    const narration = `${row.type}${row.description ? ' | ' + row.description : ''} | ₹${amount.toFixed(2)} | ${event_date}`;
+    const voucherType = isContra ? 'CONTRA' : 'JOURNAL';
+
+    const lines = tag === 'OUT'
+        ? [ { ledger_id: counterLedgerId, dr_amount: amount, cr_amount: 0,      narration },
+            { ledger_id: cashLedgerId,    dr_amount: 0,      cr_amount: amount, narration } ]
+        : [ { ledger_id: cashLedgerId,    dr_amount: amount, cr_amount: 0,      narration },
+            { ledger_id: counterLedgerId, dr_amount: 0,      cr_amount: amount, narration } ];
+
+    const vid = await createVoucher({
+        locationCode: location_code,
+        fyId:         fy_id,
+        voucherType,
+        voucherDate:  event_date,
+        sourceType:   'CASHFLOW_TXN',
+        sourceId:     transactionId,
+        narration,
+        lines,
+        postedBy:     processedBy
+    });
+
+    await markEventProcessed(event.event_id, vid, processedBy);
+    return { voucherCount: 1 };
+}
+
+// Resolves the counterpart ledger for a calc_flag='N' cashflow type, in order:
+//   1. gl_cashflow_ledger_map.bank_id  → that bank's own GL ledger (contra — deposit/withdrawal)
+//   2. gl_cashflow_ledger_map.ledger_id → explicit override
+//   3. exact ledger-name match on the cashflow type text (same convention as TANK_INVOICE charge_type)
+//   4. per-location "Unclassified Cashflow" ledger — never blocks processing; reprocess later once mapped
+async function resolveCashflowLedger(locationCode, cashflowType, processedBy) {
+    const mapRows = await db.sequelize.query(`
+        SELECT ledger_id, bank_id FROM gl_cashflow_ledger_map
+        WHERE location_code = :locationCode AND cashflow_type = :cashflowType
+        LIMIT 1
+    `, { replacements: { locationCode, cashflowType }, type: QueryTypes.SELECT });
+
+    if (mapRows.length && mapRows[0].bank_id) {
+        const ledgerId = await resolveLedger(locationCode, 'BANK', mapRows[0].bank_id);
+        if (!ledgerId) throw new Error(`gl_cashflow_ledger_map for '${cashflowType}' points at bank_id=${mapRows[0].bank_id}, but that bank has no GL ledger`);
+        return { ledgerId, isContra: true };
+    }
+
+    if (mapRows.length && mapRows[0].ledger_id) {
+        return { ledgerId: mapRows[0].ledger_id, isContra: false };
+    }
+
+    const byName = await resolveLedgerByName(locationCode, cashflowType);
+    if (byName) return { ledgerId: byName.ledger_id, isContra: false };
+
+    const fallback = await resolveLedgerByName(locationCode, 'Unclassified Cashflow');
+    if (!fallback) throw new Error(`No 'Unclassified Cashflow' ledger set up for location ${locationCode} — run db/migrations/gl-cashflow-adjustments-triggers.sql`);
+    return { ledgerId: fallback.ledger_id, isContra: false };
+}
+
+// ─── ADJUSTMENT Handler ───────────────────────────────────────────────────────
+// t_adjustments carries its own debit_amount/credit_amount — the "counterpart"
+// side (customer/vendor/bank) resolves via external_source, the "type" side
+// resolves via adjustment_type (see resolveAdjustmentTypeLedger). Two-line
+// voucher, direction taken straight from whichever amount column is set.
+
+async function processAdjustmentEvent(event, processedBy) {
+    const { location_code, fy_id, source_id: adjustmentId, event_date } = event;
+
+    const rows = await db.sequelize.query(`
+        SELECT adjustment_id, description, external_id, external_source, ledger_name,
+               debit_amount, credit_amount, adjustment_type, status
+        FROM t_adjustments
+        WHERE adjustment_id = :adjustmentId
+    `, { replacements: { adjustmentId }, type: QueryTypes.SELECT });
+
+    if (!rows.length) throw new Error(`Adjustment not found: adjustment_id=${adjustmentId}`);
+    const row = rows[0];
+
+    if (row.status !== 'ACTIVE') {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const debitAmt  = parseFloat(row.debit_amount  || 0);
+    const creditAmt = parseFloat(row.credit_amount || 0);
+    const amount    = debitAmt > 0 ? debitAmt : creditAmt;
+
+    if (amount <= 0) {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
+
+    const counterLedgerId = await resolveAdjustmentCounterpartLedger(row, location_code);
+    const typeLedgerId    = await resolveAdjustmentTypeLedger(row.adjustment_type, location_code);
+
+    const narration = `Adjustment #${adjustmentId}${row.description ? ' | ' + row.description : ''} | ₹${amount.toFixed(2)} | ${event_date}`;
+
+    // debit_amount set → counterpart is DR, type ledger is CR. credit_amount set → reverse.
+    const lines = debitAmt > 0
+        ? [ { ledger_id: counterLedgerId, dr_amount: amount, cr_amount: 0,      narration },
+            { ledger_id: typeLedgerId,    dr_amount: 0,      cr_amount: amount, narration } ]
+        : [ { ledger_id: typeLedgerId,    dr_amount: amount, cr_amount: 0,      narration },
+            { ledger_id: counterLedgerId, dr_amount: 0,      cr_amount: amount, narration } ];
+
+    const vid = await createVoucher({
+        locationCode: location_code,
+        fyId:         fy_id,
+        voucherType:  'JOURNAL',
+        voucherDate:  event_date,
+        sourceType:   'ADJUSTMENT',
+        sourceId:     adjustmentId,
+        narration,
+        lines,
+        postedBy:     processedBy
+    });
+
+    await markEventProcessed(event.event_id, vid, processedBy);
+    return { voucherCount: 1 };
+}
+
+async function resolveAdjustmentCounterpartLedger(row, locationCode) {
+    const src = (row.external_source || '').toUpperCase();
+
+    if (src === 'CUSTOMER' || src === 'DIGITAL_VENDOR') {
+        const id = await resolveLedger(locationCode, 'CREDIT', row.external_id);
+        if (!id) throw new Error(`CREDIT GL ledger not found for ${src.toLowerCase()} creditlist_id=${row.external_id} (adjustment_id:${row.adjustment_id})`);
+        return id;
+    }
+    if (src === 'SUPPLIER') {
+        const id = await resolveLedger(locationCode, 'SUPPLIER', row.external_id);
+        if (!id) throw new Error(`SUPPLIER GL ledger not found for supplier_id=${row.external_id} (adjustment_id:${row.adjustment_id})`);
+        return id;
+    }
+    if (src === 'BANK') {
+        const id = await resolveLedger(locationCode, 'BANK', row.external_id);
+        if (!id) throw new Error(`BANK GL ledger not found for bank_id=${row.external_id} (adjustment_id:${row.adjustment_id})`);
+        return id;
+    }
+    if (src === 'EXPENSE') {
+        if (!row.ledger_name) throw new Error(`Adjustment id=${row.adjustment_id} has external_source=EXPENSE but no ledger_name set`);
+        const info = await resolveLedgerByName(locationCode, row.ledger_name);
+        if (!info) throw new Error(`GL ledger '${row.ledger_name}' not found for location ${locationCode} (adjustment_id:${row.adjustment_id})`);
+        return info.ledger_id;
+    }
+    throw new Error(`Cannot resolve adjustment counterpart: external_source='${row.external_source}' (adjustment_id:${row.adjustment_id})`);
+}
+
+// adjustment_type=201 ("Opening Balance Entry") always goes to the dedicated
+// equity ledger, off the P&L. Every other type resolves by its own m_lookup
+// description (matches the ADJUSTMENT_TYPE lookup name to a same-named
+// ledger — e.g. 205 "Digital Vendor Charges", 207 "POS Rental Charges").
+// Anything that can't resolve (including adjustment_type='REVERSAL', which
+// isn't a lookup code) falls back to "General Adjustment" — never blocks.
+async function resolveAdjustmentTypeLedger(adjustmentType, locationCode) {
+    if (adjustmentType === '201') {
+        const info = await resolveLedgerByName(locationCode, 'Opening Balance Equity');
+        if (info) return info.ledger_id;
+    } else if (/^\d+$/.test(adjustmentType)) {
+        const lookupRows = await db.sequelize.query(`
+            SELECT description FROM m_lookup WHERE lookup_type = 'ADJUSTMENT_TYPE' AND lookup_id = :adjustmentType LIMIT 1
+        `, { replacements: { adjustmentType }, type: QueryTypes.SELECT });
+
+        if (lookupRows.length) {
+            const info = await resolveLedgerByName(locationCode, lookupRows[0].description);
+            if (info) return info.ledger_id;
+        }
+    }
+
+    const fallback = await resolveLedgerByName(locationCode, 'General Adjustment');
+    if (!fallback) throw new Error(`No 'General Adjustment' ledger set up for location ${locationCode} — run db/migrations/gl-cashflow-adjustments-triggers.sql`);
+    return fallback.ledger_id;
+}
+
 // Derives the Tally voucher type from bank transaction context.
 //   CONTRA  — inter-bank transfer (external_source='Bank', debit/paying side)
 //   PAYMENT — money leaves the bank (bank is CR side)
@@ -1113,16 +1377,17 @@ async function processTankInvoiceEvent(event, processedBy) {
 //   JOURNAL — oil company SOA entries (supplier account adjustments)
 function deriveBankVoucherType(txn, bankIsDr) {
     if (txn.is_oil_company === 'Y') return 'JOURNAL';
-    if (txn.external_source === 'Bank') return 'CONTRA';
+    if (txn.external_source?.toLowerCase() === 'bank') return 'CONTRA';
     return bankIsDr ? 'RECEIPT' : 'PAYMENT';
 }
 
 // Returns counterpart ledger_id, or null if the event was already marked PROCESSED (skip).
 // Throws on unresolvable ledger.
 async function resolveCounterpartLedger(txn, locationCode, eventId, processedBy) {
-    const { external_source, external_id, ledger_name } = txn;
+    const { external_id, ledger_name } = txn;
+    const external_source = txn.external_source ? txn.external_source.toLowerCase() : null;
 
-    if (external_source === 'Static' || (!external_source && ledger_name)) {
+    if (external_source === 'static' || (!external_source && ledger_name)) {
         const info = await resolveLedgerByName(locationCode, ledger_name);
         if (!info) throw new Error(`GL ledger '${ledger_name}' not found for location ${locationCode}`);
         if (info.group_name === 'Purchase Accounts') {
@@ -1133,26 +1398,31 @@ async function resolveCounterpartLedger(txn, locationCode, eventId, processedBy)
         return info.ledger_id;
     }
 
-    if (external_source === 'Credit') {
+    if (external_source === 'credit') {
+        // external_id=0 means unlinked placeholder (e.g. IOCL SOA 'Others') — skip
+        if (!external_id) {
+            await markEventProcessed(eventId, null, processedBy);
+            return null;
+        }
         const id = await resolveLedger(locationCode, 'CREDIT', external_id);
         if (!id) throw new Error(`CREDIT GL ledger not found for creditlist_id=${external_id}`);
         return id;
     }
 
-    if (external_source === 'Supplier') {
+    if (external_source === 'supplier') {
         const id = await resolveLedger(locationCode, 'SUPPLIER', external_id);
         if (!id) throw new Error(`SUPPLIER GL ledger not found for supplier_id=${external_id}`);
         return id;
     }
 
-    if (external_source === 'Bank') {
+    if (external_source === 'bank') {
         // Debit-side of a real-bank contra (credit side was already skipped above)
         const id = await resolveLedger(locationCode, 'BANK', external_id);
         if (!id) throw new Error(`BANK GL ledger not found for contra bank_id=${external_id}`);
         return id;
     }
 
-    throw new Error(`Cannot resolve counterpart ledger: external_source='${external_source}', external_id=${external_id}, ledger_name='${ledger_name}'`);
+    throw new Error(`Cannot resolve counterpart ledger: external_source='${txn.external_source}', external_id=${external_id}, ledger_name='${ledger_name}'`);
 }
 
 async function buildSplitLines(tBankId, bankLedgerId, bankIsDr, txnAmount, narration, locationCode) {

--- a/services/create-accounting-service.js
+++ b/services/create-accounting-service.js
@@ -1048,12 +1048,11 @@ async function processLubesInvoiceEvent(event, processedBy) {
 }
 
 // ─── TANK_INVOICE Handler ─────────────────────────────────────────────────────
-// Supplier CR (sum of product lines + charges) →
-//   Per t_tank_invoice_dtl: DR Product Purchase (total_line_amount)
-//   Per t_tank_invoice_charges: DR charge ledger by name (resolveLedgerByName)
-//
-// charge_type is free text in t_tank_invoice_charges — admin must create a GL ledger
-// with the exact same name, otherwise the engine throws a descriptive error.
+// Supplier CR → DR Product Purchase per t_tank_invoice_dtl, total_line_amount
+// plus every t_tank_invoice_charges row for that line folded straight in
+// (VAT, ADDITIONAL_VAT, DELIVERY_CHARGE, and any future charge_type) — none
+// of them are separately recoverable, so they're landed cost, not a distinct
+// ledger. No charge-type-to-ledger mapping needed at all.
 
 async function processTankInvoiceEvent(event, processedBy) {
     const { location_code, fy_id, source_id: invoiceId, event_date } = event;
@@ -1080,6 +1079,17 @@ async function processTankInvoiceEvent(event, processedBy) {
     const journalLines = [];
     let totalCr = 0;
 
+    // All charges (VAT, ADDITIONAL_VAT, DELIVERY_CHARGE, ...) per line — folded into that line's purchase amount
+    const chargeRows = await db.sequelize.query(`
+        SELECT c.invoice_dtl_id, SUM(c.charge_amount) AS charge_amount
+        FROM t_tank_invoice_charges c
+        JOIN t_tank_invoice_dtl d ON d.id = c.invoice_dtl_id
+        WHERE d.invoice_id = :invoiceId
+          AND c.charge_amount > 0
+        GROUP BY c.invoice_dtl_id
+    `, { replacements: { invoiceId }, type: QueryTypes.SELECT });
+    const chargesByDtl = new Map(chargeRows.map(r => [r.invoice_dtl_id, parseFloat(r.charge_amount)]));
+
     // Product purchase lines
     const dtlRows = await db.sequelize.query(`
         SELECT
@@ -1094,42 +1104,19 @@ async function processTankInvoiceEvent(event, processedBy) {
     `, { replacements: { invoiceId }, type: QueryTypes.SELECT });
 
     for (const dtl of dtlRows) {
-        const lineAmt = parseFloat(dtl.total_line_amount);
-        totalCr      += lineAmt;
+        const chargeAmt = chargesByDtl.get(dtl.dtl_id) || 0;
+        const lineAmt   = parseFloat(dtl.total_line_amount) + chargeAmt;
+        totalCr        += lineAmt;
 
         const purchaseLedgerId = await resolveProductLedger(location_code, dtl.product_id, 'PURCHASE');
         if (!purchaseLedgerId) throw new Error(`PURCHASE ledger not configured for product ${dtl.product_name} (id:${dtl.product_id})`);
 
+        const chargeNote = chargeAmt > 0 ? ` (incl. charges ₹${chargeAmt.toFixed(2)})` : '';
         journalLines.push({
             ledger_id:  purchaseLedgerId,
             dr_amount:  lineAmt,
             cr_amount:  0,
-            narration:  `${dtl.product_name} | ₹${lineAmt.toFixed(2)} | ${narration}`
-        });
-    }
-
-    // Charge lines (free-text charge_type → GL ledger by name)
-    const chargeRows = await db.sequelize.query(`
-        SELECT c.charge_type, SUM(c.charge_amount) AS amount
-        FROM t_tank_invoice_charges c
-        JOIN t_tank_invoice_dtl d ON d.id = c.invoice_dtl_id
-        WHERE d.invoice_id = :invoiceId
-          AND c.charge_amount > 0
-        GROUP BY c.charge_type
-    `, { replacements: { invoiceId }, type: QueryTypes.SELECT });
-
-    for (const ch of chargeRows) {
-        const chargeAmt = parseFloat(ch.amount);
-        totalCr        += chargeAmt;
-
-        const info = await resolveLedgerByName(location_code, ch.charge_type);
-        if (!info) throw new Error(`GL ledger '${ch.charge_type}' not found for location ${location_code} — create a ledger with this exact name to map the charge`);
-
-        journalLines.push({
-            ledger_id:  info.ledger_id,
-            dr_amount:  chargeAmt,
-            cr_amount:  0,
-            narration:  `${ch.charge_type} | ₹${chargeAmt.toFixed(2)} | ${narration}`
+            narration:  `${dtl.product_name} | ₹${lineAmt.toFixed(2)}${chargeNote} | ${narration}`
         });
     }
 

--- a/services/create-accounting-service.js
+++ b/services/create-accounting-service.js
@@ -1375,14 +1375,12 @@ async function resolveCounterpartLedger(txn, locationCode, eventId, processedBy)
     const external_source = txn.external_source ? txn.external_source.toLowerCase() : null;
 
     if (external_source === 'static' || (!external_source && ledger_name)) {
-        const info = await resolveLedgerByName(locationCode, ledger_name);
-        if (!info) throw new Error(`GL ledger '${ledger_name}' not found for location ${locationCode}`);
-        if (info.group_name === 'Purchase Accounts') {
-            // Purchase invoices are journaled by the PURCHASE_INVOICE handler — skip here
+        const { treatment, ledgerId } = await resolveStaticLedger(locationCode, ledger_name);
+        if (treatment === 'SKIP') {
             await markEventProcessed(eventId, null, processedBy);
             return null;
         }
-        return info.ledger_id;
+        return ledgerId;
     }
 
     if (external_source === 'credit') {
@@ -1447,9 +1445,12 @@ async function resolveSplitCounterLedger(split, locationCode) {
     const errCtx = `split_id=${split_id}`;
 
     if (external_source === 'Static') {
-        const info = await resolveLedgerByName(locationCode, ledger_name);
-        if (!info) throw new Error(`Static GL ledger '${ledger_name}' not found for ${errCtx}`);
-        return info.ledger_id;
+        // allowSkip=false — a split leg is one piece of a multi-line voucher that
+        // must balance against the bank total, so it can never be silently
+        // dropped the way a whole (non-split) transaction can; a SKIP-mapped
+        // label still lands in Unclassified here instead.
+        const { ledgerId } = await resolveStaticLedger(locationCode, ledger_name, false);
+        return ledgerId;
     }
     if (external_source === 'Credit') {
         const id = await resolveLedger(locationCode, 'CREDIT', external_id);
@@ -1650,6 +1651,44 @@ async function resolveLedgerByName(locationCode, ledgerName) {
         type: QueryTypes.SELECT
     });
     return rows[0] || null;
+}
+
+// Resolves a Static (free-text) bank-transaction ledger_name via the explicit
+// gl_static_ledger_map — deliberately does NOT match ledger_name against
+// gl_ledgers by name. These labels are typed by whoever sets up a bank
+// "ledger rule" (a feature that predates the GL engine), so two labels can
+// mean the same real ledger, or a label can coincidentally collide with an
+// unrelated GL ledger name — exact-name matching would silently post to the
+// wrong place with no review. Unmapped/unreviewed labels never block and
+// never guess: they land in "Unclassified Bank Transaction" until reviewed.
+// allowSkip=false (used for split legs) treats a SKIP-mapped label as
+// Unclassified instead, since one leg of a split can't be silently dropped
+// without unbalancing the voucher.
+async function resolveStaticLedger(locationCode, ledgerName, allowSkip = true) {
+    const rows = await db.sequelize.query(`
+        SELECT treatment, gl_ledger_id FROM gl_static_ledger_map
+        WHERE location_code = :locationCode AND ledger_name = :ledgerName
+        LIMIT 1
+    `, { replacements: { locationCode, ledgerName }, type: QueryTypes.SELECT });
+
+    let mapped = rows[0];
+    if (!mapped) {
+        // Never-seen-before label — register it (unreviewed) so it shows up
+        // on the review screen going forward, not just for labels present
+        // at migration time. INSERT IGNORE handles the race safely since
+        // (location_code, ledger_name) is unique.
+        await db.sequelize.query(`
+            INSERT IGNORE INTO gl_static_ledger_map (location_code, ledger_name, created_by, updated_by)
+            VALUES (:locationCode, :ledgerName, 'ENGINE', 'ENGINE')
+        `, { replacements: { locationCode, ledgerName }, type: QueryTypes.INSERT });
+        mapped = null;
+    }
+    if (allowSkip && mapped?.treatment === 'SKIP') return { treatment: 'SKIP', ledgerId: null };
+    if (mapped?.treatment === 'POST' && mapped.gl_ledger_id) return { treatment: 'POST', ledgerId: mapped.gl_ledger_id };
+
+    const fallback = await resolveLedgerByName(locationCode, 'Unclassified Bank Transaction');
+    if (!fallback) throw new Error(`No 'Unclassified Bank Transaction' ledger set up for location ${locationCode} — run db/migrations/gl-static-ledger-map.sql`);
+    return { treatment: 'POST', ledgerId: fallback.ledger_id };
 }
 
 async function resolveCashLedger(locationCode) {

--- a/views/gl-static-ledger-map.pug
+++ b/views/gl-static-ledger-map.pug
@@ -43,7 +43,7 @@ block content
                         tr(class=(!r.treatment ? 'table-warning' : ''))
                             td.small= r.ledger_name
                             td.text-center.small= r.txn_count
-                            td.text-center.small= r.last_txn_date ? r.last_txn_date.toISOString().substring(0,10) : '—'
+                            td.text-center.small= r.last_txn_date_display || '—'
                             td.text-center
                                 if r.treatment === 'POST'
                                     span.badge.badge-success Post

--- a/views/gl-static-ledger-map.pug
+++ b/views/gl-static-ledger-map.pug
@@ -1,0 +1,153 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        h4.mb-1 Static Ledger Map
+        p.text-muted.small.mb-3
+            | Bank/SOA transactions categorized with a free-text "Static" label (set on the
+            strong  Ledger Rules
+            |  screen) resolve here instead of matching against Ledgers by name. Review each label once —
+            strong  Post
+            |  it to the real GL ledger, or
+            strong  Skip
+            |  it if it's already covered elsewhere (e.g. a purchase invoice that also appears on the oil-company SOA). Unreviewed labels post to
+            code Unclassified Bank Transaction
+            |  until you decide.
+
+        if messages && messages.error && messages.error.length
+            .alert.alert-danger.py-2= messages.error[0]
+
+        - const unreviewed = rows.filter(r => !r.treatment)
+        - const reviewed = rows.filter(r => r.treatment)
+
+        if unreviewed.length
+            .alert.alert-warning.py-2.small.mb-3
+                i.bi.bi-exclamation-triangle.mr-1
+                strong= unreviewed.length
+                |  label(s) not yet reviewed — posting to Unclassified Bank Transaction in the meantime.
+
+        .table-responsive
+            table.table.table-sm.table-bordered.table-hover
+                thead.thead-light
+                    tr
+                        th Label (from Ledger Rules)
+                        th.text-center(style="width:90px") Txns
+                        th.text-center(style="width:110px") Last Seen
+                        th.text-center(style="width:100px") Status
+                        th Resolution
+                        th.text-center(style="width:80px")
+                tbody
+                    each r in unreviewed.concat(reviewed)
+                        tr(class=(!r.treatment ? 'table-warning' : ''))
+                            td.small= r.ledger_name
+                            td.text-center.small= r.txn_count
+                            td.text-center.small= r.last_txn_date ? r.last_txn_date.toISOString().substring(0,10) : '—'
+                            td.text-center
+                                if r.treatment === 'POST'
+                                    span.badge.badge-success Post
+                                else if r.treatment === 'SKIP'
+                                    span.badge.badge-secondary Skip
+                                else
+                                    span.badge.badge-warning Unreviewed
+                            td.small
+                                if r.treatment === 'POST'
+                                    span= r.target_ledger_name
+                                    span.text-muted  (#{r.target_group_name})
+                                else if r.treatment === 'SKIP'
+                                    span.text-muted.font-italic= r.skip_reason
+                                else
+                                    span.text-muted.font-italic → Unclassified Bank Transaction (temporary)
+                            td.text-center
+                                button.btn.btn-outline-primary.btn-sm.btn-edit-map(
+                                    data-id=r.map_id
+                                    data-name=r.ledger_name
+                                    data-treatment=r.treatment || ''
+                                    data-ledger=r.gl_ledger_id || ''
+                                    data-reason=r.skip_reason || ''
+                                    title="Review")
+                                    i.bi.bi-pencil
+
+    //- ── Modal ────────────────────────────────────────────────────────────────
+    .modal.fade#mapModal(tabindex="-1")
+        .modal-dialog
+            .modal-content
+                .modal-header
+                    h5.modal-title Review Label
+                    button.close(data-dismiss="modal" aria-label="Close")
+                        span &times;
+                .modal-body
+                    p.small.mb-3
+                        | Label:
+                        strong.ml-1#mLabelName
+
+                    .form-group
+                        .form-check.form-check-inline
+                            input.form-check-input#mTreatmentPost(type="radio" name="mTreatment" value="POST")
+                            label.form-check-label.small(for="mTreatmentPost") Post to a ledger
+                        .form-check.form-check-inline
+                            input.form-check-input#mTreatmentSkip(type="radio" name="mTreatment" value="SKIP")
+                            label.form-check-label.small(for="mTreatmentSkip") Skip (already covered elsewhere)
+
+                    .form-group#mPostFields
+                        label.small Target Ledger *
+                        select.form-control.form-control-sm#mLedger
+                            option(value="") — select —
+                            each l in ledgers
+                                option(value=l.ledger_id data-group=l.group_name)= l.ledger_name + ' (' + l.group_name + ')'
+
+                    .form-group#mSkipFields(style="display:none")
+                        label.small Reason *
+                        textarea.form-control.form-control-sm#mReason(rows="2" placeholder="e.g. Duplicate of TANK_INVOICE purchase — SOA mirror line")
+
+                .modal-footer
+                    button.btn.btn-secondary.btn-sm(data-dismiss="modal") Cancel
+                    button.btn.btn-primary.btn-sm#btnSaveMap Save
+
+    script.
+        let editingMapId = null;
+
+        function showTreatmentFields(treatment) {
+            document.getElementById('mPostFields').style.display = treatment === 'POST' ? '' : 'none';
+            document.getElementById('mSkipFields').style.display = treatment === 'SKIP' ? '' : 'none';
+        }
+        document.getElementById('mTreatmentPost').addEventListener('change', function() { showTreatmentFields('POST'); });
+        document.getElementById('mTreatmentSkip').addEventListener('change', function() { showTreatmentFields('SKIP'); });
+
+        document.querySelectorAll('.btn-edit-map').forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                editingMapId = this.dataset.id;
+                document.getElementById('mLabelName').textContent = this.dataset.name;
+                const treatment = this.dataset.treatment || 'POST';
+                document.getElementById('mTreatmentPost').checked = treatment !== 'SKIP';
+                document.getElementById('mTreatmentSkip').checked = treatment === 'SKIP';
+                document.getElementById('mLedger').value = this.dataset.ledger || '';
+                document.getElementById('mReason').value = this.dataset.reason || '';
+                showTreatmentFields(treatment === 'SKIP' ? 'SKIP' : 'POST');
+                $('#mapModal').modal('show');
+                setTimeout(function() {
+                    $('#mLedger').select2({ width: '100%', dropdownParent: $('#mapModal') });
+                }, 50);
+            });
+        });
+
+        document.getElementById('btnSaveMap').addEventListener('click', async function() {
+            const treatment = document.querySelector('input[name="mTreatment"]:checked').value;
+            const gl_ledger_id = document.getElementById('mLedger').value;
+            const skip_reason = document.getElementById('mReason').value.trim();
+
+            if (treatment === 'POST' && !gl_ledger_id) { alert('Select a target ledger.'); return; }
+            if (treatment === 'SKIP' && !skip_reason) { alert('Enter a reason.'); return; }
+
+            this.disabled = true;
+            try {
+                const resp = await fetch('/gl/api/static-ledger-map/' + editingMapId, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ treatment, gl_ledger_id, skip_reason })
+                });
+                const data = await resp.json();
+                if (data.success) { location.reload(); } else { alert('Error: ' + data.error); this.disabled = false; }
+            } catch (e) { alert('Network error.'); this.disabled = false; }
+        });


### PR DESCRIPTION
## Summary
Four PRs from this session's SFS P&L work, bundled for prod:
- CASHFLOW_TXN + ADJUSTMENT event handlers (#787)
- Tank invoice charges folded into purchase line instead of a separate ledger (#788)
- Explicit Static ledger mapping table + review screen, replacing exact-name matching (#789, #790 fixes a bug in it)

All tested against SFS's real data on beta. Three DB migrations still need to run on prod separately (not part of this deploy): gl-cashflow-adjustments-triggers.sql, gl-static-ledger-map.sql, gl-static-ledger-map-menu.sql (+ CALL RefreshMenuCache()).

## Test plan
- [x] All four changes validated against SFS's real transaction data on beta
- [ ] Run the three DB migrations on prod after this merges
- [ ] Fresh Generate Events + Create Accounting run on prod (separate, later)

🤖 Generated with [Claude Code](https://claude.com/claude-code)