### PR TITLE
Move landing page testimonials higher for mobile

### DIFF
--- a/public/landing.html
+++ b/public/landing.html
@@ -335,6 +335,47 @@
   </div>
 </section>
 
+<section id="testimonials">
+  <div class="wrap">
+    <div class="section-head">
+      <div class="kicker">From dealers running PetroMath</div>
+      <h2>What real outlets say</h2>
+    </div>
+    <div class="testimonials">
+      <div class="testimonial-card">
+        <p class="testimonial-quote">DSM closing used to take half a day just to track down the suspense amount — with PetroMath it's a fraction of that. Being cloud-based, we can pull and send statements from anywhere, even on mobile. Uploading bank statements and oil company SOAs is seamless, and reconciling digital sales against bank deposits is far simpler now.</p>
+        <div class="testimonial-attribution">
+          <img class="testimonial-avatar" src="/images/srinivasa-fuel-owner.jpg" alt="Owner, Srinivasa Fuel Station">
+          <div>
+            <div class="testimonial-name">Srinivasa Fuel Station</div>
+            <div class="testimonial-role">BPCL Dealer &middot; Sriperumbudur, TN</div>
+          </div>
+        </div>
+      </div>
+      <div class="testimonial-card">
+        <p class="testimonial-quote">PetroMath is user-friendly enough that even a layman can manage day-to-day operations — financial and non-financial. Shift closing, day close, digital reconciliation, bank deposit reconciliation, and credit party management make accounting for the firm's finances far easier. The GST reports make filing returns straightforward.</p>
+        <div class="testimonial-attribution">
+          <img class="testimonial-avatar" src="/images/sp-fuel-point-owner.jpg" alt="Owner, S P Fuel Point">
+          <div>
+            <div class="testimonial-name">S P Fuel Point</div>
+            <div class="testimonial-role">IOCL Dealer &middot; Telangana</div>
+          </div>
+        </div>
+      </div>
+      <div class="testimonial-card">
+        <p class="testimonial-quote">Before PetroMath, matching cashier sales against bank credits was a daily struggle, and Paytm reconciliation meant checking every transaction by hand. Now Paytm matching is fully automated — the system flags the difference itself. Shift closing and stock variance are ready the same day, and being cloud-based, the owner can check everything from mobile even when away from the bunk.</p>
+        <div class="testimonial-attribution">
+          <img class="testimonial-avatar" src="/images/balasekaran-agencies-owner.jpg" alt="Owner, Balasekaran Agencies">
+          <div>
+            <div class="testimonial-name">Balasekaran Agencies</div>
+            <div class="testimonial-role">IOCL Dealer &middot; Coimbatore, TN</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
 <section id="features">
   <div class="wrap">
     <div class="section-head">
@@ -530,47 +571,6 @@
         <div class="num">4</div>
         <h4>Books close themselves</h4>
         <p>GL journal entries post automatically, and stock, GST, and variance reports are ready to review.</p>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section id="testimonials">
-  <div class="wrap">
-    <div class="section-head">
-      <div class="kicker">From dealers running PetroMath</div>
-      <h2>What real outlets say</h2>
-    </div>
-    <div class="testimonials">
-      <div class="testimonial-card">
-        <p class="testimonial-quote">DSM closing used to take half a day just to track down the suspense amount — with PetroMath it's a fraction of that. Being cloud-based, we can pull and send statements from anywhere, even on mobile. Uploading bank statements and oil company SOAs is seamless, and reconciling digital sales against bank deposits is far simpler now.</p>
-        <div class="testimonial-attribution">
-          <img class="testimonial-avatar" src="/images/srinivasa-fuel-owner.jpg" alt="Owner, Srinivasa Fuel Station">
-          <div>
-            <div class="testimonial-name">Srinivasa Fuel Station</div>
-            <div class="testimonial-role">BPCL Dealer &middot; Sriperumbudur, TN</div>
-          </div>
-        </div>
-      </div>
-      <div class="testimonial-card">
-        <p class="testimonial-quote">PetroMath is user-friendly enough that even a layman can manage day-to-day operations — financial and non-financial. Shift closing, day close, digital reconciliation, bank deposit reconciliation, and credit party management make accounting for the firm's finances far easier. The GST reports make filing returns straightforward.</p>
-        <div class="testimonial-attribution">
-          <img class="testimonial-avatar" src="/images/sp-fuel-point-owner.jpg" alt="Owner, S P Fuel Point">
-          <div>
-            <div class="testimonial-name">S P Fuel Point</div>
-            <div class="testimonial-role">IOCL Dealer &middot; Telangana</div>
-          </div>
-        </div>
-      </div>
-      <div class="testimonial-card">
-        <p class="testimonial-quote">Before PetroMath, matching cashier sales against bank credits was a daily struggle, and Paytm reconciliation meant checking every transaction by hand. Now Paytm matching is fully automated — the system flags the difference itself. Shift closing and stock variance are ready the same day, and being cloud-based, the owner can check everything from mobile even when away from the bunk.</p>
-        <div class="testimonial-attribution">
-          <img class="testimonial-avatar" src="/images/balasekaran-agencies-owner.jpg" alt="Owner, Balasekaran Agencies">
-          <div>
-            <div class="testimonial-name">Balasekaran Agencies</div>
-            <div class="testimonial-role">IOCL Dealer &middot; Coimbatore, TN</div>
-          </div>
-        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Moved the testimonials/feedback section on the landing page to appear right after the hero instead of near the bottom, so mobile visitors don't have to scroll through the whole page to see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)