### PR TITLE
Fix runaway COGS when stock replay hits a real data gap

### DIFF
--- a/services/stock-valuation-service.js
+++ b/services/stock-valuation-service.js
@@ -165,10 +165,19 @@ async function computeProductStockCOGS(locationCode, fyId, productId, fromDate, 
         runningValue += purchaseValue;
 
         let cogsToday = 0;
-        if (qtySold > 0) {
-            const avgCost = runningQty > 0 ? runningValue / runningQty : 0;
-            cogsToday     = qtySold * avgCost;
-            runningQty   -= qtySold;
+        if (qtySold > 0 && runningQty > 0) {
+            const avgCost   = runningValue / runningQty;
+            // Clamp at what's actually tracked — a partial/in-progress month
+            // where sales have been recorded faster than purchases were
+            // entered (e.g. this month's invoices not in yet) must never
+            // drive the balance negative: that corrupts every average-cost
+            // calculation from that point forward. The uncovered portion is
+            // left unrecognized (zero-cost) rather than invented — it gets
+            // picked up correctly once the missing purchase is entered and
+            // this is recomputed.
+            const qtyCovered = Math.min(qtySold, runningQty);
+            cogsToday     = qtyCovered * avgCost;
+            runningQty   -= qtyCovered;
             runningValue -= cogsToday;
         }
 


### PR DESCRIPTION
## Summary
- Fixes a bug in `services/stock-valuation-service.js` where the stock-adjusted COGS replay let the running balance go negative when sales exceed recorded purchases (e.g. a partial/in-progress month with sales entered but invoices not yet in), corrupting the weighted-average cost for every subsequent day.
- Consumption now clamps at whatever's actually tracked — uncovered sales are left at zero cost rather than inventing a cost, self-correcting once the missing purchase is entered.

## Test plan
- [x] Reproduced the reported bug: SFS full-FY P&L showed a ₹12.7 Cr Stock Adjustment due to an August data gap (zero purchase invoices entered, but day-bill sales continue through mid-August) driving the balance negative
- [x] Confirmed fix eliminates negative balances (closing quantities now clamp at 0)
- [x] Confirmed no regression: April-only figures (already validated in PR #801) are byte-identical before/after this fix, since that range never hit the edge case

🤖 Generated with [Claude Code](https://claude.com/claude-code)