### PR TITLE
Order cashflow entry page rows to match Day Close report

### DIFF
--- a/dao/cashflow-closing-dao.js
+++ b/dao/cashflow-closing-dao.js
@@ -105,11 +105,16 @@ module.exports = {
         `, { replacements: { location, entryType }, type: Sequelize.QueryTypes.SELECT });
 
         const transactions = await db.sequelize.query(`
-            SELECT transaction_id, description, amount, type, calc_flag AS calcFlag
-            FROM t_cashflow_transaction
-            WHERE cashflow_id = :id AND entry_type = :entryType
-            ORDER BY transaction_id
-        `, { replacements: { id, entryType }, type: Sequelize.QueryTypes.SELECT });
+            SELECT tct.transaction_id, tct.description, tct.amount, tct.type, tct.calc_flag AS calcFlag
+            FROM t_cashflow_transaction tct
+            LEFT JOIN m_ledger_rules mlr
+                ON  mlr.location_code = :location
+                AND mlr.external_id   = tct.account_head_id
+                AND mlr.source_type   = 'Static'
+                AND mlr.applies_to_cashflow = 'Y'
+            WHERE tct.cashflow_id = :id AND tct.entry_type = :entryType
+            ORDER BY COALESCE(mlr.display_sequence, 999999), tct.type, tct.transaction_id
+        `, { replacements: { location, id, entryType }, type: Sequelize.QueryTypes.SELECT });
 
         return { options, transactions };
     },


### PR DESCRIPTION
## Summary
- Existing rows on the cashflow entry page now order by `display_sequence` (same as the dropdown options and the Day Close report), instead of `transaction_id`.
- Multiple entries of the same type (e.g. several "Cashier A/C (-)" rows) still keep their original relative entry order via `transaction_id` as a tiebreaker within their type cluster.

## Why
User compared the same cloned cashflow_id (8875) between prod and beta and found the ordering inconsistent between the entry page and the Day Close report. Verified this is purely a code/query difference (data is identical, confirmed clone).

## Test plan
- [x] Verified against cashflow_id=8875 on beta — now matches the Day Close report's ordering exactly (Balance B/F → Collection → Cashier A/C(+) group → To Bank → Cashier A/C(-) group → alphabetical expenses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)