### PR TITLE
GL accounting: DB-trigger-based correction queue for mapping changes

### DIFF
--- a/db/migrations/gl-correction-queue-menu.sql
+++ b/db/migrations/gl-correction-queue-menu.sql
@@ -1,0 +1,20 @@
+-- ============================================================
+-- Correction Queue — Menu Item & Access
+-- Generated: 2026-08-16
+-- ============================================================
+
+INSERT INTO m_menu_items
+    (menu_code, menu_name, icon, url_path, parent_code, sequence, effective_start_date, created_by, updated_by, group_code)
+VALUES
+    ('GL_CORRECTION_QUEUE', 'Correction Queue', 'bi-arrow-repeat', '/gl/correction-queue', NULL, 12, '2026-08-16', 'ADMIN', 'ADMIN', 'ACCOUNTING');
+
+INSERT INTO m_menu_access_global
+    (role, menu_code, allowed, effective_start_date, created_by, updated_by)
+VALUES
+    ('SuperUser', 'GL_CORRECTION_QUEUE', 1, '2026-08-16', 'ADMIN', 'ADMIN');
+
+-- ── VERIFY ────────────────────────────────────────────────────────────────────
+SELECT menu_code, menu_name, sequence, group_code
+FROM m_menu_items
+WHERE group_code = 'ACCOUNTING'
+ORDER BY sequence;

--- a/db/migrations/gl-correction-queue-triggers.sql
+++ b/db/migrations/gl-correction-queue-triggers.sql
@@ -1,0 +1,247 @@
+-- ============================================================
+-- GL Accounting: correction-queue triggers on mapping tables
+-- Generated: 2026-08-16
+--
+-- Moves correction-queue logging from application code (routes/gl-routes.js,
+-- routes/products-routes.js) into DB triggers, so it catches every change
+-- to gl_product_ledger_map / gl_static_ledger_map regardless of source —
+-- the review screens, raw SQL run by hand, or a future migration. This
+-- matters concretely: this session's own SFS mapping setup was done via
+-- direct SQL, which app-level-only logging would have silently missed.
+--
+-- gl_product_ledger_map.ledger_id is NOT NULL — "unmapped" only exists as
+-- row absence (DELETE), never a NULL value — so the UPDATE trigger never
+-- needs to handle a NULL OLD/NEW ledger_id; only DELETE represents
+-- "removed the mapping".
+-- ============================================================
+
+
+-- ── gl_product_ledger_map ──────────────────────────────────────────────────
+
+DROP TRIGGER IF EXISTS trg_product_ledger_map_gl_update;
+DROP TRIGGER IF EXISTS trg_product_ledger_map_gl_delete;
+
+DELIMITER $$
+
+CREATE TRIGGER trg_product_ledger_map_gl_update
+AFTER UPDATE ON gl_product_ledger_map
+FOR EACH ROW
+BEGIN
+    DECLARE v_old_name VARCHAR(250);
+    DECLARE v_new_name VARCHAR(250);
+    DECLARE v_old_desc VARCHAR(255);
+    DECLARE v_new_desc VARCHAR(255);
+    DECLARE v_mapping_key VARCHAR(250);
+
+    IF NOT (OLD.ledger_id <=> NEW.ledger_id) THEN
+        SELECT ledger_name INTO v_old_name FROM gl_ledgers WHERE ledger_id = OLD.ledger_id;
+        SELECT ledger_name INTO v_new_name FROM gl_ledgers WHERE ledger_id = NEW.ledger_id;
+        SET v_old_desc = CONCAT('Post to: ', COALESCE(v_old_name, CONCAT('(deleted ledger #', OLD.ledger_id, ')')));
+        SET v_new_desc = CONCAT('Post to: ', COALESCE(v_new_name, CONCAT('(deleted ledger #', NEW.ledger_id, ')')));
+        SET v_mapping_key = CONCAT('product:', NEW.product_id, ':', NEW.map_type);
+
+        IF NEW.map_type IN ('SALES', 'OUTPUT_CGST', 'OUTPUT_SGST') THEN
+            INSERT INTO gl_correction_queue
+                (location_code, mapping_source, mapping_key, old_description, new_description,
+                 source_type, source_id, voucher_id, fy_id, status, created_by)
+            SELECT NEW.location_code, 'PRODUCT_LEDGER_MAP', v_mapping_key, v_old_desc, v_new_desc,
+                   ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', NEW.updated_by
+            FROM gl_accounting_events ge
+            JOIN t_credits tc ON tc.tcredit_id = ge.source_id AND ge.source_type = 'CREDIT_SALE'
+            WHERE ge.event_status = 'PROCESSED' AND ge.location_code = NEW.location_code AND tc.product_id = NEW.product_id
+            UNION
+            SELECT NEW.location_code, 'PRODUCT_LEDGER_MAP', v_mapping_key, v_old_desc, v_new_desc,
+                   ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', NEW.updated_by
+            FROM gl_accounting_events ge
+            JOIN t_cashsales cs ON cs.cashsales_id = ge.source_id AND ge.source_type = 'CASH_SALE'
+            WHERE ge.event_status = 'PROCESSED' AND ge.location_code = NEW.location_code AND cs.product_id = NEW.product_id
+            UNION
+            SELECT NEW.location_code, 'PRODUCT_LEDGER_MAP', v_mapping_key, v_old_desc, v_new_desc,
+                   ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', NEW.updated_by
+            FROM gl_accounting_events ge
+            JOIN t_day_bill_header dbh ON dbh.day_bill_id = ge.source_id AND ge.source_type = 'DAY_BILL'
+            JOIN t_day_bill_items dbi ON dbi.header_id = dbh.header_id
+            WHERE ge.event_status = 'PROCESSED' AND ge.location_code = NEW.location_code AND dbi.product_id = NEW.product_id
+            UNION
+            SELECT NEW.location_code, 'PRODUCT_LEDGER_MAP', v_mapping_key, v_old_desc, v_new_desc,
+                   ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', NEW.updated_by
+            FROM gl_accounting_events ge
+            JOIN t_bowser_credits bc ON bc.credit_id = ge.source_id AND ge.source_type = 'BOWSER_CREDIT_SALE'
+            WHERE ge.event_status = 'PROCESSED' AND ge.location_code = NEW.location_code AND bc.product_id = NEW.product_id
+            UNION
+            SELECT NEW.location_code, 'PRODUCT_LEDGER_MAP', v_mapping_key, v_old_desc, v_new_desc,
+                   ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', NEW.updated_by
+            FROM gl_accounting_events ge
+            JOIN t_bowser_cashsales bcs ON bcs.cashsale_id = ge.source_id AND ge.source_type = 'BOWSER_CASH_SALE'
+            WHERE ge.event_status = 'PROCESSED' AND ge.location_code = NEW.location_code AND bcs.product_id = NEW.product_id
+            UNION
+            SELECT NEW.location_code, 'PRODUCT_LEDGER_MAP', v_mapping_key, v_old_desc, v_new_desc,
+                   ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', NEW.updated_by
+            FROM gl_accounting_events ge
+            JOIN t_bowser_digital_sales bds ON bds.digital_id = ge.source_id AND ge.source_type = 'BOWSER_DIGITAL_SALE'
+            JOIN t_bowser_closing tbc ON tbc.bowser_closing_id = bds.bowser_closing_id
+            JOIN m_bowser mb ON mb.bowser_id = tbc.bowser_id
+            WHERE ge.event_status = 'PROCESSED' AND ge.location_code = NEW.location_code AND mb.product_id = NEW.product_id;
+        ELSE
+            INSERT INTO gl_correction_queue
+                (location_code, mapping_source, mapping_key, old_description, new_description,
+                 source_type, source_id, voucher_id, fy_id, status, created_by)
+            SELECT NEW.location_code, 'PRODUCT_LEDGER_MAP', v_mapping_key, v_old_desc, v_new_desc,
+                   ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', NEW.updated_by
+            FROM gl_accounting_events ge
+            JOIN t_tank_invoice_dtl d ON d.invoice_id = ge.source_id AND ge.source_type = 'TANK_INVOICE'
+            WHERE ge.event_status = 'PROCESSED' AND ge.location_code = NEW.location_code AND d.product_id = NEW.product_id
+            UNION
+            SELECT NEW.location_code, 'PRODUCT_LEDGER_MAP', v_mapping_key, v_old_desc, v_new_desc,
+                   ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', NEW.updated_by
+            FROM gl_accounting_events ge
+            JOIN t_lubes_inv_lines l ON l.lubes_hdr_id = ge.source_id AND ge.source_type = 'LUBES_INVOICE'
+            WHERE ge.event_status = 'PROCESSED' AND ge.location_code = NEW.location_code AND l.product_id = NEW.product_id;
+        END IF;
+    END IF;
+END$$
+
+CREATE TRIGGER trg_product_ledger_map_gl_delete
+AFTER DELETE ON gl_product_ledger_map
+FOR EACH ROW
+BEGIN
+    DECLARE v_old_name VARCHAR(250);
+    DECLARE v_old_desc VARCHAR(255);
+    DECLARE v_mapping_key VARCHAR(250);
+
+    SELECT ledger_name INTO v_old_name FROM gl_ledgers WHERE ledger_id = OLD.ledger_id;
+    SET v_old_desc = CONCAT('Post to: ', COALESCE(v_old_name, CONCAT('(deleted ledger #', OLD.ledger_id, ')')));
+    SET v_mapping_key = CONCAT('product:', OLD.product_id, ':', OLD.map_type);
+
+    IF OLD.map_type IN ('SALES', 'OUTPUT_CGST', 'OUTPUT_SGST') THEN
+        INSERT INTO gl_correction_queue
+            (location_code, mapping_source, mapping_key, old_description, new_description,
+             source_type, source_id, voucher_id, fy_id, status, created_by)
+        SELECT OLD.location_code, 'PRODUCT_LEDGER_MAP', v_mapping_key, v_old_desc, 'Unmapped',
+               ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', OLD.updated_by
+        FROM gl_accounting_events ge
+        JOIN t_credits tc ON tc.tcredit_id = ge.source_id AND ge.source_type = 'CREDIT_SALE'
+        WHERE ge.event_status = 'PROCESSED' AND ge.location_code = OLD.location_code AND tc.product_id = OLD.product_id
+        UNION
+        SELECT OLD.location_code, 'PRODUCT_LEDGER_MAP', v_mapping_key, v_old_desc, 'Unmapped',
+               ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', OLD.updated_by
+        FROM gl_accounting_events ge
+        JOIN t_cashsales cs ON cs.cashsales_id = ge.source_id AND ge.source_type = 'CASH_SALE'
+        WHERE ge.event_status = 'PROCESSED' AND ge.location_code = OLD.location_code AND cs.product_id = OLD.product_id
+        UNION
+        SELECT OLD.location_code, 'PRODUCT_LEDGER_MAP', v_mapping_key, v_old_desc, 'Unmapped',
+               ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', OLD.updated_by
+        FROM gl_accounting_events ge
+        JOIN t_day_bill_header dbh ON dbh.day_bill_id = ge.source_id AND ge.source_type = 'DAY_BILL'
+        JOIN t_day_bill_items dbi ON dbi.header_id = dbh.header_id
+        WHERE ge.event_status = 'PROCESSED' AND ge.location_code = OLD.location_code AND dbi.product_id = OLD.product_id
+        UNION
+        SELECT OLD.location_code, 'PRODUCT_LEDGER_MAP', v_mapping_key, v_old_desc, 'Unmapped',
+               ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', OLD.updated_by
+        FROM gl_accounting_events ge
+        JOIN t_bowser_credits bc ON bc.credit_id = ge.source_id AND ge.source_type = 'BOWSER_CREDIT_SALE'
+        WHERE ge.event_status = 'PROCESSED' AND ge.location_code = OLD.location_code AND bc.product_id = OLD.product_id
+        UNION
+        SELECT OLD.location_code, 'PRODUCT_LEDGER_MAP', v_mapping_key, v_old_desc, 'Unmapped',
+               ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', OLD.updated_by
+        FROM gl_accounting_events ge
+        JOIN t_bowser_cashsales bcs ON bcs.cashsale_id = ge.source_id AND ge.source_type = 'BOWSER_CASH_SALE'
+        WHERE ge.event_status = 'PROCESSED' AND ge.location_code = OLD.location_code AND bcs.product_id = OLD.product_id
+        UNION
+        SELECT OLD.location_code, 'PRODUCT_LEDGER_MAP', v_mapping_key, v_old_desc, 'Unmapped',
+               ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', OLD.updated_by
+        FROM gl_accounting_events ge
+        JOIN t_bowser_digital_sales bds ON bds.digital_id = ge.source_id AND ge.source_type = 'BOWSER_DIGITAL_SALE'
+        JOIN t_bowser_closing tbc ON tbc.bowser_closing_id = bds.bowser_closing_id
+        JOIN m_bowser mb ON mb.bowser_id = tbc.bowser_id
+        WHERE ge.event_status = 'PROCESSED' AND ge.location_code = OLD.location_code AND mb.product_id = OLD.product_id;
+    ELSE
+        INSERT INTO gl_correction_queue
+            (location_code, mapping_source, mapping_key, old_description, new_description,
+             source_type, source_id, voucher_id, fy_id, status, created_by)
+        SELECT OLD.location_code, 'PRODUCT_LEDGER_MAP', v_mapping_key, v_old_desc, 'Unmapped',
+               ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', OLD.updated_by
+        FROM gl_accounting_events ge
+        JOIN t_tank_invoice_dtl d ON d.invoice_id = ge.source_id AND ge.source_type = 'TANK_INVOICE'
+        WHERE ge.event_status = 'PROCESSED' AND ge.location_code = OLD.location_code AND d.product_id = OLD.product_id
+        UNION
+        SELECT OLD.location_code, 'PRODUCT_LEDGER_MAP', v_mapping_key, v_old_desc, 'Unmapped',
+               ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', OLD.updated_by
+        FROM gl_accounting_events ge
+        JOIN t_lubes_inv_lines l ON l.lubes_hdr_id = ge.source_id AND ge.source_type = 'LUBES_INVOICE'
+        WHERE ge.event_status = 'PROCESSED' AND ge.location_code = OLD.location_code AND l.product_id = OLD.product_id;
+    END IF;
+END$$
+
+DELIMITER ;
+
+
+-- ── gl_static_ledger_map ────────────────────────────────────────────────────
+-- treatment/gl_ledger_id ARE nullable here (unreviewed state) — only log
+-- when OLD.treatment was already set (a real reviewed value being changed),
+-- matching the "unmapped -> mapped never queues" rule.
+
+DROP TRIGGER IF EXISTS trg_static_ledger_map_gl_update;
+
+DELIMITER $$
+
+CREATE TRIGGER trg_static_ledger_map_gl_update
+AFTER UPDATE ON gl_static_ledger_map
+FOR EACH ROW
+BEGIN
+    DECLARE v_old_ledger_name VARCHAR(250);
+    DECLARE v_new_ledger_name VARCHAR(250);
+    DECLARE v_old_desc VARCHAR(255);
+    DECLARE v_new_desc VARCHAR(255);
+
+    IF OLD.treatment IS NOT NULL
+       AND (NOT (OLD.treatment <=> NEW.treatment)
+            OR NOT (OLD.gl_ledger_id <=> NEW.gl_ledger_id)
+            OR NOT (OLD.skip_reason <=> NEW.skip_reason))
+    THEN
+        IF OLD.treatment = 'SKIP' THEN
+            SET v_old_desc = CONCAT('Skip: ', COALESCE(OLD.skip_reason, ''));
+        ELSE
+            SELECT ledger_name INTO v_old_ledger_name FROM gl_ledgers WHERE ledger_id = OLD.gl_ledger_id;
+            SET v_old_desc = CONCAT('Post to: ', COALESCE(v_old_ledger_name, CONCAT('(deleted ledger #', OLD.gl_ledger_id, ')')));
+        END IF;
+
+        IF NEW.treatment = 'SKIP' THEN
+            SET v_new_desc = CONCAT('Skip: ', COALESCE(NEW.skip_reason, ''));
+        ELSEIF NEW.treatment = 'POST' THEN
+            SELECT ledger_name INTO v_new_ledger_name FROM gl_ledgers WHERE ledger_id = NEW.gl_ledger_id;
+            SET v_new_desc = CONCAT('Post to: ', COALESCE(v_new_ledger_name, CONCAT('(deleted ledger #', NEW.gl_ledger_id, ')')));
+        ELSE
+            SET v_new_desc = 'Unreviewed';
+        END IF;
+
+        INSERT INTO gl_correction_queue
+            (location_code, mapping_source, mapping_key, old_description, new_description,
+             source_type, source_id, voucher_id, fy_id, status, created_by)
+        SELECT mb.location_code, 'STATIC_LEDGER_MAP', NEW.ledger_name, v_old_desc, v_new_desc,
+               ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', NEW.updated_by
+        FROM gl_accounting_events ge
+        JOIN t_bank_transaction tbt ON tbt.t_bank_id = ge.source_id AND ge.source_type = 'BANK_TXN'
+        JOIN m_bank mb ON mb.bank_id = tbt.bank_id
+        WHERE ge.event_status = 'PROCESSED' AND mb.location_code = NEW.location_code AND tbt.ledger_name = NEW.ledger_name
+        UNION
+        SELECT mb.location_code, 'STATIC_LEDGER_MAP', NEW.ledger_name, v_old_desc, v_new_desc,
+               ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', NEW.updated_by
+        FROM gl_accounting_events ge
+        JOIN t_bank_transaction tbt ON tbt.t_bank_id = ge.source_id AND ge.source_type = 'BANK_TXN'
+        JOIN m_bank mb ON mb.bank_id = tbt.bank_id
+        JOIN t_bank_transaction_splits tbs ON tbs.t_bank_id = tbt.t_bank_id
+        WHERE ge.event_status = 'PROCESSED' AND mb.location_code = NEW.location_code AND tbs.ledger_name = NEW.ledger_name;
+    END IF;
+END$$
+
+DELIMITER ;
+
+
+-- ── Verify ──────────────────────────────────────────────────────────────────
+SELECT trigger_name, event_manipulation, event_object_table
+FROM information_schema.TRIGGERS
+WHERE trigger_schema = DATABASE()
+  AND trigger_name IN ('trg_product_ledger_map_gl_update', 'trg_product_ledger_map_gl_delete',
+                        'trg_static_ledger_map_gl_update')
+ORDER BY trigger_name;

--- a/db/migrations/gl-correction-queue.sql
+++ b/db/migrations/gl-correction-queue.sql
@@ -1,0 +1,39 @@
+-- ============================================================
+-- GL Accounting: correction queue for mapping changes
+-- Generated: 2026-08-16
+--
+-- When a ledger mapping changes AFTER accounting entries were already
+-- posted against the old value, this logs exactly which vouchers are now
+-- stale — instead of silently leaving them wrong, or requiring a blind
+-- whole-date-range reprocess (which reverses+reposts everything in the
+-- range, not just what the mapping change actually affects).
+--
+-- Populated by AFTER UPDATE/DELETE triggers on gl_product_ledger_map and
+-- gl_static_ledger_map (see gl-correction-queue-triggers.sql) — DB-level,
+-- not application code, so it catches every change regardless of source
+-- (UI, raw SQL, future migrations). mapping_source is a free string so
+-- this extends to other mapping tables later without a schema change.
+-- creation_date uses microsecond precision so the app can identify exactly
+-- which rows a specific save just inserted (compare against a NOW(6)
+-- captured immediately before the write).
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS gl_correction_queue (
+    queue_id        INT NOT NULL AUTO_INCREMENT,
+    location_code   VARCHAR(50)  NOT NULL,
+    mapping_source  VARCHAR(50)  NOT NULL COMMENT 'e.g. STATIC_LEDGER_MAP, PRODUCT_LEDGER_MAP',
+    mapping_key     VARCHAR(250) NOT NULL COMMENT 'e.g. the ledger_name, or product_id:map_type, that changed',
+    old_description VARCHAR(255) NULL,
+    new_description VARCHAR(255) NULL,
+    source_type     VARCHAR(50)  NOT NULL,
+    source_id       INT          NOT NULL,
+    voucher_id      INT NULL,
+    fy_id           INT NULL,
+    status          ENUM('PENDING', 'REPROCESSED', 'IGNORED') NOT NULL DEFAULT 'PENDING',
+    created_by      VARCHAR(45),
+    creation_date   TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    resolved_by     VARCHAR(45) NULL,
+    resolved_date   TIMESTAMP NULL,
+    PRIMARY KEY (queue_id),
+    KEY idx_gl_correction_queue_status (location_code, status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -1082,6 +1082,20 @@ router.put('/api/static-ledger-map/:id', [isLoginEnsured, security.isAdmin()], a
     }
 
     try {
+        const [existing] = await db.sequelize.query(`
+            SELECT ledger_name FROM gl_static_ledger_map WHERE map_id = :mapId AND location_code = :locationCode
+        `, { replacements: { mapId, locationCode }, type: db.Sequelize.QueryTypes.SELECT });
+        if (!existing) return res.status(404).json({ success: false, error: 'Not found' });
+
+        const newLedgerId = treatment === 'POST' ? parseInt(gl_ledger_id) : null;
+        const newReason    = treatment === 'SKIP' ? skip_reason.trim() : null;
+
+        // trg_static_ledger_map_gl_update logs any stale-voucher fallout from
+        // this write directly — capture a DB-clock timestamp first so we can
+        // report back how many rows it just queued (UI feedback only; the
+        // trigger is the source of truth regardless of who calls this route).
+        const [{ ts: beforeTs }] = await db.sequelize.query(`SELECT NOW(6) AS ts`, { type: db.Sequelize.QueryTypes.SELECT });
+
         await db.sequelize.query(`
             UPDATE gl_static_ledger_map
             SET treatment    = :treatment,
@@ -1090,16 +1104,77 @@ router.put('/api/static-ledger-map/:id', [isLoginEnsured, security.isAdmin()], a
                 updated_by   = :user
             WHERE map_id = :mapId AND location_code = :locationCode
         `, {
-            replacements: {
-                mapId, locationCode, treatment, user,
-                gl_ledger_id: treatment === 'POST' ? parseInt(gl_ledger_id) : null,
-                skip_reason:  treatment === 'SKIP' ? skip_reason.trim() : null
-            },
+            replacements: { mapId, locationCode, treatment, user, gl_ledger_id: newLedgerId, skip_reason: newReason },
             type: db.Sequelize.QueryTypes.UPDATE
         });
-        res.json({ success: true });
+
+        const [{ cnt: queuedCount }] = await db.sequelize.query(`
+            SELECT COUNT(*) AS cnt FROM gl_correction_queue
+            WHERE location_code = :locationCode AND mapping_key = :ledgerName AND creation_date >= :beforeTs
+        `, { replacements: { locationCode, ledgerName: existing.ledger_name, beforeTs }, type: db.Sequelize.QueryTypes.SELECT });
+
+        res.json({ success: true, queuedCorrections: queuedCount });
     } catch (err) {
         console.error('Static ledger map update error:', err);
+        res.status(500).json({ success: false, error: err.message });
+    }
+});
+
+// ── Correction Queue ──────────────────────────────────────────────────────────
+// GET /gl/correction-queue — vouchers that went stale because a mapping
+// changed after they were posted (see gl_correction_queue). Reprocessing
+// here only touches the specific events listed, not a date range.
+
+router.get('/correction-queue', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    try {
+        const rows = await db.sequelize.query(`
+            SELECT queue_id, mapping_source, mapping_key, old_description, new_description,
+                   source_type, source_id, voucher_id, status, created_by, creation_date,
+                   resolved_by, resolved_date
+            FROM gl_correction_queue
+            WHERE location_code = :locationCode
+            ORDER BY (status = 'PENDING') DESC, creation_date DESC
+        `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT });
+
+        res.render('gl-correction-queue', {
+            title:  'Correction Queue',
+            user:   req.user,
+            config: require('../config/app-config').APP_CONFIGS,
+            rows,
+            messages: req.flash()
+        });
+    } catch (err) {
+        console.error('Correction queue error:', err);
+        req.flash('error', err.message);
+        res.redirect('/gl/control');
+    }
+});
+
+router.post('/api/correction-queue/reprocess', [isLoginEnsured, security.isAdmin()], async function(req, res) {
+    const locationCode = req.user.location_code;
+    const user = req.user.username || String(req.user.Person_id);
+    const { queue_ids } = req.body;
+
+    if (!Array.isArray(queue_ids) || !queue_ids.length) {
+        return res.status(400).json({ success: false, error: 'queue_ids is required' });
+    }
+
+    try {
+        // Scope to this location — belt and suspenders against a stray id
+        const owned = await db.sequelize.query(`
+            SELECT queue_id FROM gl_correction_queue
+            WHERE queue_id IN (:queueIds) AND location_code = :locationCode AND status = 'PENDING'
+        `, { replacements: { queueIds: queue_ids.map(Number), locationCode }, type: db.Sequelize.QueryTypes.SELECT });
+
+        if (!owned.length) return res.json({ success: true, summary: { processed: 0, errors: 0 } });
+
+        const summary = await createAccountingService.reprocessQueuedCorrections(
+            owned.map(o => o.queue_id), user
+        );
+        res.json({ success: true, summary });
+    } catch (err) {
+        console.error('Correction queue reprocess error:', err);
         res.status(500).json({ success: false, error: err.message });
     }
 });

--- a/routes/products-routes.js
+++ b/routes/products-routes.js
@@ -341,12 +341,25 @@ router.put('/api/ledger-maps/:productId/:mapType', [isLoginEnsured, security.isA
     const locationCode = req.user.location_code;
     const updatedBy = req.user.username || req.user.Person_id;
     try {
+        // trg_product_ledger_map_gl_update/_delete log any stale-voucher
+        // fallout from this write directly (DB-level, catches this route,
+        // raw SQL, and future migrations alike). Capture a DB-clock
+        // timestamp first just to report back the count for the UI.
+        const [{ ts: beforeTs }] = await db.sequelize.query(`SELECT NOW(6) AS ts`, { type: db.Sequelize.QueryTypes.SELECT });
+
         if (!ledger_id) {
             await ProductLedgerMapDao.deleteMapping(locationCode, productId, mapType);
         } else {
             await ProductLedgerMapDao.upsertMapping(locationCode, productId, mapType, ledger_id, updatedBy);
         }
-        res.json({ success: true });
+
+        const mappingKey = `product:${productId}:${mapType}`;
+        const [{ cnt: queuedCount }] = await db.sequelize.query(`
+            SELECT COUNT(*) AS cnt FROM gl_correction_queue
+            WHERE location_code = :locationCode AND mapping_key = :mappingKey AND creation_date >= :beforeTs
+        `, { replacements: { locationCode, mappingKey, beforeTs }, type: db.Sequelize.QueryTypes.SELECT });
+
+        res.json({ success: true, queuedCorrections: queuedCount });
     } catch (err) {
         console.error('Error saving product ledger map:', err);
         res.status(500).json({ success: false, error: err.message });

--- a/services/create-accounting-service.js
+++ b/services/create-accounting-service.js
@@ -130,7 +130,70 @@ async function reprocessEvents(locationCode, fromDate, toDate, processedBy, logg
     return await processEvents(locationCode, fromDate, toDate, processedBy, log);
 }
 
-module.exports = { processEvents, reprocessEvents, generateMissingEvents };
+// Reprocesses exactly the events named by a set of gl_correction_queue rows
+// (a mapping changed after they were posted) — not a date range, so
+// everything else already correct in that window is left untouched. Same
+// reverse-then-repost mechanics as reprocessEvents, just targeted.
+async function reprocessQueuedCorrections(queueIds, processedBy, logger) {
+    const log = logger || { info: () => {}, debug: () => {}, error: () => {} };
+    const summary = { processed: 0, errors: 0, details: [] };
+
+    const queueRows = await db.sequelize.query(`
+        SELECT queue_id, source_type, source_id
+        FROM gl_correction_queue
+        WHERE queue_id IN (:queueIds) AND status = 'PENDING'
+    `, { replacements: { queueIds }, type: QueryTypes.SELECT });
+
+    if (!queueRows.length) return summary;
+
+    const uniqueEvents = [...new Map(queueRows.map(r => [`${r.source_type}#${r.source_id}`, r])).values()];
+    log.info(`Reprocessing ${uniqueEvents.length} queued correction(s) from ${queueRows.length} queue entr(y/ies)`);
+
+    for (const { source_type, source_id } of uniqueEvents) {
+        await db.sequelize.query(`
+            UPDATE gl_accounting_events
+            SET event_status  = 'UNPROCESSED',
+                event_type    = 'UPDATE',
+                voucher_id    = NULL,
+                error_message = NULL,
+                processed_at  = NULL,
+                processed_by  = NULL
+            WHERE source_type = :source_type AND source_id = :source_id
+              AND event_status IN ('PROCESSED', 'ERROR')
+        `, { replacements: { source_type, source_id }, type: QueryTypes.UPDATE });
+
+        const [event] = await db.sequelize.query(`
+            SELECT * FROM gl_accounting_events
+            WHERE source_type = :source_type AND source_id = :source_id AND event_status = 'UNPROCESSED'
+            ORDER BY event_id DESC LIMIT 1
+        `, { replacements: { source_type, source_id }, type: QueryTypes.SELECT });
+
+        if (!event) continue;
+
+        try {
+            const result = await processEvent(event, processedBy);
+            summary.processed += result.voucherCount;
+            log.debug(`REPROCESSED ${source_type}#${source_id} → ${result.voucherCount} voucher(s)`);
+            summary.details.push({ source_type, source_id, status: 'PROCESSED' });
+        } catch (err) {
+            await markEventError(event.event_id, err.message);
+            summary.errors++;
+            log.error(`ERROR reprocessing ${source_type}#${source_id}: ${err.message}`);
+            summary.details.push({ source_type, source_id, status: 'ERROR', message: err.message });
+        }
+    }
+
+    await db.sequelize.query(`
+        UPDATE gl_correction_queue
+        SET status = 'REPROCESSED', resolved_by = :processedBy, resolved_date = NOW()
+        WHERE queue_id IN (:queueIds) AND status = 'PENDING'
+    `, { replacements: { processedBy, queueIds }, type: QueryTypes.UPDATE });
+
+    log.info(`Reprocess queued corrections done — processed=${summary.processed} errors=${summary.errors}`);
+    return summary;
+}
+
+module.exports = { processEvents, reprocessEvents, reprocessQueuedCorrections, generateMissingEvents };
 
 // ─── Generate Missing Events ──────────────────────────────────────────────────
 // Backfill tool: scan each source table for records with no event and INSERT them.

--- a/views/gl-correction-queue.pug
+++ b/views/gl-correction-queue.pug
@@ -1,0 +1,112 @@
+extends layout
+include mixins/mixins
+
+block content
+    .container-fluid.pt-3
+
+        h4.mb-1 Correction Queue
+        p.text-muted.small.mb-3
+            | Vouchers that were already posted when a ledger mapping changed underneath them. Reprocessing here reverses and reposts
+            strong  only the listed events
+            | , not a whole date range.
+
+        if messages && messages.error && messages.error.length
+            .alert.alert-danger.py-2= messages.error[0]
+
+        - const pending = rows.filter(r => r.status === 'PENDING')
+        - const resolved = rows.filter(r => r.status !== 'PENDING')
+
+        if pending.length
+            .d-flex.justify-content-between.align-items-center.mb-2
+                .alert.alert-warning.py-2.small.mb-0.flex-grow-1.mr-2
+                    i.bi.bi-exclamation-triangle.mr-1
+                    strong= pending.length
+                    |  stale voucher(s) pending correction.
+                button.btn.btn-primary.btn-sm#btnReprocessSelected(disabled)
+                    i.bi.bi-arrow-repeat.mr-1
+                    | Reprocess Selected
+        else
+            .alert.alert-success.py-2.small
+                i.bi.bi-check-circle.mr-1
+                | Nothing pending.
+
+        .table-responsive
+            table.table.table-sm.table-bordered.table-hover
+                thead.thead-light
+                    tr
+                        th(style="width:30px")
+                            input#chkAll(type="checkbox")
+                        th Label / Mapping
+                        th Old Resolution
+                        th New Resolution
+                        th Source
+                        th.text-center(style="width:90px") Status
+                        th.text-center(style="width:110px") Changed
+                tbody
+                    each r in pending.concat(resolved)
+                        tr
+                            td.text-center
+                                if r.status === 'PENDING'
+                                    input.chk-row(type="checkbox" value=r.queue_id)
+                            td.small= r.mapping_key
+                            td.small.text-danger= r.old_description
+                            td.small.text-success= r.new_description
+                            td.small= r.source_type + ' #' + r.source_id
+                            td.text-center
+                                if r.status === 'PENDING'
+                                    span.badge.badge-warning Pending
+                                else if r.status === 'REPROCESSED'
+                                    span.badge.badge-success Reprocessed
+                                else
+                                    span.badge.badge-secondary Ignored
+                            td.text-center.small= r.creation_date ? String(r.creation_date).substring(0,10) : ''
+
+    script.
+        function updateReprocessBtn() {
+            const checked = document.querySelectorAll('.chk-row:checked').length;
+            const btn = document.getElementById('btnReprocessSelected');
+            btn.disabled = checked === 0;
+            btn.innerHTML = checked
+                ? '<i class="bi bi-arrow-repeat mr-1"></i> Reprocess Selected (' + checked + ')'
+                : '<i class="bi bi-arrow-repeat mr-1"></i> Reprocess Selected';
+        }
+
+        const chkAll = document.getElementById('chkAll');
+        if (chkAll) {
+            chkAll.addEventListener('change', function() {
+                document.querySelectorAll('.chk-row').forEach(c => c.checked = chkAll.checked);
+                updateReprocessBtn();
+            });
+        }
+        document.querySelectorAll('.chk-row').forEach(function(c) {
+            c.addEventListener('change', updateReprocessBtn);
+        });
+
+        const reprocessBtn = document.getElementById('btnReprocessSelected');
+        if (reprocessBtn) {
+            reprocessBtn.addEventListener('click', async function() {
+                const ids = [...document.querySelectorAll('.chk-row:checked')].map(c => parseInt(c.value));
+                if (!ids.length) return;
+                if (!confirm('Reprocess ' + ids.length + ' voucher(s)? Each will be reversed and reposted with the corrected mapping.')) return;
+                this.disabled = true;
+                this.textContent = 'Reprocessing…';
+                try {
+                    const resp = await fetch('/gl/api/correction-queue/reprocess', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ queue_ids: ids })
+                    });
+                    const data = await resp.json();
+                    if (data.success) {
+                        alert('Done — ' + data.summary.processed + ' voucher(s) reprocessed' + (data.summary.errors ? ', ' + data.summary.errors + ' error(s)' : '') + '.');
+                        location.reload();
+                    } else {
+                        alert('Error: ' + data.error);
+                        this.disabled = false;
+                    }
+                } catch (e) {
+                    alert('Network error.');
+                    this.disabled = false;
+                }
+            });
+        }

--- a/views/gl-static-ledger-map.pug
+++ b/views/gl-static-ledger-map.pug
@@ -148,6 +148,11 @@ block content
                     body: JSON.stringify({ treatment, gl_ledger_id, skip_reason })
                 });
                 const data = await resp.json();
-                if (data.success) { location.reload(); } else { alert('Error: ' + data.error); this.disabled = false; }
+                if (data.success) {
+                    if (data.queuedCorrections) {
+                        alert(data.queuedCorrections + ' already-posted voucher(s) used the old mapping — queued for review at Correction Queue.');
+                    }
+                    location.reload();
+                } else { alert('Error: ' + data.error); this.disabled = false; }
             } catch (e) { alert('Network error.'); this.disabled = false; }
         });

--- a/views/product-ledger-map.pug
+++ b/views/product-ledger-map.pug
@@ -177,6 +177,9 @@ block content
                     updateBadge(productId);
                     statusEl.innerHTML = '<i class="bi bi-check-circle-fill text-success"></i>';
                     setTimeout(() => { statusEl.innerHTML = ''; }, 2000);
+                    if (data.queuedCorrections) {
+                        alert(data.queuedCorrections + ' already-posted voucher(s) used the old mapping — queued for review at Accounting > Correction Queue.');
+                    }
                 } else {
                     statusEl.innerHTML = '<i class="bi bi-x-circle-fill text-danger" title="' + data.error + '"></i>';
                 }


### PR DESCRIPTION
## Summary
- Correction queue logging (gl_correction_queue) moved from app code to AFTER UPDATE/DELETE triggers on gl_product_ledger_map and gl_static_ledger_map — catches every change regardless of source (UI, raw SQL, migrations).
- Product Ledger Map correction detection now built: sales-side (6 source types) and purchase-side (2 source types).
- Verified against real SFS data on beta: confirmed exact affected-voucher counts on both trigger types, confirmed first-time mappings correctly don't queue anything. Beta restored to clean state after testing.

## Test plan
- [x] node --check on all changed JS files
- [x] Both new triggers tested live on beta against real data — exact match counts confirmed
- [x] First-time/unreviewed mapping changes confirmed to NOT queue (no false positives)
- [ ] Run gl-correction-queue.sql, gl-correction-queue-triggers.sql, gl-correction-queue-menu.sql on prod + CALL RefreshMenuCache()

🤖 Generated with [Claude Code](https://claude.com/claude-code)