### PR TITLE
Add stock-adjusted COGS to P&L; close correction-queue gaps

### DIFF
--- a/db/migrations/cashflow-account-heads-gap-fix.sql
+++ b/db/migrations/cashflow-account-heads-gap-fix.sql
@@ -1,0 +1,81 @@
+-- ============================================================
+-- Gap fix: cashflow-account-heads-correction-seed.sql left two holes
+-- Generated: 2026-08-17
+--
+-- Found by spot-checking SFS: comparing m_lookup(CashFlow) against
+-- m_account_heads + cashflow-scoped m_ledger_rules turned up two distinct
+-- gaps, both across every location, not just SFS:
+--
+-- 1. 30 Account Heads (all created_by='system', i.e. pre-existing from the
+--    bank-categorization work, predating this session) share a name with a
+--    real cashflow type but never got a cashflow-scoped Ledger Rule — the
+--    original seed's Step 3 only covered heads it had just created
+--    (created_by='MIGRATION'), wrongly skipping heads that already existed.
+--
+-- 2. 3 m_lookup(CashFlow) rows have no Account Head at all (MC/'MPDC
+--    Cement', SFS/'To Bank SBI 8015', SFS/'PROFFSONAL CHARGES') — the
+--    original seed only created a head when EXISTS-matched against real
+--    t_cashflow_transaction usage, but these are valid configured dropdown
+--    options that simply haven't been used yet. Since the cashflow entry
+--    screen now sources its dropdown from Account Heads (not m_lookup
+--    directly), an unused-but-valid option silently disappearing from the
+--    dropdown is a real regression.
+--
+-- Safe to re-run — guarded with NOT EXISTS throughout.
+-- ============================================================
+
+-- ── Step 1: create Account Heads for the 3 m_lookup rows with none ────────
+
+INSERT INTO m_account_heads
+    (location_code, account_head_name, allowed_entry_type, is_system_type,
+     effective_start_date, created_by, updated_by)
+SELECT ml.location_code, ml.description,
+       CASE ml.tag WHEN 'IN' THEN 'CREDIT' WHEN 'OUT' THEN 'DEBIT' END,
+       'N', '2025-04-01', 'MIGRATION', 'MIGRATION'
+FROM m_lookup ml
+WHERE ml.lookup_type = 'CashFlow'
+  AND ml.location_code IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM m_account_heads mah
+      WHERE mah.location_code = ml.location_code AND mah.account_head_name = ml.description
+  );
+
+-- ── Step 2: cashflow-scoped Ledger Rule for every Account Head that
+--    matches a real m_lookup CashFlow entry and doesn't have one yet —
+--    regardless of who/what created the Account Head. ─────────────────────
+
+INSERT INTO m_ledger_rules
+    (location_code, source_type, external_id, ledger_name, allowed_entry_type,
+     applies_to_cashflow, display_sequence, created_by, updated_by)
+SELECT DISTINCT mah.location_code, 'Static', mah.account_head_id, mah.account_head_name,
+       mah.allowed_entry_type, 'Y', seq.display_sequence, 'MIGRATION', 'MIGRATION'
+FROM m_account_heads mah
+INNER JOIN m_lookup ml
+        ON ml.lookup_type = 'CashFlow'
+       AND ml.location_code = mah.location_code
+       AND ml.description   = mah.account_head_name
+LEFT JOIN (
+    SELECT DISTINCT location_code, description, MIN(attribute1 + 0) AS display_sequence
+    FROM m_lookup WHERE lookup_type = 'CashFlow'
+    GROUP BY location_code, description
+) seq ON seq.location_code = mah.location_code AND seq.description = mah.account_head_name
+WHERE NOT EXISTS (
+    SELECT 1 FROM m_ledger_rules mlr
+    WHERE mlr.location_code = mah.location_code AND mlr.external_id = mah.account_head_id
+      AND mlr.source_type = 'Static' AND mlr.applies_to_cashflow = 'Y'
+);
+
+-- ── Verify ──────────────────────────────────────────────────────────────────
+SELECT COUNT(*) AS account_heads_created_this_pass FROM m_account_heads WHERE created_by = 'MIGRATION' AND creation_date >= NOW() - INTERVAL 5 MINUTE;
+
+SELECT
+  COUNT(*) AS total_lookup_rows,
+  SUM(mah.account_head_id IS NULL) AS still_missing_account_head,
+  SUM(mah.account_head_id IS NOT NULL AND mlr.rule_id IS NULL) AS still_missing_rule
+FROM m_lookup ml
+LEFT JOIN m_account_heads mah
+       ON mah.location_code = ml.location_code AND mah.account_head_name = ml.description
+LEFT JOIN m_ledger_rules mlr
+       ON mlr.location_code = ml.location_code AND mlr.external_id = mah.account_head_id
+      AND mlr.source_type = 'Static' AND mlr.applies_to_cashflow = 'Y'
+WHERE ml.lookup_type = 'CashFlow' AND ml.location_code IS NOT NULL;

--- a/db/migrations/gl-correction-queue-trigger-fix.sql
+++ b/db/migrations/gl-correction-queue-trigger-fix.sql
@@ -1,0 +1,88 @@
+-- ============================================================
+-- Fix trg_static_ledger_map_gl_update: two bugs found while investigating
+-- why SFS's cashflow/bank vouchers weren't showing up correctly on the P&L
+-- Generated: 2026-08-18 (documents a fix already applied live on beta)
+--
+-- Bug 1: `IF OLD.treatment IS NOT NULL` skipped queuing a correction
+-- whenever a label's FIRST-EVER review happened after vouchers were already
+-- posted using the unreviewed fallback (Unclassified Bank Transaction /
+-- Unclassified Cashflow). That's exactly the case that needs catching —
+-- vouchers post using the fallback long before anyone reviews the label.
+--
+-- Bug 2: the trigger only ever matched BANK_TXN events (joins to
+-- t_bank_transaction) — no branch for CASHFLOW_TXN at all, since it
+-- predated this session's cashflow/Account Heads work.
+--
+-- Both fixed below. This does NOT retroactively catch vouchers that were
+-- already missed before this fix (see
+-- cashflow-account-heads-correction-backfill.sql and the manual backfill
+-- run for SFS this session for that).
+-- ============================================================
+
+DROP TRIGGER IF EXISTS trg_static_ledger_map_gl_update;
+
+DELIMITER $$
+
+CREATE TRIGGER trg_static_ledger_map_gl_update
+AFTER UPDATE ON gl_static_ledger_map
+FOR EACH ROW
+BEGIN
+    DECLARE v_old_ledger_name VARCHAR(250);
+    DECLARE v_new_ledger_name VARCHAR(250);
+    DECLARE v_old_desc VARCHAR(255);
+    DECLARE v_new_desc VARCHAR(255);
+
+    IF NOT (OLD.treatment <=> NEW.treatment)
+       OR NOT (OLD.gl_ledger_id <=> NEW.gl_ledger_id)
+       OR NOT (OLD.skip_reason <=> NEW.skip_reason)
+    THEN
+        IF OLD.treatment = 'SKIP' THEN
+            SET v_old_desc = CONCAT('Skip: ', COALESCE(OLD.skip_reason, ''));
+        ELSEIF OLD.treatment = 'POST' THEN
+            SELECT ledger_name INTO v_old_ledger_name FROM gl_ledgers WHERE ledger_id = OLD.gl_ledger_id;
+            SET v_old_desc = CONCAT('Post to: ', COALESCE(v_old_ledger_name, CONCAT('(deleted ledger #', OLD.gl_ledger_id, ')')));
+        ELSE
+            SET v_old_desc = 'Unreviewed';
+        END IF;
+
+        IF NEW.treatment = 'SKIP' THEN
+            SET v_new_desc = CONCAT('Skip: ', COALESCE(NEW.skip_reason, ''));
+        ELSEIF NEW.treatment = 'POST' THEN
+            SELECT ledger_name INTO v_new_ledger_name FROM gl_ledgers WHERE ledger_id = NEW.gl_ledger_id;
+            SET v_new_desc = CONCAT('Post to: ', COALESCE(v_new_ledger_name, CONCAT('(deleted ledger #', NEW.gl_ledger_id, ')')));
+        ELSE
+            SET v_new_desc = 'Unreviewed';
+        END IF;
+
+        INSERT INTO gl_correction_queue
+            (location_code, mapping_source, mapping_key, old_description, new_description,
+             source_type, source_id, voucher_id, fy_id, status, created_by)
+        SELECT mb.location_code, 'STATIC_LEDGER_MAP', NEW.ledger_name, v_old_desc, v_new_desc,
+               ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', NEW.updated_by
+        FROM gl_accounting_events ge
+        JOIN t_bank_transaction tbt ON tbt.t_bank_id = ge.source_id AND ge.source_type = 'BANK_TXN'
+        JOIN m_bank mb ON mb.bank_id = tbt.bank_id
+        WHERE ge.event_status = 'PROCESSED' AND mb.location_code = NEW.location_code AND tbt.ledger_name = NEW.ledger_name
+
+        UNION
+
+        SELECT mb.location_code, 'STATIC_LEDGER_MAP', NEW.ledger_name, v_old_desc, v_new_desc,
+               ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', NEW.updated_by
+        FROM gl_accounting_events ge
+        JOIN t_bank_transaction tbt ON tbt.t_bank_id = ge.source_id AND ge.source_type = 'BANK_TXN'
+        JOIN m_bank mb ON mb.bank_id = tbt.bank_id
+        JOIN t_bank_transaction_splits tbs ON tbs.t_bank_id = tbt.t_bank_id
+        WHERE ge.event_status = 'PROCESSED' AND mb.location_code = NEW.location_code AND tbs.ledger_name = NEW.ledger_name
+
+        UNION
+
+        SELECT tcc.location_code, 'STATIC_LEDGER_MAP', NEW.ledger_name, v_old_desc, v_new_desc,
+               ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', NEW.updated_by
+        FROM gl_accounting_events ge
+        JOIN t_cashflow_transaction tct ON tct.transaction_id = ge.source_id AND ge.source_type = 'CASHFLOW_TXN'
+        JOIN t_cashflow_closing tcc ON tcc.cashflow_id = tct.cashflow_id
+        WHERE ge.event_status = 'PROCESSED' AND tcc.location_code = NEW.location_code AND tct.type = NEW.ledger_name;
+    END IF;
+END$$
+
+DELIMITER ;

--- a/db/migrations/gl-stock-opening-balance.sql
+++ b/db/migrations/gl-stock-opening-balance.sql
@@ -1,0 +1,35 @@
+-- ============================================================
+-- Stock-adjusted COGS: FY opening balance seed table
+-- Generated: 2026-08-18
+--
+-- Holds the ONE persisted number this feature needs per (location, product,
+-- financial year): the opening stock quantity + value at FY start. Everything
+-- else (COGS for any date range inside the FY, closing balance at any point)
+-- is computed on the fly by services/stock-valuation-service.js, replaying
+-- purchases and sales chronologically from this opening balance forward.
+--
+-- source='SEED' = manually estimated because no prior-FY closing balance
+-- exists yet (first year a location's stock is tracked this way).
+-- source='FY_CLOSE' = will be written once, permanently, when a FY is
+-- closed — the computed closing balance becomes the next FY's opening row.
+-- Until a FY is closed, nothing here changes; mid-FY, everything replays
+-- on the fly from this starting point.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS gl_stock_opening_balance (
+    id              INT NOT NULL AUTO_INCREMENT,
+    location_code   VARCHAR(50) NOT NULL,
+    product_id      INT NOT NULL,
+    fy_id           INT NOT NULL,
+    opening_qty     DECIMAL(15,3) NOT NULL,
+    opening_value   DECIMAL(15,2) NOT NULL,
+    source          ENUM('SEED', 'FY_CLOSE') NOT NULL DEFAULT 'SEED',
+    notes           VARCHAR(255) DEFAULT NULL,
+    created_by      VARCHAR(45) DEFAULT NULL,
+    creation_date   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_stock_opening (location_code, product_id, fy_id),
+    KEY fk_stock_opening_product (product_id),
+    CONSTRAINT fk_stock_opening_fy FOREIGN KEY (fy_id) REFERENCES gl_financial_years (fy_id),
+    CONSTRAINT fk_stock_opening_product FOREIGN KEY (product_id) REFERENCES m_product (product_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -7,6 +7,7 @@ const security = require('../utils/app-security');
 const db = require('../db/db-connection');
 const createAccountingService = require('../services/create-accounting-service');
 const glBatchService = require('../services/gl-batch-service');
+const stockValuationService = require('../services/stock-valuation-service');
 
 // GET /gl/api/ledgers/search?location=&group=&q=
 // Returns [{ledger_id, ledger_name}] — used by Select2 ajax typeahead on product ledger fields
@@ -463,6 +464,60 @@ router.get('/profit-loss', [isLoginEnsured, security.isAdmin()], async function(
                 g.rows.push({ ledger_id: row.ledger_id, ledger_name: row.ledger_name, amount: net });
                 g.subtotal    += net;
                 totalExpenses += net;
+            }
+        }
+
+        // Stock-adjusted COGS — only for products with a gl_stock_opening_balance
+        // seed for the FY covering fromDate. Never changes the per-ledger figures
+        // above (those still match the trial balance); adds one visible
+        // adjustment line per group instead, so the swap from raw invoiced
+        // purchases to actual COGS (opening + purchases - closing) is auditable,
+        // not a silent number change. See services/stock-valuation-service.js.
+        const [fy] = await db.sequelize.query(`
+            SELECT fy_id FROM gl_financial_years
+            WHERE location_code = :locationCode AND :fromDate BETWEEN start_date AND end_date
+            LIMIT 1
+        `, { replacements: { locationCode, fromDate }, type: db.Sequelize.QueryTypes.SELECT });
+
+        if (fy) {
+            const stockResults = await stockValuationService.computeStockCOGS(locationCode, fy.fy_id, fromDate, toDate);
+
+            if (stockResults.length) {
+                const productLedgers = await db.sequelize.query(`
+                    SELECT product_id, ledger_id FROM gl_product_ledger_map
+                    WHERE location_code = :locationCode AND map_type = 'PURCHASE'
+                `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT });
+                const ledgerByProduct = new Map(productLedgers.map(r => [r.product_id, r.ledger_id]));
+
+                // Multiple products can share one purchase ledger (e.g. MS and
+                // HSD both post to "PURCHASE DIESEL EBMS" for SFS) — aggregate
+                // computed COGS by ledger before comparing against that
+                // ledger's raw total, or a shared ledger gets compared against
+                // itself twice and produces nonsense.
+                const stockCogsByLedger = new Map();
+                for (const r of stockResults) {
+                    const ledgerId = ledgerByProduct.get(r.productId);
+                    if (!ledgerId) continue;
+                    stockCogsByLedger.set(ledgerId, (stockCogsByLedger.get(ledgerId) || 0) + r.cogs);
+                }
+
+                let totalAdjustment = 0;
+                for (const [ledgerId, cogs] of stockCogsByLedger) {
+                    const rawRow = rows.find(row => row.ledger_id === ledgerId);
+                    const rawAmount = rawRow ? (parseFloat(rawRow.total_dr) - parseFloat(rawRow.total_cr)) : 0;
+                    totalAdjustment += (cogs - rawAmount);
+                }
+
+                if (Math.abs(totalAdjustment) > 0.01 && expenseGroupMap.has('Purchase Accounts')) {
+                    const g = expenseGroupMap.get('Purchase Accounts');
+                    g.rows.push({
+                        ledger_id: null,
+                        ledger_name: 'Stock Adjustment (Opening + Purchases − Closing vs. Invoiced)',
+                        amount: totalAdjustment
+                    });
+                    g.subtotal    += totalAdjustment;
+                    totalExpenses += totalAdjustment;
+                }
             }
         }
 

--- a/services/stock-valuation-service.js
+++ b/services/stock-valuation-service.js
@@ -1,0 +1,199 @@
+// services/stock-valuation-service.js
+// On-the-fly stock-adjusted COGS — no persisted running balance (see
+// gl_stock_opening_balance for why: this domain backdates invoices
+// routinely, and a live-updated balance would need the same
+// correction-cascade machinery already built for gl_static_ledger_map).
+//
+// Instead: one seed row per (location, product, FY) in
+// gl_stock_opening_balance, then every call here replays that FY's
+// purchases and sales chronologically (day-by-day: purchases before that
+// day's sales) using weighted-average costing, bounded by FY start — so
+// cost stays manageable within a single financial year. At FY close, the
+// computed closing balance gets written down once as the next FY's opening
+// row (source='FY_CLOSE') — not implemented yet, deferred until a FY
+// actually needs closing.
+//
+// Known gap: BOWSER_CASH_SALE / BOWSER_DIGITAL_SALE are payment-mode-only
+// records (no product_id or quantity), so their fuel volume can't be
+// subtracted from the running balance. Immaterial where those modes aren't
+// used; overstates closing stock / understates COGS slightly otherwise.
+
+const db = require('../db/db-connection');
+const { QueryTypes } = require('sequelize');
+
+async function getOpeningBalances(locationCode, fyId) {
+    return db.sequelize.query(`
+        SELECT sob.product_id, p.product_name, sob.opening_qty, sob.opening_value
+        FROM gl_stock_opening_balance sob
+        JOIN m_product p ON p.product_id = sob.product_id
+        WHERE sob.location_code = :locationCode AND sob.fy_id = :fyId
+    `, { replacements: { locationCode, fyId }, type: QueryTypes.SELECT });
+}
+
+// { d: 'YYYY-MM-DD', qty, value } per day, purchases only, for one product.
+async function getDailyPurchases(locationCode, productId, fromDate, toDate) {
+    const tankRows = await db.sequelize.query(`
+        SELECT DATE(ti.invoice_date) AS d,
+               SUM(CASE WHEN td.qty_unit = 'KL' THEN td.quantity * 1000 ELSE td.quantity END) AS qty,
+               SUM(td.total_line_amount + COALESCE(chg.charge_total, 0)) AS value
+        FROM t_tank_invoice_dtl td
+        JOIN t_tank_invoice ti ON ti.id = td.invoice_id
+        LEFT JOIN (
+            SELECT invoice_dtl_id, SUM(charge_amount) AS charge_total
+            FROM t_tank_invoice_charges
+            GROUP BY invoice_dtl_id
+        ) chg ON chg.invoice_dtl_id = td.id
+        WHERE ti.location_id = :locationCode AND td.product_id = :productId
+          AND ti.invoice_date BETWEEN :fromDate AND :toDate
+        GROUP BY DATE(ti.invoice_date)
+    `, { replacements: { locationCode, productId, fromDate, toDate }, type: QueryTypes.SELECT });
+
+    const lubesRows = await db.sequelize.query(`
+        SELECT DATE(h.invoice_date) AS d, SUM(l.qty) AS qty, SUM(l.taxable_value) AS value
+        FROM t_lubes_inv_lines l
+        JOIN t_lubes_inv_hdr h ON h.lubes_hdr_id = l.lubes_hdr_id
+        WHERE h.location_code = :locationCode AND l.product_id = :productId
+          AND h.closing_status = 'CLOSED'
+          AND h.invoice_date BETWEEN :fromDate AND :toDate
+        GROUP BY DATE(h.invoice_date)
+    `, { replacements: { locationCode, productId, fromDate, toDate }, type: QueryTypes.SELECT });
+
+    return [...tankRows, ...lubesRows];
+}
+
+// { d: 'YYYY-MM-DD', qty } per day, sold quantity only, for one product —
+// value isn't needed here, COGS is computed from the running average, not
+// from what any individual channel recorded as revenue.
+async function getDailySoldQty(locationCode, productId, fromDate, toDate) {
+    const dayBill = await db.sequelize.query(`
+        SELECT tdb.bill_date AS d, SUM(tdi.quantity) AS qty
+        FROM t_day_bill_items tdi
+        JOIN t_day_bill_header tdh ON tdh.header_id = tdi.header_id
+        JOIN t_day_bill tdb ON tdb.day_bill_id = tdh.day_bill_id
+        WHERE tdb.location_code = :locationCode AND tdi.product_id = :productId
+          AND tdb.bill_date BETWEEN :fromDate AND :toDate
+        GROUP BY tdb.bill_date
+    `, { replacements: { locationCode, productId, fromDate, toDate }, type: QueryTypes.SELECT });
+
+    const creditSale = await db.sequelize.query(`
+        SELECT DATE(cl.closing_date) AS d, SUM(tc.qty) AS qty
+        FROM t_credits tc
+        JOIN t_closing cl ON cl.closing_id = tc.closing_id
+        WHERE cl.location_code = :locationCode AND tc.product_id = :productId
+          AND DATE(cl.closing_date) BETWEEN :fromDate AND :toDate
+        GROUP BY DATE(cl.closing_date)
+    `, { replacements: { locationCode, productId, fromDate, toDate }, type: QueryTypes.SELECT });
+
+    const cashSale = await db.sequelize.query(`
+        SELECT DATE(cl.closing_date) AS d, SUM(cs.qty) AS qty
+        FROM t_cashsales cs
+        JOIN t_closing cl ON cl.closing_id = cs.closing_id
+        WHERE cl.location_code = :locationCode AND cs.product_id = :productId
+          AND DATE(cl.closing_date) BETWEEN :fromDate AND :toDate
+        GROUP BY DATE(cl.closing_date)
+    `, { replacements: { locationCode, productId, fromDate, toDate }, type: QueryTypes.SELECT });
+
+    const bowserCredit = await db.sequelize.query(`
+        SELECT DATE(tbc.closing_date) AS d, SUM(bc.quantity) AS qty
+        FROM t_bowser_credits bc
+        JOIN t_bowser_closing tbc ON tbc.bowser_closing_id = bc.bowser_closing_id
+        WHERE tbc.location_code = :locationCode AND bc.product_id = :productId
+          AND DATE(tbc.closing_date) BETWEEN :fromDate AND :toDate
+        GROUP BY DATE(tbc.closing_date)
+    `, { replacements: { locationCode, productId, fromDate, toDate }, type: QueryTypes.SELECT });
+
+    return [...dayBill, ...creditSale, ...cashSale, ...bowserCredit];
+}
+
+function toDateStr(d) {
+    return typeof d === 'string' ? d.substring(0, 10) : d.toISOString().substring(0, 10);
+}
+
+// Merges same-day purchase/sale rows, replays weighted-average costing from
+// the opening balance forward, and returns COGS for [fromDate, toDate] plus
+// the closing balance as of toDate. fromDate/toDate must fall inside the FY
+// gl_stock_opening_balance was seeded for.
+async function computeProductStockCOGS(locationCode, fyId, productId, fromDate, toDate) {
+    const [fy] = await db.sequelize.query(`
+        SELECT start_date FROM gl_financial_years WHERE fy_id = :fyId
+    `, { replacements: { fyId }, type: QueryTypes.SELECT });
+    if (!fy) throw new Error(`Financial year not found: fy_id=${fyId}`);
+    const fyStart = toDateStr(fy.start_date);
+
+    const [opening] = await db.sequelize.query(`
+        SELECT opening_qty, opening_value FROM gl_stock_opening_balance
+        WHERE location_code = :locationCode AND product_id = :productId AND fy_id = :fyId
+    `, { replacements: { locationCode, productId, fyId }, type: QueryTypes.SELECT });
+    if (!opening) return null; // not a stock-tracked product for this FY — caller falls back to raw purchases
+
+    const [purchases, soldQty] = await Promise.all([
+        getDailyPurchases(locationCode, productId, fyStart, toDate),
+        getDailySoldQty(locationCode, productId, fyStart, toDate)
+    ]);
+
+    const byDay = new Map(); // 'YYYY-MM-DD' -> { purchaseQty, purchaseValue, soldQty }
+    const ensureDay = (d) => {
+        if (!byDay.has(d)) byDay.set(d, { purchaseQty: 0, purchaseValue: 0, soldQty: 0 });
+        return byDay.get(d);
+    };
+    for (const r of purchases) {
+        const day = ensureDay(toDateStr(r.d));
+        day.purchaseQty   += parseFloat(r.qty)   || 0;
+        day.purchaseValue += parseFloat(r.value) || 0;
+    }
+    for (const r of soldQty) {
+        const day = ensureDay(toDateStr(r.d));
+        day.soldQty += parseFloat(r.qty) || 0;
+    }
+
+    const orderedDays = [...byDay.keys()].sort();
+    const fromDateStr = toDateStr(fromDate);
+    const toDateStr_   = toDateStr(toDate);
+
+    let runningQty   = parseFloat(opening.opening_qty);
+    let runningValue = parseFloat(opening.opening_value);
+    let cogsBeforeFrom = 0;
+    let cogsThroughTo   = 0;
+
+    for (const day of orderedDays) {
+        if (day > toDateStr_) break;
+
+        const { purchaseQty, purchaseValue, soldQty: qtySold } = byDay.get(day);
+
+        // Purchases land before that day's sales — stock arrives, then gets sold.
+        runningQty   += purchaseQty;
+        runningValue += purchaseValue;
+
+        let cogsToday = 0;
+        if (qtySold > 0) {
+            const avgCost = runningQty > 0 ? runningValue / runningQty : 0;
+            cogsToday     = qtySold * avgCost;
+            runningQty   -= qtySold;
+            runningValue -= cogsToday;
+        }
+
+        cogsThroughTo += cogsToday;
+        if (day < fromDateStr) cogsBeforeFrom += cogsToday;
+    }
+
+    return {
+        productId,
+        cogs: cogsThroughTo - cogsBeforeFrom,
+        closingQty: runningQty,
+        closingValue: runningValue
+    };
+}
+
+// All stock-tracked products (i.e. every product with a gl_stock_opening_balance
+// row) for a location + FY, in one call — what the P&L route actually needs.
+async function computeStockCOGS(locationCode, fyId, fromDate, toDate) {
+    const openings = await getOpeningBalances(locationCode, fyId);
+    const results = [];
+    for (const o of openings) {
+        const r = await computeProductStockCOGS(locationCode, fyId, o.product_id, fromDate, toDate);
+        if (r) results.push({ ...r, productName: o.product_name });
+    }
+    return results;
+}
+
+module.exports = { computeStockCOGS, computeProductStockCOGS };

--- a/views/gl-profit-loss.pug
+++ b/views/gl-profit-loss.pug
@@ -56,7 +56,10 @@ block content
                                 each row in g.rows
                                     tr
                                         td.pl-4
-                                            a(href='/gl/ledger?ledger_id=' + row.ledger_id + '&from_date=' + fromDate + '&to_date=' + toDate)= row.ledger_name
+                                            if row.ledger_id
+                                                a(href='/gl/ledger?ledger_id=' + row.ledger_id + '&from_date=' + fromDate + '&to_date=' + toDate)= row.ledger_name
+                                            else
+                                                span.text-muted= row.ledger_name
                                         td.text-right.small= fmt(row.amount)
                                 tr.group-subtotal
                                     td.text-right.font-weight-bold.text-muted.small #{g.group_name} Total
@@ -79,7 +82,10 @@ block content
                                 each row in g.rows
                                     tr
                                         td.pl-4
-                                            a(href='/gl/ledger?ledger_id=' + row.ledger_id + '&from_date=' + fromDate + '&to_date=' + toDate)= row.ledger_name
+                                            if row.ledger_id
+                                                a(href='/gl/ledger?ledger_id=' + row.ledger_id + '&from_date=' + fromDate + '&to_date=' + toDate)= row.ledger_name
+                                            else
+                                                span.text-muted= row.ledger_name
                                         td.text-right.small= fmt(row.amount)
                                 tr.group-subtotal
                                     td.text-right.font-weight-bold.text-muted.small #{g.group_name} Total


### PR DESCRIPTION
## Summary
- New `services/stock-valuation-service.js`: computes actual COGS (opening + purchases − closing, weighted-average costed) on the fly for any date range within a financial year — no persisted running balance, since this domain backdates invoices routinely.
- New `gl_stock_opening_balance` table: one seed row per (location, product, FY) — the only persisted number this feature needs.
- `/gl/profit-loss` now shows a transparent "Stock Adjustment" line per affected ledger group when a stock-tracked product's actual COGS differs from raw invoiced purchases. Per-ledger figures are untouched.
- Fixes `trg_static_ledger_map_gl_update` (was skipping first-time-review corrections entirely, and had no CASHFLOW_TXN branch) — already applied live on beta, now recorded as a migration.
- Fixes the earlier Account Heads seed gap (33 cashflow types missing an Account Head or a cashflow-scoped Ledger Rule) — already applied live on beta, now recorded as a migration.

## Test plan
- [x] Verified `computeStockCOGS` against real SFS April 2026 data — matches hand-derived estimates to the rupee (MS/HSD/CNG closing stock, COGS delta)
- [x] Verified the P&L route change end-to-end via a standalone script replicating its exact logic against real beta data
- [x] Confirmed the ledger-sharing edge case (SFS: MS+HSD share one purchase ledger) is handled correctly by aggregating per-ledger before comparing, and confirmed via real data (MUE) that locations with separate per-product ledgers are handled by the same code path with no special-casing
- [x] Pug template compiles; handles the new `ledger_id: null` adjustment row without breaking existing ledger links
- [ ] Manually view SFS's P&L on beta after deploy to confirm the Stock Adjustment line renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)