### PR TITLE
Move remaining cashflow reports off m_lookup

### DIFF
--- a/dao/cashflow-closing-dao.js
+++ b/dao/cashflow-closing-dao.js
@@ -101,7 +101,7 @@ module.exports = {
                 AND mlr.applies_to_cashflow = 'Y'
                 AND mlr.allowed_entry_type IN (:entryType, 'BOTH')
             WHERE ah.location_code = :location AND ah.active_flag = 'Y'
-            ORDER BY ah.account_head_name
+            ORDER BY COALESCE(mlr.display_sequence, 999999), ah.account_head_name
         `, { replacements: { location, entryType }, type: Sequelize.QueryTypes.SELECT });
 
         const transactions = await db.sequelize.query(`

--- a/dao/cashflow-detailed-dao.js
+++ b/dao/cashflow-detailed-dao.js
@@ -6,35 +6,32 @@ module.exports = {
     
     getCashflowDetailedData: async (fromDate, toDate, locationCode) => {
         const result = await db.sequelize.query(
-            `SELECT 
+            `SELECT
                 DATE_FORMAT(tcc.cashflow_date, '%d/%m/%Y') as transaction_date,
                 tct.description,
                 tct.type as transaction_type,
-                ml.tag as flow_type,
-                CASE 
-                    WHEN ml.tag = 'IN' THEN 'Inflow'
-                    WHEN ml.tag = 'OUT' THEN 'Outflow'
-                    ELSE ml.tag
+                tct.entry_type as flow_type,
+                CASE
+                    WHEN tct.entry_type = 'CREDIT' THEN 'Inflow'
+                    WHEN tct.entry_type = 'DEBIT' THEN 'Outflow'
+                    ELSE tct.entry_type
                 END as type,
-                IFNULL(ml.attribute5, tct.type) as category,
+                tct.type as category,
                 tct.amount,
                 tcc.cashflow_id as reference_no,
                 tct.transaction_id,
                 tct.calc_flag
-            FROM 
+            FROM
                 t_cashflow_transaction tct
                 JOIN t_cashflow_closing tcc ON tct.cashflow_id = tcc.cashflow_id
-                LEFT JOIN m_lookup ml ON ml.lookup_type = 'CashFlow' 
-                    AND ml.description = tct.type 
-                    AND ml.location_code = tcc.location_code
-            WHERE 
+            WHERE
                 tcc.location_code = :locationCode
                 AND DATE(tcc.cashflow_date) BETWEEN :fromDate AND :toDate
                 AND tcc.closing_status = 'CLOSED'
                 AND tct.amount > 0
-            ORDER BY 
-                tcc.cashflow_date DESC, 
-                ml.tag DESC, 
+            ORDER BY
+                tcc.cashflow_date DESC,
+                tct.entry_type DESC,
                 tct.amount DESC`,
             {
                 replacements: { 
@@ -51,22 +48,19 @@ module.exports = {
 
     getCashflowDetailedSummary: async (fromDate, toDate, locationCode) => {
         const result = await db.sequelize.query(
-            `SELECT 
+            `SELECT
                 COUNT(DISTINCT tct.transaction_id) as total_transactions,
-                COALESCE(SUM(CASE WHEN ml.tag = 'IN' THEN tct.amount ELSE 0 END), 0) as total_inflow,
-                COALESCE(SUM(CASE WHEN ml.tag = 'OUT' THEN tct.amount ELSE 0 END), 0) as total_outflow,
-                COALESCE(SUM(CASE 
-                    WHEN ml.tag = 'IN' THEN tct.amount
-                    WHEN ml.tag = 'OUT' THEN -tct.amount
-                    ELSE 0 
+                COALESCE(SUM(CASE WHEN tct.entry_type = 'CREDIT' THEN tct.amount ELSE 0 END), 0) as total_inflow,
+                COALESCE(SUM(CASE WHEN tct.entry_type = 'DEBIT' THEN tct.amount ELSE 0 END), 0) as total_outflow,
+                COALESCE(SUM(CASE
+                    WHEN tct.entry_type = 'CREDIT' THEN tct.amount
+                    WHEN tct.entry_type = 'DEBIT' THEN -tct.amount
+                    ELSE 0
                 END), 0) as net_cashflow
-            FROM 
+            FROM
                 t_cashflow_transaction tct
                 JOIN t_cashflow_closing tcc ON tct.cashflow_id = tcc.cashflow_id
-                LEFT JOIN m_lookup ml ON ml.lookup_type = 'CashFlow' 
-                    AND ml.description = tct.type 
-                    AND ml.location_code = tcc.location_code
-            WHERE 
+            WHERE
                 tcc.location_code = :locationCode
                 AND DATE(tcc.cashflow_date) BETWEEN :fromDate AND :toDate
                 AND tcc.closing_status = 'CLOSED'
@@ -86,26 +80,23 @@ module.exports = {
 
     getCashflowTypeWiseSummary: async (fromDate, toDate, locationCode) => {
         const result = await db.sequelize.query(
-            `SELECT 
+            `SELECT
                 tct.type,
-                ml.tag,
+                tct.entry_type as tag,
                 COUNT(*) as transaction_count,
                 SUM(tct.amount) as total_amount
-            FROM 
+            FROM
                 t_cashflow_transaction tct
                 JOIN t_cashflow_closing tcc ON tct.cashflow_id = tcc.cashflow_id
-                LEFT JOIN m_lookup ml ON ml.lookup_type = 'CashFlow' 
-                    AND ml.description = tct.type 
-                    AND ml.location_code = tcc.location_code
-            WHERE 
+            WHERE
                 tcc.location_code = :locationCode
                 AND DATE(tcc.cashflow_date) BETWEEN :fromDate AND :toDate
                 AND tcc.closing_status = 'CLOSED'
                 AND tct.amount > 0
-            GROUP BY 
-                tct.type, ml.tag
-            ORDER BY 
-                ml.tag DESC, total_amount DESC`,
+            GROUP BY
+                tct.type, tct.entry_type
+            ORDER BY
+                tct.entry_type DESC, total_amount DESC`,
             {
                 replacements: { 
                     locationCode: locationCode, 

--- a/dao/report-bank-deposit-recon-dao.js
+++ b/dao/report-bank-deposit-recon-dao.js
@@ -10,37 +10,33 @@ module.exports = {
      */
     getCashflowBankDeposits: async (locationCode, fromDate, toDate) => {
         const query = `
-            SELECT 
+            SELECT
                 DATE_FORMAT(tcc.cashflow_date, '%d-%m-%Y') as Date,
                 tcc.cashflow_date as DateObj,
                 tct.description as Description,
                 tct.type as BankAccount,
                 tct.amount as Amount,
-                
+
                 -- Source tracking
                 't_cashflow_transaction' as source_table,
                 tct.transaction_id as source_id,
-                
+
                 -- Reconciliation fields
                 tct.recon_match_id,
                 tct.manual_recon_flag,
                 tct.manual_recon_by,
                 tct.manual_recon_date,
-                
+
                 -- Additional metadata
-                tcc.cashflow_id,
-                ml.lookup_id
-                
+                tcc.cashflow_id
+
             FROM t_cashflow_transaction tct
             INNER JOIN t_cashflow_closing tcc ON tct.cashflow_id = tcc.cashflow_id
-            LEFT JOIN m_lookup ml ON ml.lookup_type = 'CashFlow' 
-                AND ml.description = tct.type
-                AND ml.location_code = tcc.location_code
-            WHERE 
+            WHERE
                 tcc.location_code = :locationCode
                 AND DATE(tcc.cashflow_date) BETWEEN :fromDate AND :toDate
                 AND tcc.closing_status = 'CLOSED'
-                AND ml.tag = 'OUT'
+                AND tct.entry_type = 'DEBIT'
                 AND tct.type LIKE 'To Bank%'
                 AND tct.amount > 0
             ORDER BY tcc.cashflow_date ASC
@@ -210,14 +206,11 @@ module.exports = {
                 SUM(CASE WHEN tct.recon_match_id IS NOT NULL THEN tct.amount ELSE 0 END) as matched_amount
             FROM t_cashflow_transaction tct
             INNER JOIN t_cashflow_closing tcc ON tct.cashflow_id = tcc.cashflow_id
-            LEFT JOIN m_lookup ml ON ml.lookup_type = 'CashFlow' 
-                AND ml.description = tct.type
-                AND ml.location_code = tcc.location_code
-            WHERE 
+            WHERE
                 tcc.location_code = :locationCode
                 AND DATE(tcc.cashflow_date) BETWEEN :fromDate AND :toDate
                 AND tcc.closing_status = 'CLOSED'
-                AND ml.tag = 'OUT'
+                AND tct.entry_type = 'DEBIT'
                 AND tct.type LIKE 'To Bank%'
                 AND tct.amount > 0
 

--- a/dao/report-cashflow-dao.js
+++ b/dao/report-cashflow-dao.js
@@ -13,21 +13,21 @@ module.exports = {
     const result = await db.sequelize.query(
         `SELECT tct.type,
                 tct.description,
-                IF(ml.tag = 'IN', tct.amount, '') credit,
-                IF(ml.tag = 'OUT', tct.amount, '') debit
+                IF(tct.entry_type = 'CREDIT', tct.amount, '') credit,
+                IF(tct.entry_type = 'DEBIT', tct.amount, '') debit
             FROM
-                t_cashflow_transaction tct,
-                t_cashflow_closing tcc,
-                m_lookup ml
+                t_cashflow_transaction tct
+                JOIN t_cashflow_closing tcc ON tcc.cashflow_id = tct.cashflow_id
+                LEFT JOIN m_ledger_rules mlr
+                    ON  mlr.location_code = tcc.location_code
+                    AND mlr.external_id   = tct.account_head_id
+                    AND mlr.source_type   = 'Static'
+                    AND mlr.applies_to_cashflow = 'Y'
             WHERE
                 tcc.location_code = :locationCode
                     AND DATE(tcc.cashflow_date) = :cashflowDate
-                    AND tcc.cashflow_id = tct.cashflow_id
-                    AND ml.lookup_type = 'CashFlow'
-                    AND ml.description = tct.type
-                    AND ml.location_code = tcc.location_code
                     AND tcc.closing_status = 'CLOSED'
-            ORDER BY CONVERT( ml.attribute1 , SIGNED)`,
+            ORDER BY COALESCE(mlr.display_sequence, 999999), tct.type`,
         {
           replacements: { locationCode: locationCode, cashflowDate: cashhflowDate },
           type: Sequelize.QueryTypes.SELECT


### PR DESCRIPTION
## Summary
- Day Close report, Cashflow Detailed report, and Bank Deposit Recon report now resolve credit/debit direction from `t_cashflow_transaction.entry_type` instead of joining `m_lookup(CashFlow)` by text-matching `type`.
- Cashflow Detailed's "category" column now shows the account head name directly instead of `m_lookup.attribute5` (populated for only 2 of 25 locations anyway).
- Tally export v2 intentionally left untouched (explicitly out of scope).
- Fixes a real ordering gap found along the way: the cashflow entry screen's dropdown was sorting purely alphabetically, ignoring the `attribute1`-derived `display_sequence` already carried into `m_ledger_rules` by the earlier Account Heads migration. Now wired in, and matches the Day Close report's ordering.

## Why
User is retiring the `m_lookup(CashFlow)` rows (backed up on prod as `m_lookup_backup_20260819` first) since Account Heads/Ledger Rules now own this data and maintaining both is redundant. These were the last live-code consumers besides Tally export.

## Test plan
- [x] Verified all 4 queries against real SFS data — correct output, no regressions
- [x] Verified entry-page ordering now matches Day Close report ordering (system types in configured sequence, rest alphabetical)
- [x] Confirmed every downstream consumer (controllers/views) reads the same column names as before — no breaking changes to callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)