### PR TITLE
Move cashflow types onto Account Heads/Ledger Rules; simplify GL cashflow processing

### DIFF
--- a/controllers/account-heads-controller.js
+++ b/controllers/account-heads-controller.js
@@ -3,6 +3,18 @@ const AccountHeadsDao    = require("../dao/account-heads-dao");
 const LedgerRulesDao     = require("../dao/ledger-rules-dao");
 const BankDao            = require("../dao/bank-dao");
 const rolePermissionsDao = require("../dao/role-permissions-dao");
+const { getLedgersByGroup } = require('../routes/gl-routes');
+const db = require('../db/db-connection');
+const { QueryTypes } = require('sequelize');
+
+async function getAllGlGroups(locationCode) {
+    return db.sequelize.query(`
+        SELECT group_id, group_name, group_nature
+        FROM gl_ledger_groups
+        WHERE location_code = :locationCode AND active_flag = 'Y'
+        ORDER BY group_nature, group_name
+    `, { replacements: { locationCode }, type: QueryTypes.SELECT });
+}
 
 module.exports = {
 
@@ -12,11 +24,12 @@ module.exports = {
             const role         = req.user.Role;
             const activeTab    = req.query.tab || 'heads';
 
-            const [accountHeads, allRules, banks,
+            const [accountHeads, allRules, banks, glGroups,
                    canEdit, canAdd, canDisable] = await Promise.all([
                 AccountHeadsDao.getAccountHeads(locationCode),
                 LedgerRulesDao.getAllRules(locationCode),
                 BankDao.findAll(locationCode),
+                getAllGlGroups(locationCode),
                 rolePermissionsDao.hasPermission(role, locationCode, 'EDIT_ACCOUNT_HEADS'),
                 rolePermissionsDao.hasPermission(role, locationCode, 'ADD_ACCOUNT_HEADS'),
                 rolePermissionsDao.hasPermission(role, locationCode, 'DISABLE_ACCOUNT_HEADS'),
@@ -28,6 +41,7 @@ module.exports = {
                 accountHeads,
                 allRules,
                 banks,
+                glGroups,
                 canEdit,
                 canAdd,
                 canDisable,
@@ -84,7 +98,7 @@ module.exports = {
             res.redirect("/account-heads");
         } catch (err) {
             console.error("Error updating account head:", err);
-            req.flash("error", "Error updating account head");
+            req.flash("error", err.message || "Error updating account head");
             res.redirect("/account-heads");
         }
     },
@@ -99,7 +113,7 @@ module.exports = {
             res.redirect("/account-heads");
         } catch (err) {
             console.error("Error deactivating account head:", err);
-            req.flash("error", "Error deactivating account head");
+            req.flash("error", err.message || "Error deactivating account head");
             res.redirect("/account-heads");
         }
     },
@@ -110,10 +124,17 @@ module.exports = {
 
     createRule: async (req, res, next) => {
         try {
+            const appliesToCashflow = req.body.applies_to_cashflow === 'Y' ? 'Y' : 'N';
+
+            if (appliesToCashflow === 'Y') {
+                const dup = await LedgerRulesDao.findCashflowRuleByHead(req.user.location_code, req.body.account_head_id);
+                if (dup) throw new Error("A Cashflow rule for this Account Head already exists");
+            }
+
             // external_id and ledger_name come from the account head dropdown selection
             const data = {
                 location_code:        req.user.location_code,
-                bank_id:              req.body.bank_id,
+                bank_id:              appliesToCashflow === 'Y' ? null : req.body.bank_id,
                 external_id:          req.body.account_head_id,
                 ledger_name:          req.body.ledger_name,
                 allowed_entry_type:   req.body.allowed_entry_type,
@@ -122,6 +143,7 @@ module.exports = {
                 effective_start_date: req.body.effective_start_date  || null,
                 effective_end_date:   req.body.effective_end_date    || null,
                 allow_split_flag:     req.body.allow_split_flag      === 'Y' ? 'Y' : 'N',
+                applies_to_cashflow:  appliesToCashflow,
                 created_by:           req.user.username || req.user.Person_id
             };
 
@@ -132,7 +154,7 @@ module.exports = {
             console.error("Error creating ledger rule:", err);
             const msg = err.original?.code === 'ER_DUP_ENTRY'
                 ? "A rule for this Bank + Account Head combination already exists"
-                : (err.original?.sqlMessage || "Error creating ledger rule");
+                : (err.original?.sqlMessage || err.message || "Error creating ledger rule");
             req.flash("error", msg);
             res.redirect("/account-heads?tab=rules");
         }
@@ -140,9 +162,16 @@ module.exports = {
 
     updateRule: async (req, res, next) => {
         try {
+            const appliesToCashflow = req.body.applies_to_cashflow === 'Y' ? 'Y' : 'N';
+
+            if (appliesToCashflow === 'Y') {
+                const dup = await LedgerRulesDao.findCashflowRuleByHead(req.user.location_code, req.body.account_head_id, req.body.rule_id);
+                if (dup) throw new Error("A Cashflow rule for this Account Head already exists");
+            }
+
             const data = {
                 rule_id:              req.body.rule_id,
-                bank_id:              req.body.bank_id,
+                bank_id:              appliesToCashflow === 'Y' ? null : req.body.bank_id,
                 external_id:          req.body.account_head_id,
                 ledger_name:          req.body.ledger_name,
                 allowed_entry_type:   req.body.allowed_entry_type,
@@ -151,6 +180,7 @@ module.exports = {
                 effective_start_date: req.body.effective_start_date  || null,
                 effective_end_date:   req.body.effective_end_date    || null,
                 allow_split_flag:     req.body.allow_split_flag      === 'Y' ? 'Y' : 'N',
+                applies_to_cashflow:  appliesToCashflow,
                 updated_by:           req.user.username || req.user.Person_id
             };
 
@@ -161,7 +191,7 @@ module.exports = {
             console.error("Error updating ledger rule:", err);
             const msg = err.original?.code === 'ER_DUP_ENTRY'
                 ? "A rule for this Bank + Account Head combination already exists"
-                : (err.original?.sqlMessage || "Error updating ledger rule");
+                : (err.original?.sqlMessage || err.message || "Error updating ledger rule");
             req.flash("error", msg);
             res.redirect("/account-heads?tab=rules");
         }
@@ -198,6 +228,19 @@ module.exports = {
     },
 
     // ── Credit / Supplier — entry type override only ──────────────────────
+
+    updateGlGroup: async (req, res, next) => {
+        try {
+            const id       = req.params.id;
+            const glGroupId = req.body.gl_group_id || null;
+            const updatedBy = req.user.username || req.user.Person_id;
+            await AccountHeadsDao.updateGlGroup(id, glGroupId, updatedBy);
+            res.json({ success: true });
+        } catch (err) {
+            console.error('Error updating GL group:', err);
+            res.status(500).json({ error: err.message });
+        }
+    },
 
     updateEntryType: async (req, res, next) => {
         try {

--- a/controllers/cash-flow-controller.js
+++ b/controllers/cash-flow-controller.js
@@ -297,26 +297,16 @@ function getManagerNames(closingValues, cashflowDate, personData) {
     return managers.toString();
 }
 
-function collectCreditAndDebits(tableJoinData) {
-    let creditOrDebits = [], options = [];
-    if(tableJoinData) {
-        tableJoinData.forEach((data) => {
-            options.push({id: data.lookup_id, name: data.description});
-            let t_cashflows = data.t_cashflow_transactions;
-            if (t_cashflows && t_cashflows.length > 0) {
-                t_cashflows.forEach((t_cashflow) => {
-                    creditOrDebits.push({
-                        txn_id: t_cashflow.transaction_id,
-                        description: t_cashflow.description,
-                        amount: t_cashflow.amount,
-                        type: t_cashflow.type,
-                        calcFlag: t_cashflow.calcFlag
-                    });
-                });
-            }
-        });
-    }
-    return {data : creditOrDebits, options: options};
+function collectCreditAndDebits(result) {
+    if (!result) return { data: [], options: [] };
+    const creditOrDebits = (result.transactions || []).map((t) => ({
+        txn_id: t.transaction_id,
+        description: t.description,
+        amount: t.amount,
+        type: t.type,
+        calcFlag: t.calcFlag
+    }));
+    return { data: creditOrDebits, options: result.options || [] };
 }
 
 

--- a/dao/account-heads-dao.js
+++ b/dao/account-heads-dao.js
@@ -5,25 +5,29 @@ const { QueryTypes } = require("sequelize");
 module.exports = {
     getAccountHeads: async (locationCode, includeInactive = false) => {
         let query = `
-            SELECT 
-                account_head_id,
-                account_head_name,
-                account_head_type,
-                allowed_entry_type,
-                notes_required_flag,
-                active_flag,
-                effective_start_date,
-                effective_end_date,
-                created_by,
-                updated_by,
-                creation_date,
-                updation_date
-            FROM m_account_heads
-            WHERE location_code = :locationCode
+            SELECT
+                ah.account_head_id,
+                ah.account_head_name,
+                ah.account_head_type,
+                ah.allowed_entry_type,
+                ah.notes_required_flag,
+                ah.active_flag,
+                ah.is_system_type,
+                ah.effective_start_date,
+                ah.effective_end_date,
+                ah.gl_group_id,
+                g.group_name AS gl_group_name,
+                ah.created_by,
+                ah.updated_by,
+                ah.creation_date,
+                ah.updation_date
+            FROM m_account_heads ah
+            LEFT JOIN gl_ledger_groups g ON g.group_id = ah.gl_group_id
+            WHERE ah.location_code = :locationCode
         `;
 
-        if (!includeInactive) query += " AND active_flag = 'Y'";
-        query += " ORDER BY account_head_type, account_head_name";
+        if (!includeInactive) query += " AND ah.active_flag = 'Y'";
+        query += " ORDER BY ah.account_head_type, ah.account_head_name";
 
         return await db.sequelize.query(query, {
             replacements: { locationCode },
@@ -62,6 +66,11 @@ module.exports = {
     },
 
     updateAccountHead: async (data) => {
+        const existing = await module.exports.getAccountHeadById(data.account_head_id);
+        if (existing && existing.is_system_type === 'Y' && existing.account_head_name !== data.account_head_name) {
+            throw new Error(`'${existing.account_head_name}' is a system-generated account head (used by cashflow auto-generation) and cannot be renamed`);
+        }
+
         const query = `
             UPDATE m_account_heads
             SET
@@ -83,6 +92,11 @@ module.exports = {
     },
 
     deactivateAccountHead: async (id, user) => {
+        const existing = await module.exports.getAccountHeadById(id);
+        if (existing && existing.is_system_type === 'Y') {
+            throw new Error(`'${existing.account_head_name}' is a system-generated account head (used by cashflow auto-generation) and cannot be deactivated`);
+        }
+
         const query = `
             UPDATE m_account_heads
             SET active_flag = 'N',
@@ -93,6 +107,46 @@ module.exports = {
         return await db.sequelize.query(query, {
             replacements: { id, user },
             type: QueryTypes.UPDATE
+        });
+    },
+
+    updateGlGroup: async (id, glGroupId, updatedBy) => {
+        // 1. Update m_account_heads
+        await db.sequelize.query(`
+            UPDATE m_account_heads
+            SET gl_group_id   = :glGroupId,
+                updated_by    = :updatedBy,
+                updation_date = NOW()
+            WHERE account_head_id = :id
+        `, {
+            replacements: { id, glGroupId: glGroupId || null, updatedBy },
+            type: QueryTypes.UPDATE
+        });
+
+        if (!glGroupId) return; // cleared — nothing to sync to gl_ledgers
+
+        // 2. Update gl_ledgers entry if it already exists
+        await db.sequelize.query(`
+            UPDATE gl_ledgers
+            SET group_id   = :glGroupId,
+                updated_by = :updatedBy
+            WHERE source_type = 'STATIC'
+              AND source_id   = :id
+        `, {
+            replacements: { id, glGroupId, updatedBy },
+            type: QueryTypes.UPDATE
+        });
+
+        // 3. Create gl_ledgers entry if it was missing (skipped in initial population)
+        await db.sequelize.query(`
+            INSERT IGNORE INTO gl_ledgers
+                (location_code, ledger_name, group_id, source_type, source_id, created_by)
+            SELECT ah.location_code, ah.account_head_name, :glGroupId, 'STATIC', ah.account_head_id, :updatedBy
+            FROM m_account_heads ah
+            WHERE ah.account_head_id = :id
+        `, {
+            replacements: { id, glGroupId, updatedBy },
+            type: QueryTypes.INSERT
         });
     },
 

--- a/dao/cashflow-closing-dao.js
+++ b/dao/cashflow-closing-dao.js
@@ -3,7 +3,6 @@ const CashFlowClosing = db.cashflow_closing;
 const CashFlowTxn = db.txn_cashflow;
 const ClosingTxn = db.txn_closing;
 const CashFlowDenoms = db.cashflow_denoms;
-const Lookup = db.lookup;
 const config = require("../config/app-config");
 const { Sequelize, Op } = require("sequelize");
 
@@ -84,21 +83,35 @@ module.exports = {
     addNew: (cashflowClosing) => {
         return CashFlowClosing.create(cashflowClosing)
     },
-    findCashflowTxnById: (location, id, type) => {
-        return Lookup.findAll({
-            where: {
-                location_code: location,
-                tag: type
-            },
-            include: [
-                {
-                    model: CashFlowTxn,
-                    where: {
-                        cashflow_id: id,
-                    },
-                    required: false
-                }],
-        });
+    // Dropdown options + existing entries for one flow direction (Credit/InFlow
+    // or Debit/OutFlow) of a cashflow. Options come from Account Heads that
+    // have a cashflow-scoped Ledger Rule (applies_to_cashflow='Y') for this
+    // direction; existing entries come straight off t_cashflow_transaction.entry_type
+    // (set at insert time — see trg_cashflow_txn_account_head_insert).
+    findCashflowTxnById: async (location, id, type) => {
+        const entryType = type === 'IN' ? 'CREDIT' : 'DEBIT';
+
+        const options = await db.sequelize.query(`
+            SELECT DISTINCT ah.account_head_id AS id, ah.account_head_name AS name
+            FROM m_account_heads ah
+            INNER JOIN m_ledger_rules mlr
+                ON  mlr.location_code = ah.location_code
+                AND mlr.external_id   = ah.account_head_id
+                AND mlr.source_type   = 'Static'
+                AND mlr.applies_to_cashflow = 'Y'
+                AND mlr.allowed_entry_type IN (:entryType, 'BOTH')
+            WHERE ah.location_code = :location AND ah.active_flag = 'Y'
+            ORDER BY ah.account_head_name
+        `, { replacements: { location, entryType }, type: Sequelize.QueryTypes.SELECT });
+
+        const transactions = await db.sequelize.query(`
+            SELECT transaction_id, description, amount, type, calc_flag AS calcFlag
+            FROM t_cashflow_transaction
+            WHERE cashflow_id = :id AND entry_type = :entryType
+            ORDER BY transaction_id
+        `, { replacements: { id, entryType }, type: Sequelize.QueryTypes.SELECT });
+
+        return { options, transactions };
     },
     triggerGenerateCashflow : (cashflowId) => {
         const cashflowTxn = db.sequelize.query('CALL generate_cashflow(' + cashflowId + ');', null, { raw: true });
@@ -106,7 +119,7 @@ module.exports = {
     },
     saveCashflowTxns: (data) => {
         const txns = CashFlowTxn.bulkCreate(data, {returning: true,
-            updateOnDuplicate: ["description", "type", "amount", "updated_by", "updation_date"]});
+            updateOnDuplicate: ["description", "type", "account_head_id", "amount", "updated_by", "updation_date"]});
         return txns;
     },
     delete: (id) => {

--- a/dao/ledger-rules-dao.js
+++ b/dao/ledger-rules-dao.js
@@ -4,9 +4,11 @@
 const db = require("../db/db-connection");
 const { QueryTypes } = require("sequelize");
 
-// Builds the bank display label: "SBI (...1234)" or just "SBI" when no account number.
+// Builds the bank display label: "Cashflow" for cashflow-scoped rules,
+// otherwise "SBI (...1234)" or just "SBI" when no account number.
 const BANK_DISPLAY = `
     CASE
+        WHEN r.applies_to_cashflow = 'Y' THEN 'Cashflow'
         WHEN b.account_number IS NOT NULL AND b.account_number != ''
         THEN CONCAT(b.bank_name, ' (...', RIGHT(b.account_number, 4), ')')
         ELSE b.bank_name
@@ -16,12 +18,14 @@ const BANK_DISPLAY = `
 module.exports = {
 
     // All rules for the location — Static + Credit + Supplier + Bank.
+    // bank_id is NULL for cashflow-scoped Static rules, hence LEFT JOIN.
     getAllRules: async (locationCode) => {
         const query = `
             SELECT
                 r.rule_id,
                 r.source_type,
                 r.bank_id,
+                r.applies_to_cashflow,
                 ${BANK_DISPLAY}          AS bank_display,
                 r.external_id,
                 CASE
@@ -37,12 +41,12 @@ module.exports = {
                 r.created_by,
                 r.updated_by
             FROM m_ledger_rules r
-            INNER JOIN m_bank b  ON b.bank_id  = r.bank_id
+            LEFT  JOIN m_bank b  ON b.bank_id  = r.bank_id
             LEFT  JOIN m_bank mb2
                 ON  r.source_type  = 'Bank'
                 AND r.external_id  = mb2.bank_id
             WHERE r.location_code = :locationCode
-            ORDER BY r.source_type, b.bank_name,
+            ORDER BY r.source_type, r.applies_to_cashflow DESC, b.bank_name,
                      CASE WHEN r.source_type = 'Bank' THEN mb2.ledger_name ELSE r.ledger_name END
         `;
         return await db.sequelize.query(query, {
@@ -53,18 +57,39 @@ module.exports = {
 
     // ── Static rule CRUD ────────────────────────────────────────────────────
 
+    // bank_id has no unique-index protection against duplicates when NULL
+    // (MySQL treats each NULL as distinct), so cashflow-scoped rules need an
+    // explicit app-level duplicate check — see createRule/updateRule in the
+    // controller.
+    findCashflowRuleByHead: async (locationCode, externalId, excludeRuleId = null) => {
+        const query = `
+            SELECT rule_id FROM m_ledger_rules
+            WHERE location_code = :locationCode
+              AND external_id   = :externalId
+              AND source_type   = 'Static'
+              AND applies_to_cashflow = 'Y'
+              ${excludeRuleId ? 'AND rule_id != :excludeRuleId' : ''}
+            LIMIT 1
+        `;
+        const rows = await db.sequelize.query(query, {
+            replacements: { locationCode, externalId, excludeRuleId },
+            type: QueryTypes.SELECT
+        });
+        return rows[0] || null;
+    },
+
     createStaticRule: async (data) => {
         const query = `
             INSERT INTO m_ledger_rules (
                 location_code, bank_id, source_type, external_id,
                 ledger_name, allowed_entry_type, notes_required_flag,
                 max_amount, effective_start_date, effective_end_date,
-                allow_split_flag, created_by
+                allow_split_flag, applies_to_cashflow, created_by
             ) VALUES (
                 :location_code, :bank_id, 'Static', :external_id,
                 :ledger_name, :allowed_entry_type, :notes_required_flag,
                 :max_amount, :effective_start_date, :effective_end_date,
-                :allow_split_flag, :created_by
+                :allow_split_flag, :applies_to_cashflow, :created_by
             )
         `;
         return await db.sequelize.query(query, {
@@ -86,6 +111,7 @@ module.exports = {
                 effective_start_date = :effective_start_date,
                 effective_end_date   = :effective_end_date,
                 allow_split_flag     = :allow_split_flag,
+                applies_to_cashflow  = :applies_to_cashflow,
                 updated_by           = :updated_by,
                 updation_date        = NOW()
             WHERE rule_id = :rule_id

--- a/db/migrations/cashflow-account-heads-correction-backfill.sql
+++ b/db/migrations/cashflow-account-heads-correction-backfill.sql
@@ -1,0 +1,158 @@
+-- ============================================================
+-- Correction: backfill account_head_id + entry_type, repoint the trigger
+-- Generated: 2026-08-17
+-- Updated:   2026-08-17 — added system-type fallback for entry_type. Some
+-- GL-enabled locations (e.g. NS) have real cashflow transactions using the
+-- 10 system-protected types but never had a matching m_lookup(CashFlow) row
+-- for them, so the m_lookup-only join left entry_type NULL even though
+-- account_head_id resolved fine via the guaranteed system-type seeding.
+-- The fallback below uses the same universal name -> direction mapping
+-- already used in cashflow-account-heads-correction-seed.sql (confirmed
+-- 100% consistent tag across every location for these 10 types).
+--
+-- entry_type is meant to be set at cashflow-entry time going forward (which
+-- section of the screen the user filled in) — that UI change is separate,
+-- future work. Until it ships, this trigger derives entry_type from
+-- m_lookup.tag (falling back to the system-type mapping), so every row
+-- always has a value and the GL engine never needs to guess or join
+-- anything at processing time — it only ever reads columns already on the
+-- row.
+-- ============================================================
+
+-- ── Step 1: backfill existing rows ─────────────────────────────────────────
+
+UPDATE t_cashflow_transaction tct
+JOIN t_cashflow_closing tcc ON tcc.cashflow_id = tct.cashflow_id
+JOIN m_account_heads mah ON mah.location_code = tcc.location_code AND mah.account_head_name = tct.type
+SET tct.account_head_id = mah.account_head_id
+WHERE tct.account_head_id IS NULL;
+
+UPDATE t_cashflow_transaction tct
+JOIN t_cashflow_closing tcc ON tcc.cashflow_id = tct.cashflow_id
+JOIN m_lookup ml ON ml.lookup_type = 'CashFlow' AND ml.description = tct.type
+    AND (ml.location_code = tcc.location_code OR ml.location_code IS NULL)
+SET tct.entry_type = CASE ml.tag WHEN 'IN' THEN 'CREDIT' WHEN 'OUT' THEN 'DEBIT' END
+WHERE tct.entry_type IS NULL;
+
+-- System-type fallback — closes the NS-style gap (m_lookup missing rows for
+-- types m_account_heads was guaranteed-seeded with).
+UPDATE t_cashflow_transaction tct
+SET tct.entry_type = CASE tct.type
+    WHEN 'Balance B/F' THEN 'CREDIT'
+    WHEN 'Collection' THEN 'CREDIT'
+    WHEN '2T Oil' THEN 'CREDIT'
+    WHEN 'Discount' THEN 'DEBIT'
+    WHEN 'Cashier A/C (+)' THEN 'CREDIT'
+    WHEN 'Cashier A/C (-)' THEN 'DEBIT'
+    WHEN 'Cash Receipt' THEN 'CREDIT'
+    WHEN 'Expense' THEN 'DEBIT'
+    WHEN 'Salary Payout' THEN 'DEBIT'
+    WHEN 'Salary Recovery' THEN 'CREDIT'
+    ELSE NULL
+END
+WHERE tct.entry_type IS NULL;
+
+-- ── Step 2: repoint the auto-populate trigger ──────────────────────────────
+
+DROP TRIGGER IF EXISTS trg_cashflow_txn_ledger_rule_insert;
+DROP TRIGGER IF EXISTS trg_cashflow_txn_ledger_rule_update;
+
+DELIMITER $$
+
+CREATE TRIGGER trg_cashflow_txn_account_head_insert
+BEFORE INSERT ON t_cashflow_transaction
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+
+    IF NEW.type IS NOT NULL THEN
+        SELECT location_code INTO v_location_code
+        FROM t_cashflow_closing WHERE cashflow_id = NEW.cashflow_id;
+
+        IF v_location_code IS NOT NULL THEN
+            IF NEW.account_head_id IS NULL THEN
+                SELECT account_head_id INTO @v_ah
+                FROM m_account_heads
+                WHERE location_code = v_location_code AND account_head_name = NEW.type
+                LIMIT 1;
+                SET NEW.account_head_id = @v_ah;
+            END IF;
+
+            IF NEW.entry_type IS NULL THEN
+                SELECT CASE tag WHEN 'IN' THEN 'CREDIT' WHEN 'OUT' THEN 'DEBIT' END INTO @v_et
+                FROM m_lookup
+                WHERE lookup_type = 'CashFlow' AND description = NEW.type
+                  AND (location_code = v_location_code OR location_code IS NULL)
+                ORDER BY (location_code = v_location_code) DESC
+                LIMIT 1;
+                IF @v_et IS NULL THEN
+                    SET @v_et = CASE NEW.type
+                        WHEN 'Balance B/F' THEN 'CREDIT'
+                        WHEN 'Collection' THEN 'CREDIT'
+                        WHEN '2T Oil' THEN 'CREDIT'
+                        WHEN 'Discount' THEN 'DEBIT'
+                        WHEN 'Cashier A/C (+)' THEN 'CREDIT'
+                        WHEN 'Cashier A/C (-)' THEN 'DEBIT'
+                        WHEN 'Cash Receipt' THEN 'CREDIT'
+                        WHEN 'Expense' THEN 'DEBIT'
+                        WHEN 'Salary Payout' THEN 'DEBIT'
+                        WHEN 'Salary Recovery' THEN 'CREDIT'
+                        ELSE NULL
+                    END;
+                END IF;
+                SET NEW.entry_type = @v_et;
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+CREATE TRIGGER trg_cashflow_txn_account_head_update
+BEFORE UPDATE ON t_cashflow_transaction
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+
+    IF NOT (OLD.type <=> NEW.type) THEN
+        SELECT location_code INTO v_location_code
+        FROM t_cashflow_closing WHERE cashflow_id = NEW.cashflow_id;
+
+        IF v_location_code IS NOT NULL THEN
+            SELECT account_head_id INTO @v_ah
+            FROM m_account_heads
+            WHERE location_code = v_location_code AND account_head_name = NEW.type
+            LIMIT 1;
+            SET NEW.account_head_id = @v_ah;
+
+            SELECT CASE tag WHEN 'IN' THEN 'CREDIT' WHEN 'OUT' THEN 'DEBIT' END INTO @v_et
+            FROM m_lookup
+            WHERE lookup_type = 'CashFlow' AND description = NEW.type
+              AND (location_code = v_location_code OR location_code IS NULL)
+            ORDER BY (location_code = v_location_code) DESC
+            LIMIT 1;
+            IF @v_et IS NULL THEN
+                SET @v_et = CASE NEW.type
+                    WHEN 'Balance B/F' THEN 'CREDIT'
+                    WHEN 'Collection' THEN 'CREDIT'
+                    WHEN '2T Oil' THEN 'CREDIT'
+                    WHEN 'Discount' THEN 'DEBIT'
+                    WHEN 'Cashier A/C (+)' THEN 'CREDIT'
+                    WHEN 'Cashier A/C (-)' THEN 'DEBIT'
+                    WHEN 'Cash Receipt' THEN 'CREDIT'
+                    WHEN 'Expense' THEN 'DEBIT'
+                    WHEN 'Salary Payout' THEN 'DEBIT'
+                    WHEN 'Salary Recovery' THEN 'CREDIT'
+                    ELSE NULL
+                END;
+            END IF;
+            SET NEW.entry_type = @v_et;
+        END IF;
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- ── Verify ──────────────────────────────────────────────────────────────────
+SELECT COUNT(*) total_rows,
+       SUM(account_head_id IS NOT NULL) has_account_head,
+       SUM(entry_type IS NOT NULL) has_entry_type
+FROM t_cashflow_transaction;

--- a/db/migrations/cashflow-account-heads-correction-schema.sql
+++ b/db/migrations/cashflow-account-heads-correction-schema.sql
@@ -1,0 +1,52 @@
+-- ============================================================
+-- Correction: cashflow types belong on m_account_heads, not m_ledger_rules
+-- Generated: 2026-08-17
+--
+-- The previous migration (cashflow-into-ledger-rules-*.sql) inserted
+-- cashflow types directly into m_ledger_rules as raw strings — wrong
+-- table. The real model, per the actual Accounting Masters screen already
+-- in use:
+--   m_account_heads = just a ledger name (+ optional gl_group_id sync to
+--                     gl_ledgers). No usage rules live here.
+--   m_ledger_rules  = the real rules — each row scopes ONE Account Head to
+--                     ONE context (a specific bank, OR cashflow — never
+--                     both in one row) with that context's own
+--                     allowed_entry_type. One Account Head can have
+--                     several rule rows, one per context.
+--   gl_static_ledger_map = unchanged — still the sole bridge from a label
+--                     name to POST/SKIP/CONTRA. The GL engine never reads
+--                     m_ledger_rules or m_account_heads for direction or
+--                     ledger resolution; it only reads
+--                     t_cashflow_transaction (account_head_id + entry_type,
+--                     both already resolved before processing time) and
+--                     gl_static_ledger_map.
+-- ============================================================
+
+-- ── t_cashflow_transaction ──────────────────────────────────────────────────
+
+ALTER TABLE t_cashflow_transaction
+    ADD COLUMN account_head_id INT NULL COMMENT 'FK to m_account_heads.account_head_id — replaces ledger_rule_id',
+    ADD COLUMN entry_type ENUM('CREDIT', 'DEBIT') NULL COMMENT 'Set at entry time (which section of the cashflow screen); GL engine reads this directly, no lookup';
+
+-- ledger_rule_id pointed at the wrong table entirely — drop it, nothing
+-- downstream depends on it (the code using it was never deployed to prod).
+ALTER TABLE t_cashflow_transaction DROP COLUMN ledger_rule_id;
+
+-- ── m_ledger_rules ───────────────────────────────────────────────────────────
+
+ALTER TABLE m_ledger_rules
+    ADD COLUMN applies_to_cashflow CHAR(1) NOT NULL DEFAULT 'N' COMMENT 'Y = this rule row scopes its Account Head to Cashflow instead of a bank';
+
+-- usable_in_cashflow / is_system_type were added to the wrong table in the
+-- earlier migration — is_system_type moves to m_account_heads below;
+-- usable_in_cashflow is superseded by applies_to_cashflow (a real rule row,
+-- not a flag on every row). display_sequence stays — still useful for
+-- ordering the cashflow dropdown.
+ALTER TABLE m_ledger_rules
+    DROP COLUMN usable_in_cashflow,
+    DROP COLUMN is_system_type;
+
+-- ── m_account_heads ──────────────────────────────────────────────────────────
+
+ALTER TABLE m_account_heads
+    ADD COLUMN is_system_type CHAR(1) NOT NULL DEFAULT 'N' COMMENT 'Y = seeded by generate_cashflow, cannot be deleted';

--- a/db/migrations/cashflow-account-heads-correction-seed.sql
+++ b/db/migrations/cashflow-account-heads-correction-seed.sql
@@ -1,0 +1,85 @@
+-- ============================================================
+-- Correction: seed m_account_heads + cashflow-scoped m_ledger_rules
+-- Generated: 2026-08-17
+-- No unique key on (location_code, account_head_name) in m_account_heads —
+-- guarded with NOT EXISTS throughout, safe to re-run.
+-- ============================================================
+
+-- ── Step 1: Account Heads — one per distinct real cashflow type ────────────
+-- Reuse an existing Account Head with the same name if one's already there
+-- (e.g. from bank-categorization work); only create when genuinely new.
+
+INSERT INTO m_account_heads
+    (location_code, account_head_name, allowed_entry_type, is_system_type,
+     effective_start_date, created_by, updated_by)
+SELECT cf.location_code, cf.description,
+       CASE cf.tag WHEN 'IN' THEN 'CREDIT' WHEN 'OUT' THEN 'DEBIT' END,
+       CASE WHEN cf.description IN
+           ('Balance B/F','Collection','2T Oil','Discount','Cashier A/C (+)','Cashier A/C (-)','Cash Receipt','Expense','Salary Payout','Salary Recovery')
+           THEN 'Y' ELSE 'N' END,
+       '2025-04-01', 'MIGRATION', 'MIGRATION'
+FROM (
+    SELECT DISTINCT ml.location_code, ml.description, ml.tag
+    FROM m_lookup ml
+    WHERE ml.lookup_type = 'CashFlow'
+      AND EXISTS (SELECT 1 FROM t_cashflow_transaction tct WHERE tct.type = ml.description)
+) cf
+WHERE NOT EXISTS (
+    SELECT 1 FROM m_account_heads mah
+    WHERE mah.location_code = cf.location_code AND mah.account_head_name = cf.description
+);
+
+-- ── Step 2: guarantee the 10 system-generated types exist for every
+--    GL-enabled location, same reasoning as before (generate_cashflow can
+--    fire any of them for any location). Tag confirmed 100% consistent
+--    across every location that's used each type. ─────────────────────────
+
+INSERT INTO m_account_heads
+    (location_code, account_head_name, allowed_entry_type, is_system_type,
+     effective_start_date, created_by, updated_by)
+SELECT loc.location_code, t.name, t.entry_type, 'Y', '2025-04-01', 'MIGRATION', 'MIGRATION'
+FROM (SELECT DISTINCT location_code FROM gl_ledgers) loc
+CROSS JOIN (
+    SELECT 'Balance B/F' name, 'CREDIT' entry_type
+    UNION ALL SELECT 'Collection', 'CREDIT'
+    UNION ALL SELECT '2T Oil', 'CREDIT'
+    UNION ALL SELECT 'Discount', 'DEBIT'
+    UNION ALL SELECT 'Cashier A/C (+)', 'CREDIT'
+    UNION ALL SELECT 'Cashier A/C (-)', 'DEBIT'
+    UNION ALL SELECT 'Cash Receipt', 'CREDIT'
+    UNION ALL SELECT 'Expense', 'DEBIT'
+    UNION ALL SELECT 'Salary Payout', 'DEBIT'
+    UNION ALL SELECT 'Salary Recovery', 'CREDIT'
+) t
+WHERE NOT EXISTS (
+    SELECT 1 FROM m_account_heads mah
+    WHERE mah.location_code = loc.location_code AND mah.account_head_name = t.name
+);
+
+-- ── Step 3: a cashflow-scoped Ledger Rule (applies_to_cashflow='Y') for
+--    every Account Head that's actually used as a cashflow type — bank_id
+--    NULL (not bank-scoped), external_id = the Account Head, ledger_name
+--    denormalized to match createStaticRule's existing convention. ────────
+
+INSERT INTO m_ledger_rules
+    (location_code, source_type, external_id, ledger_name, allowed_entry_type,
+     applies_to_cashflow, display_sequence, created_by, updated_by)
+SELECT mah.location_code, 'Static', mah.account_head_id, mah.account_head_name,
+       mah.allowed_entry_type, 'Y', seq.display_sequence, 'MIGRATION', 'MIGRATION'
+FROM m_account_heads mah
+LEFT JOIN (
+    SELECT DISTINCT location_code, description, MIN(attribute1 + 0) AS display_sequence
+    FROM m_lookup WHERE lookup_type = 'CashFlow'
+    GROUP BY location_code, description
+) seq ON seq.location_code = mah.location_code AND seq.description = mah.account_head_name
+WHERE mah.created_by = 'MIGRATION'
+  AND NOT EXISTS (
+      SELECT 1 FROM m_ledger_rules mlr
+      WHERE mlr.location_code = mah.location_code AND mlr.external_id = mah.account_head_id
+        AND mlr.source_type = 'Static' AND mlr.applies_to_cashflow = 'Y'
+  );
+
+-- ── Verify ──────────────────────────────────────────────────────────────────
+SELECT COUNT(*) AS account_heads_created FROM m_account_heads WHERE created_by = 'MIGRATION';
+SELECT COUNT(*) AS system_type_account_heads FROM m_account_heads WHERE is_system_type = 'Y';
+SELECT COUNT(*) AS cashflow_scoped_rules FROM m_ledger_rules WHERE applies_to_cashflow = 'Y';

--- a/db/txn-cashflow.js
+++ b/db/txn-cashflow.js
@@ -21,6 +21,11 @@ module.exports = function(sequelize, DataTypes) {
             field: 'type',
             type: DataTypes.STRING
         },
+        account_head_id: {
+            field: 'account_head_id',
+            type: DataTypes.INTEGER,
+            allowNull: true
+        },
         amount: {
             field: 'amount',
             type: DataTypes.DECIMAL

--- a/public/javascripts/app-master-page-scripts.js
+++ b/public/javascripts/app-master-page-scripts.js
@@ -302,6 +302,7 @@ function formCashFlowTxn(txnId, prefix, rowNum, user) {
         'cashflowId': document.getElementById('cashflowId_hiddenId').value,
         'description': document.getElementById(prefix + 'remarks-' + rowNum).value,
         'type': typeObj.options[typeObj.selectedIndex].text,
+        'account_head_id': typeObj.value,
         'amount': document.getElementById(prefix + 'amt-' + rowNum).value,
         'calcFlag': 'N',
         'created_by': user.User_Name,

--- a/services/create-accounting-service.js
+++ b/services/create-accounting-service.js
@@ -12,11 +12,11 @@
 //   LUBES_INVOICE       (source_id = lubes_hdr_id)     — Purchase DR + Input CGST/SGST DR / Supplier CR
 //   TANK_INVOICE        (source_id = t_tank_invoice.id)— Purchase DR + Charges DR / Supplier CR
 //   CASHFLOW_TXN        (source_id = transaction_id)   — calc_flag='N' cashflow-close lines only.
-//                                                         Direction + ledger resolution both come from
-//                                                         ledger_rule_id -> m_ledger_rules (shared with
-//                                                         BANK_TXN's Static labels — see resolveStaticLedger).
-//                                                         Never blocks processing; unmapped labels fall
-//                                                         back to "Unclassified Cashflow".
+//                                                         Direction comes from entry_type on the row itself;
+//                                                         ledger resolution goes through the linked Account
+//                                                         Head's name -> resolveStaticLedger (shared with
+//                                                         BANK_TXN's Static labels). Never blocks processing;
+//                                                         unmapped labels fall back to "Unclassified Cashflow".
 //   ADJUSTMENT          (source_id = adjustment_id)    — customer/vendor/bank corrections + opening
 //                                                         balances (adjustment_type=201 → "Opening Balance
 //                                                         Equity", off the P&L; other types resolve by
@@ -1206,20 +1206,22 @@ async function processTankInvoiceEvent(event, processedBy) {
 
 // ─── CASHFLOW_TXN Handler ─────────────────────────────────────────────────────
 // Only calc_flag='N' rows reach this handler (calc_flag='Y' rows never raise an
-// event — see trg_cashflow_txn_gl_insert). Direction and ledger resolution both
-// come from t_cashflow_transaction.ledger_rule_id -> m_ledger_rules — the same
-// Static Ledger label system BANK_TXN uses (see resolveStaticLedger), not a
-// separate cashflow-only mapping. tag='OUT' → cash left the drawer (DR resolved
-// ledger / CR Cash-in-Hand). tag='IN' → cash came in (reverse).
+// event — see trg_cashflow_txn_gl_insert). Direction comes straight off
+// t_cashflow_transaction.entry_type (resolved before processing time by the
+// account-head trigger, or by the entry UI once that ships). Ledger resolution
+// goes through the Account Head's name -> resolveStaticLedger -> gl_static_ledger_map,
+// same as BANK_TXN. The engine never joins m_ledger_rules or m_account_heads for
+// direction — allowed_entry_type there is a data-entry-time constraint, not a
+// per-row fact.
 
 async function processCashflowTxnEvent(event, processedBy) {
     const { location_code, fy_id, source_id: transactionId, event_date } = event;
 
     const rows = await db.sequelize.query(`
         SELECT tct.transaction_id, tct.type, tct.description, tct.amount, tct.calc_flag,
-               mlr.ledger_name AS rule_ledger_name, mlr.allowed_entry_type
+               tct.entry_type, mah.account_head_name
         FROM t_cashflow_transaction tct
-        LEFT JOIN m_ledger_rules mlr ON mlr.rule_id = tct.ledger_rule_id
+        LEFT JOIN m_account_heads mah ON mah.account_head_id = tct.account_head_id
         WHERE tct.transaction_id = :transactionId
     `, { replacements: { transactionId }, type: QueryTypes.SELECT });
 
@@ -1238,36 +1240,15 @@ async function processCashflowTxnEvent(event, processedBy) {
         return { voucherCount: 0 };
     }
 
-    let tag;
-    if (row.allowed_entry_type === 'CREDIT') {
-        tag = 'IN';
-    } else if (row.allowed_entry_type === 'DEBIT') {
-        tag = 'OUT';
-    } else if (row.allowed_entry_type === 'BOTH') {
-        // No per-entry Cr/Dr column exists yet on t_cashflow_transaction — a
-        // BOTH-direction rule can't be resolved automatically. Not hit by any
-        // real data today (verified: every CashFlow type in use is strictly
-        // IN or OUT), so this is a deliberate stop, not a silent guess.
-        throw new Error(`Cashflow type '${row.type}' is mapped to ledger rule '${row.rule_ledger_name}' with allowed_entry_type=BOTH — direction can't be inferred per-entry. Split into separate CREDIT/DEBIT rules, or add an entry-level direction column.`);
-    } else {
-        // Legacy fallback — row predates the ledger_rule_id backfill/trigger
-        // (shouldn't happen post-migration; kept as a safety net).
-        const tagRows = await db.sequelize.query(`
-            SELECT tag FROM m_lookup
-            WHERE lookup_type = 'CashFlow' AND description = :type
-              AND (location_code = :locationCode OR location_code IS NULL)
-            ORDER BY (location_code = :locationCode) DESC
-            LIMIT 1
-        `, { replacements: { type: row.type, locationCode: location_code }, type: QueryTypes.SELECT });
-        if (!tagRows.length) throw new Error(`Cashflow type '${row.type}' has no ledger rule and no legacy m_lookup CashFlow entry — cannot determine direction`);
-        tag = tagRows[0].tag;
-        if (tag !== 'IN' && tag !== 'OUT') throw new Error(`Cashflow type '${row.type}' has an unexpected legacy tag '${tag}' (expected IN/OUT)`);
+    if (row.entry_type !== 'CREDIT' && row.entry_type !== 'DEBIT') {
+        throw new Error(`Cashflow transaction ${transactionId} (type '${row.type}') has no entry_type set — cannot determine direction`);
     }
+    const tag = row.entry_type === 'CREDIT' ? 'IN' : 'OUT';
 
     const cashLedgerId = await resolveCashLedger(location_code);
     if (!cashLedgerId) throw new Error(`Cash-in-Hand ledger not found for location ${location_code}`);
 
-    const staticLedgerName = row.rule_ledger_name || row.type;
+    const staticLedgerName = row.account_head_name || row.type;
     const { treatment, ledgerId: counterLedgerId, isContra } =
         await resolveStaticLedger(location_code, staticLedgerName, true, 'Unclassified Cashflow');
 

--- a/views/account-heads.pug
+++ b/views/account-heads.pug
@@ -63,6 +63,7 @@ block content
                                     th Active
                                     th Effective From
                                     th Effective To
+                                    th GL Group
                                     if canEdit
                                         th Edit
                                     if canDisable
@@ -71,7 +72,10 @@ block content
                                 each head, index in accountHeads
                                     tr.head-row
                                         th(scope="row")= index + 1
-                                        td.searchable= head.account_head_name
+                                        td.searchable
+                                            = head.account_head_name
+                                            if head.is_system_type === 'Y'
+                                                i.bi.bi-lock-fill.text-muted.ml-1(title="System-generated — used by cashflow auto-generation, name/deactivation locked")
                                         td.searchable= head.account_head_type
                                         td
                                             span.badge(class=head.allowed_entry_type === 'CREDIT' ? 'badge-success' : (head.allowed_entry_type === 'DEBIT' ? 'badge-danger' : 'badge-secondary'))= head.allowed_entry_type
@@ -79,6 +83,13 @@ block content
                                         td= head.active_flag
                                         td= head.effective_start_date ? new Date(head.effective_start_date).toLocaleDateString('en-GB') : '-'
                                         td= head.effective_end_date   ? new Date(head.effective_end_date).toLocaleDateString('en-GB')   : '-'
+                                        td
+                                            select.form-control.form-control-sm.gl-group-select(
+                                                data-id=head.account_head_id,
+                                                style="min-width:160px;")
+                                                option(value="") — Not Set —
+                                                each g in glGroups
+                                                    option(value=g.group_id, selected=(head.gl_group_id === g.group_id))= g.group_name
                                         if canEdit
                                             td
                                                 button.btn.btn-primary.btn-sm.btn-edit-head(
@@ -89,19 +100,27 @@ block content
                                                     data-entry-type=head.allowed_entry_type,
                                                     data-notes=head.notes_required_flag,
                                                     data-active=head.active_flag,
+                                                    data-system=head.is_system_type,
                                                     data-start=head.effective_start_date ? head.effective_start_date.toString().substring(0,10) : '',
                                                     data-end=head.effective_end_date     ? head.effective_end_date.toString().substring(0,10)   : '')
                                                     i.bi.bi-pencil
                                         if canDisable
                                             td
-                                                button.btn.btn-danger.btn-sm(type="button", onclick=`confirmDeactivate(${head.account_head_id})`)
-                                                    i.bi.bi-trash
+                                                if head.is_system_type === 'Y'
+                                                    button.btn.btn-danger.btn-sm(type="button", disabled, title="System-generated — cannot be deactivated")
+                                                        i.bi.bi-trash
+                                                else
+                                                    button.btn.btn-danger.btn-sm(type="button", onclick=`confirmDeactivate(${head.account_head_id})`)
+                                                        i.bi.bi-trash
 
                 .mobile-cards-view.d-block.d-lg-none
                     each head in accountHeads
                         .card.shadow-sm.mb-2.head-card
                             .card-header.d-flex.justify-content-between.align-items-center
-                                h6.mb-0.text-uppercase= head.account_head_name
+                                h6.mb-0.text-uppercase
+                                    = head.account_head_name
+                                    if head.is_system_type === 'Y'
+                                        i.bi.bi-lock-fill.text-muted.ml-1
                                 .actions
                                     if canEdit
                                         button.btn.btn-primary.btn-sm.mr-1.btn-edit-head(
@@ -112,12 +131,17 @@ block content
                                             data-entry-type=head.allowed_entry_type,
                                             data-notes=head.notes_required_flag,
                                             data-active=head.active_flag,
+                                            data-system=head.is_system_type,
                                             data-start=head.effective_start_date ? head.effective_start_date.toString().substring(0,10) : '',
                                             data-end=head.effective_end_date     ? head.effective_end_date.toString().substring(0,10)   : '')
                                             i.bi.bi-pencil
                                     if canDisable
-                                        button.btn.btn-danger.btn-sm(type="button", onclick=`confirmDeactivate(${head.account_head_id})`)
-                                            i.bi.bi-trash
+                                        if head.is_system_type === 'Y'
+                                            button.btn.btn-danger.btn-sm(type="button", disabled, title="System-generated — cannot be deactivated")
+                                                i.bi.bi-trash
+                                        else
+                                            button.btn.btn-danger.btn-sm(type="button", onclick=`confirmDeactivate(${head.account_head_id})`)
+                                                i.bi.bi-trash
                             .card-body.p-2
                                 p.mb-1
                                     b Head Type:&nbsp;
@@ -147,7 +171,8 @@ block content
                                     i.bi.bi-x-circle
                     .col-auto
                         select.form-control#filterBank
-                            option(value="") All Banks
+                            option(value="") All Banks / Cashflow
+                            option(value="CASHFLOW") Cashflow
                             each bank in banks
                                 option(value=bank.bank_id)
                                     = bank.account_number ? `${bank.bank_name} (...${bank.account_number.slice(-4)})` : bank.bank_name
@@ -166,7 +191,7 @@ block content
                                 tr
                                     th #
                                     th Type
-                                    th Bank
+                                    th Bank / Context
                                     th Ledger Name
                                     th Entry Type
                                     th Max Amt
@@ -177,7 +202,7 @@ block content
                             tbody#rulesTableBody
                                 each rule, index in allRules
                                     - const isStatic = rule.source_type === 'Static'
-                                    tr.rule-row(data-bank-id=rule.bank_id, data-source-type=rule.source_type)
+                                    tr.rule-row(data-bank-id=rule.bank_id, data-source-type=rule.source_type, data-applies-cashflow=rule.applies_to_cashflow)
                                         th(scope="row")= index + 1
                                         td
                                             span.badge(class=isStatic ? 'badge-info' : (rule.source_type === 'Credit' ? 'badge-success' : (rule.source_type === 'Bank' ? 'badge-primary' : 'badge-warning')))= rule.source_type
@@ -211,6 +236,7 @@ block content
                                                         data-notes=rule.notes_required_flag,
                                                         data-max-amount=rule.max_amount || '',
                                                         data-allow-split=(rule.allow_split_flag || 'N'),
+                                                        data-applies-cashflow=rule.applies_to_cashflow,
                                                         data-start=rule.effective_start_date ? rule.effective_start_date.toString().substring(0,10) : '',
                                                         data-end=rule.effective_end_date     ? rule.effective_end_date.toString().substring(0,10)   : '')
                                                         i.bi.bi-pencil
@@ -229,7 +255,7 @@ block content
                 .mobile-cards-view.d-block.d-lg-none
                     each rule in allRules
                         - const isStatic = rule.source_type === 'Static'
-                        .card.shadow-sm.mb-2.rule-card(data-bank-id=rule.bank_id, data-source-type=rule.source_type)
+                        .card.shadow-sm.mb-2.rule-card(data-bank-id=rule.bank_id, data-source-type=rule.source_type, data-applies-cashflow=rule.applies_to_cashflow)
                             .card-header.d-flex.justify-content-between.align-items-center
                                 div
                                     span.badge.mr-1(class=isStatic ? 'badge-info' : (rule.source_type === 'Credit' ? 'badge-success' : 'badge-warning'))= rule.source_type
@@ -247,6 +273,7 @@ block content
                                                 data-notes=rule.notes_required_flag,
                                                 data-max-amount=rule.max_amount || '',
                                                 data-allow-split=(rule.allow_split_flag || 'N'),
+                                                data-applies-cashflow=rule.applies_to_cashflow,
                                                 data-start=rule.effective_start_date ? rule.effective_start_date.toString().substring(0,10) : '',
                                                 data-end=rule.effective_end_date     ? rule.effective_end_date.toString().substring(0,10)   : '')
                                                 i.bi.bi-pencil
@@ -332,6 +359,9 @@ block content
                 .modal-body
                     form#editHeadForm(method='POST', action='/account-heads/update')
                         input(type="hidden", name="account_head_id", id="edit_account_head_id")
+                        p.text-muted.small.mb-2#editHeadSystemNote(style="display:none;")
+                            i.bi.bi-lock-fill.mr-1
+                            | System-generated — name is locked (used by cashflow auto-generation).
                         .form-group
                             label Account Head Name *
                             input.form-control(type="text", name="account_head_name", id="edit_account_head_name", required, style="text-transform:uppercase;", autocomplete="off")
@@ -380,15 +410,24 @@ block content
                     button.close(type="button", data-dismiss="modal", aria-label="Close")
                         span(aria-hidden="true") &times;
                 .modal-body
-                    p.text-muted.small Select the bank and the account head it should map to for statement uploads.
+                    p.text-muted.small Select what this rule applies to and the account head it should map to.
                     form#addRuleForm(method='POST', action='/account-heads/rules')
                         input(type="hidden", name="account_head_id", id="add_rule_head_id")
                         input(type="hidden", name="ledger_name",     id="add_rule_ledger_name")
+                        input(type="hidden", name="applies_to_cashflow", id="add_rule_applies_cashflow", value="N")
+                        .form-group
+                            label Applies To *
+                            .form-check.form-check-inline
+                                input.form-check-input.add-rule-context(type="radio", name="context_type", id="add_rule_context_bank", value="BANK", checked)
+                                label.form-check-label(for="add_rule_context_bank") Bank
+                            .form-check.form-check-inline
+                                input.form-check-input.add-rule-context(type="radio", name="context_type", id="add_rule_context_cashflow", value="CASHFLOW")
+                                label.form-check-label(for="add_rule_context_cashflow") Cashflow
                         .form-row
-                            .col-md-6
+                            .col-md-6#add_rule_bank_wrapper
                                 .form-group
                                     label Bank *
-                                    select.form-control(name="bank_id", required)
+                                    select.form-control(name="bank_id", id="add_rule_bank_select", required)
                                         option(value="") — Select Bank —
                                         each bank in banks
                                             option(value=bank.bank_id)
@@ -449,8 +488,17 @@ block content
                         input(type="hidden", name="rule_id",         id="edit_rule_id")
                         input(type="hidden", name="account_head_id", id="edit_rule_head_id")
                         input(type="hidden", name="ledger_name",     id="edit_rule_ledger_name")
+                        input(type="hidden", name="applies_to_cashflow", id="edit_rule_applies_cashflow", value="N")
+                        .form-group
+                            label Applies To *
+                            .form-check.form-check-inline
+                                input.form-check-input.edit-rule-context(type="radio", name="context_type", id="edit_rule_context_bank", value="BANK")
+                                label.form-check-label(for="edit_rule_context_bank") Bank
+                            .form-check.form-check-inline
+                                input.form-check-input.edit-rule-context(type="radio", name="context_type", id="edit_rule_context_cashflow", value="CASHFLOW")
+                                label.form-check-label(for="edit_rule_context_cashflow") Cashflow
                         .form-row
-                            .col-md-6
+                            .col-md-6#edit_rule_bank_wrapper
                                 .form-group
                                     label Bank *
                                     select.form-control(name="bank_id", id="edit_rule_bank_id", required)
@@ -599,19 +647,25 @@ block content
             const ruleRows    = document.querySelectorAll('#rulesTableBody tr.rule-row');
             const ruleCards   = document.querySelectorAll('.rule-card');
 
+            function ruleBankMatches(el, bankId) {
+                if (!bankId) return true;
+                if (bankId === 'CASHFLOW') return el.dataset.appliesCashflow === 'Y';
+                return el.dataset.bankId === bankId;
+            }
+
             function applyRuleFilters() {
                 const term   = searchRules.value.toLowerCase().trim();
                 const bankId = filterBank.value;
                 const type   = filterType.value;
                 ruleRows.forEach(r => {
                     const textOk = !term   || Array.from(r.querySelectorAll('.searchable')).map(el => el.textContent.toLowerCase()).join(' ').includes(term);
-                    const bankOk = !bankId || r.dataset.bankId === bankId;
+                    const bankOk = ruleBankMatches(r, bankId);
                     const typeOk = !type   || r.dataset.sourceType === type;
                     r.style.display = (textOk && bankOk && typeOk) ? '' : 'none';
                 });
                 ruleCards.forEach(c => {
                     const textOk = !term   || c.textContent.toLowerCase().includes(term);
-                    const bankOk = !bankId || c.dataset.bankId === bankId;
+                    const bankOk = ruleBankMatches(c, bankId);
                     const typeOk = !type   || c.dataset.sourceType === type;
                     c.style.display = (textOk && bankOk && typeOk) ? '' : 'none';
                 });
@@ -636,10 +690,24 @@ block content
                 document.getElementById('add_rule_ledger_name').value = opt.dataset.name || '';
             });
 
+            // ── Add Rule: Bank vs Cashflow context toggle ──────────────────
+            function setAddRuleContext(isCashflow) {
+                document.getElementById('add_rule_applies_cashflow').value = isCashflow ? 'Y' : 'N';
+                document.getElementById('add_rule_bank_wrapper').style.display = isCashflow ? 'none' : '';
+                document.getElementById('add_rule_bank_select').required = !isCashflow;
+                if (isCashflow) document.getElementById('add_rule_bank_select').value = '';
+            }
+            document.querySelectorAll('.add-rule-context').forEach(function (radio) {
+                radio.addEventListener('change', function () {
+                    setAddRuleContext(this.value === 'CASHFLOW');
+                });
+            });
+
             $('#addRuleModal').on('hidden.bs.modal', function () {
                 document.getElementById('addRuleForm').reset();
                 document.getElementById('add_rule_head_id').value     = '';
                 document.getElementById('add_rule_ledger_name').value = '';
+                setAddRuleContext(false);
             });
 
             // ── Edit Account Head ─────────────────────────────────────────
@@ -655,7 +723,24 @@ block content
                 document.getElementById('edit_active_flag').value          = d.active;
                 document.getElementById('edit_effective_start_date').value = d.start;
                 document.getElementById('edit_effective_end_date').value   = d.end;
+                const isSystem = d.system === 'Y';
+                document.getElementById('edit_account_head_name').readOnly = isSystem;
+                document.getElementById('editHeadSystemNote').style.display = isSystem ? '' : 'none';
                 $('#editHeadModal').modal('show');
+            });
+
+            // ── Edit Rule: Bank vs Cashflow context toggle ─────────────────
+            function setEditRuleContext(isCashflow) {
+                document.getElementById('edit_rule_applies_cashflow').value = isCashflow ? 'Y' : 'N';
+                document.getElementById('edit_rule_bank_wrapper').style.display = isCashflow ? 'none' : '';
+                document.getElementById('edit_rule_bank_id').required = !isCashflow;
+                if (isCashflow) document.getElementById('edit_rule_bank_id').value = '';
+                document.getElementById(isCashflow ? 'edit_rule_context_cashflow' : 'edit_rule_context_bank').checked = true;
+            }
+            document.querySelectorAll('.edit-rule-context').forEach(function (radio) {
+                radio.addEventListener('change', function () {
+                    setEditRuleContext(this.value === 'CASHFLOW');
+                });
             });
 
             // ── Edit Static Rule ──────────────────────────────────────────
@@ -664,7 +749,6 @@ block content
                 if (!btn) return;
                 const d = btn.dataset;
                 document.getElementById('edit_rule_id').value          = d.id;
-                document.getElementById('edit_rule_bank_id').value     = d.bankId;
                 document.getElementById('edit_rule_head_id').value     = d.accountHeadId;
                 document.getElementById('edit_rule_ledger_name').value = d.ledgerName;
                 document.getElementById('edit_rule_head_select').value = d.accountHeadId;
@@ -674,6 +758,9 @@ block content
                 document.getElementById('edit_rule_max_amount').value  = d.maxAmount;
                 document.getElementById('edit_rule_start').value       = d.start;
                 document.getElementById('edit_rule_end').value         = d.end;
+                const isCashflow = d.appliesCashflow === 'Y';
+                setEditRuleContext(isCashflow);
+                document.getElementById('edit_rule_bank_id').value = isCashflow ? '' : (d.bankId || '');
                 $('#editRuleModal').modal('show');
             });
 
@@ -736,3 +823,32 @@ block content
                 form.submit();
             }
         }
+
+        // GL Group auto-save — fires on dropdown change
+        document.querySelectorAll('.gl-group-select').forEach(function(sel) {
+            sel.addEventListener('change', function() {
+                const id      = this.dataset.id;
+                const groupId = this.value;
+                const orig    = this;
+                orig.disabled = true;
+                fetch('/account-heads/' + id + '/gl-group', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ gl_group_id: groupId || null })
+                })
+                .then(r => r.json())
+                .then(data => {
+                    orig.disabled = false;
+                    if (data.success) {
+                        orig.style.borderColor = '#28a745';
+                        setTimeout(() => orig.style.borderColor = '', 1500);
+                    } else {
+                        alert('Failed to save GL group: ' + (data.error || 'Unknown error'));
+                    }
+                })
+                .catch(() => {
+                    orig.disabled = false;
+                    alert('Network error saving GL group');
+                });
+            });
+        });


### PR DESCRIPTION
## Summary
- `t_cashflow_transaction` now carries `account_head_id` + `entry_type` directly (resolved by trigger at insert/update time), replacing the dropped `ledger_rule_id` column from the earlier attempt.
- `processCashflowTxnEvent` reads those columns directly — zero joins to `m_ledger_rules`/`m_account_heads` at GL-processing time.
- Ledger Rules screen: fixed an `INNER JOIN m_bank` bug that silently hid every cashflow-scoped rule; added a Bank vs Cashflow context toggle to the Add/Edit Rule modal with an app-level duplicate check.
- Account Heads screen: system-generated heads (`is_system_type='Y'`) can no longer be renamed/deactivated (would break `generate_cashflow`'s hardcoded string matching).
- Cashflow entry screen now sources its Credit/Debit dropdowns from Account Heads via cashflow-scoped Ledger Rules instead of `m_lookup`.
- Includes the 3 DB migrations for this correction (schema/seed/backfill) — already run directly on beta DB this session; included here for the repo record.

## Test plan
- [x] Verified `findCashflowTxnById` DAO against real SFS data — correct options + existing transactions per direction
- [x] Verified `getAllRules`/`getAccountHeads` DAO queries against real SFS data — cashflow rules now visible, system-type flag correct
- [x] Full SFS event reprocess run against beta (in progress at PR time) — CASHFLOW_TXN events processing with zero errors so far
- [ ] Manually exercise the cashflow entry screen and Ledger Rules/Account Heads UI on beta after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)