### PR TITLE
Cashflow -> Account Heads/Ledger Rules migration, stock-adjusted COGS, report fixes

### DIFF
--- a/controllers/account-heads-controller.js
+++ b/controllers/account-heads-controller.js
@@ -3,6 +3,18 @@ const AccountHeadsDao    = require("../dao/account-heads-dao");
 const LedgerRulesDao     = require("../dao/ledger-rules-dao");
 const BankDao            = require("../dao/bank-dao");
 const rolePermissionsDao = require("../dao/role-permissions-dao");
+const { getLedgersByGroup } = require('../routes/gl-routes');
+const db = require('../db/db-connection');
+const { QueryTypes } = require('sequelize');
+
+async function getAllGlGroups(locationCode) {
+    return db.sequelize.query(`
+        SELECT group_id, group_name, group_nature
+        FROM gl_ledger_groups
+        WHERE location_code = :locationCode AND active_flag = 'Y'
+        ORDER BY group_nature, group_name
+    `, { replacements: { locationCode }, type: QueryTypes.SELECT });
+}
 
 module.exports = {
 
@@ -12,11 +24,12 @@ module.exports = {
             const role         = req.user.Role;
             const activeTab    = req.query.tab || 'heads';
 
-            const [accountHeads, allRules, banks,
+            const [accountHeads, allRules, banks, glGroups,
                    canEdit, canAdd, canDisable] = await Promise.all([
                 AccountHeadsDao.getAccountHeads(locationCode),
                 LedgerRulesDao.getAllRules(locationCode),
                 BankDao.findAll(locationCode),
+                getAllGlGroups(locationCode),
                 rolePermissionsDao.hasPermission(role, locationCode, 'EDIT_ACCOUNT_HEADS'),
                 rolePermissionsDao.hasPermission(role, locationCode, 'ADD_ACCOUNT_HEADS'),
                 rolePermissionsDao.hasPermission(role, locationCode, 'DISABLE_ACCOUNT_HEADS'),
@@ -28,6 +41,7 @@ module.exports = {
                 accountHeads,
                 allRules,
                 banks,
+                glGroups,
                 canEdit,
                 canAdd,
                 canDisable,
@@ -84,7 +98,7 @@ module.exports = {
             res.redirect("/account-heads");
         } catch (err) {
             console.error("Error updating account head:", err);
-            req.flash("error", "Error updating account head");
+            req.flash("error", err.message || "Error updating account head");
             res.redirect("/account-heads");
         }
     },
@@ -99,7 +113,7 @@ module.exports = {
             res.redirect("/account-heads");
         } catch (err) {
             console.error("Error deactivating account head:", err);
-            req.flash("error", "Error deactivating account head");
+            req.flash("error", err.message || "Error deactivating account head");
             res.redirect("/account-heads");
         }
     },
@@ -110,10 +124,17 @@ module.exports = {
 
     createRule: async (req, res, next) => {
         try {
+            const appliesToCashflow = req.body.applies_to_cashflow === 'Y' ? 'Y' : 'N';
+
+            if (appliesToCashflow === 'Y') {
+                const dup = await LedgerRulesDao.findCashflowRuleByHead(req.user.location_code, req.body.account_head_id);
+                if (dup) throw new Error("A Cashflow rule for this Account Head already exists");
+            }
+
             // external_id and ledger_name come from the account head dropdown selection
             const data = {
                 location_code:        req.user.location_code,
-                bank_id:              req.body.bank_id,
+                bank_id:              appliesToCashflow === 'Y' ? null : req.body.bank_id,
                 external_id:          req.body.account_head_id,
                 ledger_name:          req.body.ledger_name,
                 allowed_entry_type:   req.body.allowed_entry_type,
@@ -122,6 +143,7 @@ module.exports = {
                 effective_start_date: req.body.effective_start_date  || null,
                 effective_end_date:   req.body.effective_end_date    || null,
                 allow_split_flag:     req.body.allow_split_flag      === 'Y' ? 'Y' : 'N',
+                applies_to_cashflow:  appliesToCashflow,
                 created_by:           req.user.username || req.user.Person_id
             };
 
@@ -132,7 +154,7 @@ module.exports = {
             console.error("Error creating ledger rule:", err);
             const msg = err.original?.code === 'ER_DUP_ENTRY'
                 ? "A rule for this Bank + Account Head combination already exists"
-                : (err.original?.sqlMessage || "Error creating ledger rule");
+                : (err.original?.sqlMessage || err.message || "Error creating ledger rule");
             req.flash("error", msg);
             res.redirect("/account-heads?tab=rules");
         }
@@ -140,9 +162,16 @@ module.exports = {
 
     updateRule: async (req, res, next) => {
         try {
+            const appliesToCashflow = req.body.applies_to_cashflow === 'Y' ? 'Y' : 'N';
+
+            if (appliesToCashflow === 'Y') {
+                const dup = await LedgerRulesDao.findCashflowRuleByHead(req.user.location_code, req.body.account_head_id, req.body.rule_id);
+                if (dup) throw new Error("A Cashflow rule for this Account Head already exists");
+            }
+
             const data = {
                 rule_id:              req.body.rule_id,
-                bank_id:              req.body.bank_id,
+                bank_id:              appliesToCashflow === 'Y' ? null : req.body.bank_id,
                 external_id:          req.body.account_head_id,
                 ledger_name:          req.body.ledger_name,
                 allowed_entry_type:   req.body.allowed_entry_type,
@@ -151,6 +180,7 @@ module.exports = {
                 effective_start_date: req.body.effective_start_date  || null,
                 effective_end_date:   req.body.effective_end_date    || null,
                 allow_split_flag:     req.body.allow_split_flag      === 'Y' ? 'Y' : 'N',
+                applies_to_cashflow:  appliesToCashflow,
                 updated_by:           req.user.username || req.user.Person_id
             };
 
@@ -161,7 +191,7 @@ module.exports = {
             console.error("Error updating ledger rule:", err);
             const msg = err.original?.code === 'ER_DUP_ENTRY'
                 ? "A rule for this Bank + Account Head combination already exists"
-                : (err.original?.sqlMessage || "Error updating ledger rule");
+                : (err.original?.sqlMessage || err.message || "Error updating ledger rule");
             req.flash("error", msg);
             res.redirect("/account-heads?tab=rules");
         }
@@ -198,6 +228,19 @@ module.exports = {
     },
 
     // ── Credit / Supplier — entry type override only ──────────────────────
+
+    updateGlGroup: async (req, res, next) => {
+        try {
+            const id       = req.params.id;
+            const glGroupId = req.body.gl_group_id || null;
+            const updatedBy = req.user.username || req.user.Person_id;
+            await AccountHeadsDao.updateGlGroup(id, glGroupId, updatedBy);
+            res.json({ success: true });
+        } catch (err) {
+            console.error('Error updating GL group:', err);
+            res.status(500).json({ error: err.message });
+        }
+    },
 
     updateEntryType: async (req, res, next) => {
         try {

--- a/controllers/cash-flow-controller.js
+++ b/controllers/cash-flow-controller.js
@@ -297,26 +297,16 @@ function getManagerNames(closingValues, cashflowDate, personData) {
     return managers.toString();
 }
 
-function collectCreditAndDebits(tableJoinData) {
-    let creditOrDebits = [], options = [];
-    if(tableJoinData) {
-        tableJoinData.forEach((data) => {
-            options.push({id: data.lookup_id, name: data.description});
-            let t_cashflows = data.t_cashflow_transactions;
-            if (t_cashflows && t_cashflows.length > 0) {
-                t_cashflows.forEach((t_cashflow) => {
-                    creditOrDebits.push({
-                        txn_id: t_cashflow.transaction_id,
-                        description: t_cashflow.description,
-                        amount: t_cashflow.amount,
-                        type: t_cashflow.type,
-                        calcFlag: t_cashflow.calcFlag
-                    });
-                });
-            }
-        });
-    }
-    return {data : creditOrDebits, options: options};
+function collectCreditAndDebits(result) {
+    if (!result) return { data: [], options: [] };
+    const creditOrDebits = (result.transactions || []).map((t) => ({
+        txn_id: t.transaction_id,
+        description: t.description,
+        amount: t.amount,
+        type: t.type,
+        calcFlag: t.calcFlag
+    }));
+    return { data: creditOrDebits, options: result.options || [] };
 }
 
 

--- a/dao/account-heads-dao.js
+++ b/dao/account-heads-dao.js
@@ -5,25 +5,29 @@ const { QueryTypes } = require("sequelize");
 module.exports = {
     getAccountHeads: async (locationCode, includeInactive = false) => {
         let query = `
-            SELECT 
-                account_head_id,
-                account_head_name,
-                account_head_type,
-                allowed_entry_type,
-                notes_required_flag,
-                active_flag,
-                effective_start_date,
-                effective_end_date,
-                created_by,
-                updated_by,
-                creation_date,
-                updation_date
-            FROM m_account_heads
-            WHERE location_code = :locationCode
+            SELECT
+                ah.account_head_id,
+                ah.account_head_name,
+                ah.account_head_type,
+                ah.allowed_entry_type,
+                ah.notes_required_flag,
+                ah.active_flag,
+                ah.is_system_type,
+                ah.effective_start_date,
+                ah.effective_end_date,
+                ah.gl_group_id,
+                g.group_name AS gl_group_name,
+                ah.created_by,
+                ah.updated_by,
+                ah.creation_date,
+                ah.updation_date
+            FROM m_account_heads ah
+            LEFT JOIN gl_ledger_groups g ON g.group_id = ah.gl_group_id
+            WHERE ah.location_code = :locationCode
         `;
 
-        if (!includeInactive) query += " AND active_flag = 'Y'";
-        query += " ORDER BY account_head_type, account_head_name";
+        if (!includeInactive) query += " AND ah.active_flag = 'Y'";
+        query += " ORDER BY ah.account_head_type, ah.account_head_name";
 
         return await db.sequelize.query(query, {
             replacements: { locationCode },
@@ -62,6 +66,11 @@ module.exports = {
     },
 
     updateAccountHead: async (data) => {
+        const existing = await module.exports.getAccountHeadById(data.account_head_id);
+        if (existing && existing.is_system_type === 'Y' && existing.account_head_name !== data.account_head_name) {
+            throw new Error(`'${existing.account_head_name}' is a system-generated account head (used by cashflow auto-generation) and cannot be renamed`);
+        }
+
         const query = `
             UPDATE m_account_heads
             SET
@@ -83,6 +92,11 @@ module.exports = {
     },
 
     deactivateAccountHead: async (id, user) => {
+        const existing = await module.exports.getAccountHeadById(id);
+        if (existing && existing.is_system_type === 'Y') {
+            throw new Error(`'${existing.account_head_name}' is a system-generated account head (used by cashflow auto-generation) and cannot be deactivated`);
+        }
+
         const query = `
             UPDATE m_account_heads
             SET active_flag = 'N',
@@ -93,6 +107,46 @@ module.exports = {
         return await db.sequelize.query(query, {
             replacements: { id, user },
             type: QueryTypes.UPDATE
+        });
+    },
+
+    updateGlGroup: async (id, glGroupId, updatedBy) => {
+        // 1. Update m_account_heads
+        await db.sequelize.query(`
+            UPDATE m_account_heads
+            SET gl_group_id   = :glGroupId,
+                updated_by    = :updatedBy,
+                updation_date = NOW()
+            WHERE account_head_id = :id
+        `, {
+            replacements: { id, glGroupId: glGroupId || null, updatedBy },
+            type: QueryTypes.UPDATE
+        });
+
+        if (!glGroupId) return; // cleared — nothing to sync to gl_ledgers
+
+        // 2. Update gl_ledgers entry if it already exists
+        await db.sequelize.query(`
+            UPDATE gl_ledgers
+            SET group_id   = :glGroupId,
+                updated_by = :updatedBy
+            WHERE source_type = 'STATIC'
+              AND source_id   = :id
+        `, {
+            replacements: { id, glGroupId, updatedBy },
+            type: QueryTypes.UPDATE
+        });
+
+        // 3. Create gl_ledgers entry if it was missing (skipped in initial population)
+        await db.sequelize.query(`
+            INSERT IGNORE INTO gl_ledgers
+                (location_code, ledger_name, group_id, source_type, source_id, created_by)
+            SELECT ah.location_code, ah.account_head_name, :glGroupId, 'STATIC', ah.account_head_id, :updatedBy
+            FROM m_account_heads ah
+            WHERE ah.account_head_id = :id
+        `, {
+            replacements: { id, glGroupId, updatedBy },
+            type: QueryTypes.INSERT
         });
     },
 

--- a/dao/cashflow-closing-dao.js
+++ b/dao/cashflow-closing-dao.js
@@ -3,7 +3,6 @@ const CashFlowClosing = db.cashflow_closing;
 const CashFlowTxn = db.txn_cashflow;
 const ClosingTxn = db.txn_closing;
 const CashFlowDenoms = db.cashflow_denoms;
-const Lookup = db.lookup;
 const config = require("../config/app-config");
 const { Sequelize, Op } = require("sequelize");
 
@@ -84,21 +83,35 @@ module.exports = {
     addNew: (cashflowClosing) => {
         return CashFlowClosing.create(cashflowClosing)
     },
-    findCashflowTxnById: (location, id, type) => {
-        return Lookup.findAll({
-            where: {
-                location_code: location,
-                tag: type
-            },
-            include: [
-                {
-                    model: CashFlowTxn,
-                    where: {
-                        cashflow_id: id,
-                    },
-                    required: false
-                }],
-        });
+    // Dropdown options + existing entries for one flow direction (Credit/InFlow
+    // or Debit/OutFlow) of a cashflow. Options come from Account Heads that
+    // have a cashflow-scoped Ledger Rule (applies_to_cashflow='Y') for this
+    // direction; existing entries come straight off t_cashflow_transaction.entry_type
+    // (set at insert time — see trg_cashflow_txn_account_head_insert).
+    findCashflowTxnById: async (location, id, type) => {
+        const entryType = type === 'IN' ? 'CREDIT' : 'DEBIT';
+
+        const options = await db.sequelize.query(`
+            SELECT DISTINCT ah.account_head_id AS id, ah.account_head_name AS name
+            FROM m_account_heads ah
+            INNER JOIN m_ledger_rules mlr
+                ON  mlr.location_code = ah.location_code
+                AND mlr.external_id   = ah.account_head_id
+                AND mlr.source_type   = 'Static'
+                AND mlr.applies_to_cashflow = 'Y'
+                AND mlr.allowed_entry_type IN (:entryType, 'BOTH')
+            WHERE ah.location_code = :location AND ah.active_flag = 'Y'
+            ORDER BY ah.account_head_name
+        `, { replacements: { location, entryType }, type: Sequelize.QueryTypes.SELECT });
+
+        const transactions = await db.sequelize.query(`
+            SELECT transaction_id, description, amount, type, calc_flag AS calcFlag
+            FROM t_cashflow_transaction
+            WHERE cashflow_id = :id AND entry_type = :entryType
+            ORDER BY transaction_id
+        `, { replacements: { id, entryType }, type: Sequelize.QueryTypes.SELECT });
+
+        return { options, transactions };
     },
     triggerGenerateCashflow : (cashflowId) => {
         const cashflowTxn = db.sequelize.query('CALL generate_cashflow(' + cashflowId + ');', null, { raw: true });
@@ -106,7 +119,7 @@ module.exports = {
     },
     saveCashflowTxns: (data) => {
         const txns = CashFlowTxn.bulkCreate(data, {returning: true,
-            updateOnDuplicate: ["description", "type", "amount", "updated_by", "updation_date"]});
+            updateOnDuplicate: ["description", "type", "account_head_id", "amount", "updated_by", "updation_date"]});
         return txns;
     },
     delete: (id) => {

--- a/dao/cashflow-closing-dao.js
+++ b/dao/cashflow-closing-dao.js
@@ -101,7 +101,7 @@ module.exports = {
                 AND mlr.applies_to_cashflow = 'Y'
                 AND mlr.allowed_entry_type IN (:entryType, 'BOTH')
             WHERE ah.location_code = :location AND ah.active_flag = 'Y'
-            ORDER BY ah.account_head_name
+            ORDER BY COALESCE(mlr.display_sequence, 999999), ah.account_head_name
         `, { replacements: { location, entryType }, type: Sequelize.QueryTypes.SELECT });
 
         const transactions = await db.sequelize.query(`

--- a/dao/cashflow-closing-dao.js
+++ b/dao/cashflow-closing-dao.js
@@ -105,11 +105,16 @@ module.exports = {
         `, { replacements: { location, entryType }, type: Sequelize.QueryTypes.SELECT });
 
         const transactions = await db.sequelize.query(`
-            SELECT transaction_id, description, amount, type, calc_flag AS calcFlag
-            FROM t_cashflow_transaction
-            WHERE cashflow_id = :id AND entry_type = :entryType
-            ORDER BY transaction_id
-        `, { replacements: { id, entryType }, type: Sequelize.QueryTypes.SELECT });
+            SELECT tct.transaction_id, tct.description, tct.amount, tct.type, tct.calc_flag AS calcFlag
+            FROM t_cashflow_transaction tct
+            LEFT JOIN m_ledger_rules mlr
+                ON  mlr.location_code = :location
+                AND mlr.external_id   = tct.account_head_id
+                AND mlr.source_type   = 'Static'
+                AND mlr.applies_to_cashflow = 'Y'
+            WHERE tct.cashflow_id = :id AND tct.entry_type = :entryType
+            ORDER BY COALESCE(mlr.display_sequence, 999999), tct.type, tct.transaction_id
+        `, { replacements: { location, id, entryType }, type: Sequelize.QueryTypes.SELECT });
 
         return { options, transactions };
     },

--- a/dao/cashflow-detailed-dao.js
+++ b/dao/cashflow-detailed-dao.js
@@ -6,35 +6,32 @@ module.exports = {
     
     getCashflowDetailedData: async (fromDate, toDate, locationCode) => {
         const result = await db.sequelize.query(
-            `SELECT 
+            `SELECT
                 DATE_FORMAT(tcc.cashflow_date, '%d/%m/%Y') as transaction_date,
                 tct.description,
                 tct.type as transaction_type,
-                ml.tag as flow_type,
-                CASE 
-                    WHEN ml.tag = 'IN' THEN 'Inflow'
-                    WHEN ml.tag = 'OUT' THEN 'Outflow'
-                    ELSE ml.tag
+                tct.entry_type as flow_type,
+                CASE
+                    WHEN tct.entry_type = 'CREDIT' THEN 'Inflow'
+                    WHEN tct.entry_type = 'DEBIT' THEN 'Outflow'
+                    ELSE tct.entry_type
                 END as type,
-                IFNULL(ml.attribute5, tct.type) as category,
+                tct.type as category,
                 tct.amount,
                 tcc.cashflow_id as reference_no,
                 tct.transaction_id,
                 tct.calc_flag
-            FROM 
+            FROM
                 t_cashflow_transaction tct
                 JOIN t_cashflow_closing tcc ON tct.cashflow_id = tcc.cashflow_id
-                LEFT JOIN m_lookup ml ON ml.lookup_type = 'CashFlow' 
-                    AND ml.description = tct.type 
-                    AND ml.location_code = tcc.location_code
-            WHERE 
+            WHERE
                 tcc.location_code = :locationCode
                 AND DATE(tcc.cashflow_date) BETWEEN :fromDate AND :toDate
                 AND tcc.closing_status = 'CLOSED'
                 AND tct.amount > 0
-            ORDER BY 
-                tcc.cashflow_date DESC, 
-                ml.tag DESC, 
+            ORDER BY
+                tcc.cashflow_date DESC,
+                tct.entry_type DESC,
                 tct.amount DESC`,
             {
                 replacements: { 
@@ -51,22 +48,19 @@ module.exports = {
 
     getCashflowDetailedSummary: async (fromDate, toDate, locationCode) => {
         const result = await db.sequelize.query(
-            `SELECT 
+            `SELECT
                 COUNT(DISTINCT tct.transaction_id) as total_transactions,
-                COALESCE(SUM(CASE WHEN ml.tag = 'IN' THEN tct.amount ELSE 0 END), 0) as total_inflow,
-                COALESCE(SUM(CASE WHEN ml.tag = 'OUT' THEN tct.amount ELSE 0 END), 0) as total_outflow,
-                COALESCE(SUM(CASE 
-                    WHEN ml.tag = 'IN' THEN tct.amount
-                    WHEN ml.tag = 'OUT' THEN -tct.amount
-                    ELSE 0 
+                COALESCE(SUM(CASE WHEN tct.entry_type = 'CREDIT' THEN tct.amount ELSE 0 END), 0) as total_inflow,
+                COALESCE(SUM(CASE WHEN tct.entry_type = 'DEBIT' THEN tct.amount ELSE 0 END), 0) as total_outflow,
+                COALESCE(SUM(CASE
+                    WHEN tct.entry_type = 'CREDIT' THEN tct.amount
+                    WHEN tct.entry_type = 'DEBIT' THEN -tct.amount
+                    ELSE 0
                 END), 0) as net_cashflow
-            FROM 
+            FROM
                 t_cashflow_transaction tct
                 JOIN t_cashflow_closing tcc ON tct.cashflow_id = tcc.cashflow_id
-                LEFT JOIN m_lookup ml ON ml.lookup_type = 'CashFlow' 
-                    AND ml.description = tct.type 
-                    AND ml.location_code = tcc.location_code
-            WHERE 
+            WHERE
                 tcc.location_code = :locationCode
                 AND DATE(tcc.cashflow_date) BETWEEN :fromDate AND :toDate
                 AND tcc.closing_status = 'CLOSED'
@@ -86,26 +80,23 @@ module.exports = {
 
     getCashflowTypeWiseSummary: async (fromDate, toDate, locationCode) => {
         const result = await db.sequelize.query(
-            `SELECT 
+            `SELECT
                 tct.type,
-                ml.tag,
+                tct.entry_type as tag,
                 COUNT(*) as transaction_count,
                 SUM(tct.amount) as total_amount
-            FROM 
+            FROM
                 t_cashflow_transaction tct
                 JOIN t_cashflow_closing tcc ON tct.cashflow_id = tcc.cashflow_id
-                LEFT JOIN m_lookup ml ON ml.lookup_type = 'CashFlow' 
-                    AND ml.description = tct.type 
-                    AND ml.location_code = tcc.location_code
-            WHERE 
+            WHERE
                 tcc.location_code = :locationCode
                 AND DATE(tcc.cashflow_date) BETWEEN :fromDate AND :toDate
                 AND tcc.closing_status = 'CLOSED'
                 AND tct.amount > 0
-            GROUP BY 
-                tct.type, ml.tag
-            ORDER BY 
-                ml.tag DESC, total_amount DESC`,
+            GROUP BY
+                tct.type, tct.entry_type
+            ORDER BY
+                tct.entry_type DESC, total_amount DESC`,
             {
                 replacements: { 
                     locationCode: locationCode, 

--- a/dao/ledger-rules-dao.js
+++ b/dao/ledger-rules-dao.js
@@ -4,9 +4,11 @@
 const db = require("../db/db-connection");
 const { QueryTypes } = require("sequelize");
 
-// Builds the bank display label: "SBI (...1234)" or just "SBI" when no account number.
+// Builds the bank display label: "Cashflow" for cashflow-scoped rules,
+// otherwise "SBI (...1234)" or just "SBI" when no account number.
 const BANK_DISPLAY = `
     CASE
+        WHEN r.applies_to_cashflow = 'Y' THEN 'Cashflow'
         WHEN b.account_number IS NOT NULL AND b.account_number != ''
         THEN CONCAT(b.bank_name, ' (...', RIGHT(b.account_number, 4), ')')
         ELSE b.bank_name
@@ -16,12 +18,14 @@ const BANK_DISPLAY = `
 module.exports = {
 
     // All rules for the location — Static + Credit + Supplier + Bank.
+    // bank_id is NULL for cashflow-scoped Static rules, hence LEFT JOIN.
     getAllRules: async (locationCode) => {
         const query = `
             SELECT
                 r.rule_id,
                 r.source_type,
                 r.bank_id,
+                r.applies_to_cashflow,
                 ${BANK_DISPLAY}          AS bank_display,
                 r.external_id,
                 CASE
@@ -37,12 +41,12 @@ module.exports = {
                 r.created_by,
                 r.updated_by
             FROM m_ledger_rules r
-            INNER JOIN m_bank b  ON b.bank_id  = r.bank_id
+            LEFT  JOIN m_bank b  ON b.bank_id  = r.bank_id
             LEFT  JOIN m_bank mb2
                 ON  r.source_type  = 'Bank'
                 AND r.external_id  = mb2.bank_id
             WHERE r.location_code = :locationCode
-            ORDER BY r.source_type, b.bank_name,
+            ORDER BY r.source_type, r.applies_to_cashflow DESC, b.bank_name,
                      CASE WHEN r.source_type = 'Bank' THEN mb2.ledger_name ELSE r.ledger_name END
         `;
         return await db.sequelize.query(query, {
@@ -53,18 +57,39 @@ module.exports = {
 
     // ── Static rule CRUD ────────────────────────────────────────────────────
 
+    // bank_id has no unique-index protection against duplicates when NULL
+    // (MySQL treats each NULL as distinct), so cashflow-scoped rules need an
+    // explicit app-level duplicate check — see createRule/updateRule in the
+    // controller.
+    findCashflowRuleByHead: async (locationCode, externalId, excludeRuleId = null) => {
+        const query = `
+            SELECT rule_id FROM m_ledger_rules
+            WHERE location_code = :locationCode
+              AND external_id   = :externalId
+              AND source_type   = 'Static'
+              AND applies_to_cashflow = 'Y'
+              ${excludeRuleId ? 'AND rule_id != :excludeRuleId' : ''}
+            LIMIT 1
+        `;
+        const rows = await db.sequelize.query(query, {
+            replacements: { locationCode, externalId, excludeRuleId },
+            type: QueryTypes.SELECT
+        });
+        return rows[0] || null;
+    },
+
     createStaticRule: async (data) => {
         const query = `
             INSERT INTO m_ledger_rules (
                 location_code, bank_id, source_type, external_id,
                 ledger_name, allowed_entry_type, notes_required_flag,
                 max_amount, effective_start_date, effective_end_date,
-                allow_split_flag, created_by
+                allow_split_flag, applies_to_cashflow, created_by
             ) VALUES (
                 :location_code, :bank_id, 'Static', :external_id,
                 :ledger_name, :allowed_entry_type, :notes_required_flag,
                 :max_amount, :effective_start_date, :effective_end_date,
-                :allow_split_flag, :created_by
+                :allow_split_flag, :applies_to_cashflow, :created_by
             )
         `;
         return await db.sequelize.query(query, {
@@ -86,6 +111,7 @@ module.exports = {
                 effective_start_date = :effective_start_date,
                 effective_end_date   = :effective_end_date,
                 allow_split_flag     = :allow_split_flag,
+                applies_to_cashflow  = :applies_to_cashflow,
                 updated_by           = :updated_by,
                 updation_date        = NOW()
             WHERE rule_id = :rule_id

--- a/dao/report-bank-deposit-recon-dao.js
+++ b/dao/report-bank-deposit-recon-dao.js
@@ -10,37 +10,33 @@ module.exports = {
      */
     getCashflowBankDeposits: async (locationCode, fromDate, toDate) => {
         const query = `
-            SELECT 
+            SELECT
                 DATE_FORMAT(tcc.cashflow_date, '%d-%m-%Y') as Date,
                 tcc.cashflow_date as DateObj,
                 tct.description as Description,
                 tct.type as BankAccount,
                 tct.amount as Amount,
-                
+
                 -- Source tracking
                 't_cashflow_transaction' as source_table,
                 tct.transaction_id as source_id,
-                
+
                 -- Reconciliation fields
                 tct.recon_match_id,
                 tct.manual_recon_flag,
                 tct.manual_recon_by,
                 tct.manual_recon_date,
-                
+
                 -- Additional metadata
-                tcc.cashflow_id,
-                ml.lookup_id
-                
+                tcc.cashflow_id
+
             FROM t_cashflow_transaction tct
             INNER JOIN t_cashflow_closing tcc ON tct.cashflow_id = tcc.cashflow_id
-            LEFT JOIN m_lookup ml ON ml.lookup_type = 'CashFlow' 
-                AND ml.description = tct.type
-                AND ml.location_code = tcc.location_code
-            WHERE 
+            WHERE
                 tcc.location_code = :locationCode
                 AND DATE(tcc.cashflow_date) BETWEEN :fromDate AND :toDate
                 AND tcc.closing_status = 'CLOSED'
-                AND ml.tag = 'OUT'
+                AND tct.entry_type = 'DEBIT'
                 AND tct.type LIKE 'To Bank%'
                 AND tct.amount > 0
             ORDER BY tcc.cashflow_date ASC
@@ -210,14 +206,11 @@ module.exports = {
                 SUM(CASE WHEN tct.recon_match_id IS NOT NULL THEN tct.amount ELSE 0 END) as matched_amount
             FROM t_cashflow_transaction tct
             INNER JOIN t_cashflow_closing tcc ON tct.cashflow_id = tcc.cashflow_id
-            LEFT JOIN m_lookup ml ON ml.lookup_type = 'CashFlow' 
-                AND ml.description = tct.type
-                AND ml.location_code = tcc.location_code
-            WHERE 
+            WHERE
                 tcc.location_code = :locationCode
                 AND DATE(tcc.cashflow_date) BETWEEN :fromDate AND :toDate
                 AND tcc.closing_status = 'CLOSED'
-                AND ml.tag = 'OUT'
+                AND tct.entry_type = 'DEBIT'
                 AND tct.type LIKE 'To Bank%'
                 AND tct.amount > 0
 

--- a/dao/report-cashflow-dao.js
+++ b/dao/report-cashflow-dao.js
@@ -13,21 +13,21 @@ module.exports = {
     const result = await db.sequelize.query(
         `SELECT tct.type,
                 tct.description,
-                IF(ml.tag = 'IN', tct.amount, '') credit,
-                IF(ml.tag = 'OUT', tct.amount, '') debit
+                IF(tct.entry_type = 'CREDIT', tct.amount, '') credit,
+                IF(tct.entry_type = 'DEBIT', tct.amount, '') debit
             FROM
-                t_cashflow_transaction tct,
-                t_cashflow_closing tcc,
-                m_lookup ml
+                t_cashflow_transaction tct
+                JOIN t_cashflow_closing tcc ON tcc.cashflow_id = tct.cashflow_id
+                LEFT JOIN m_ledger_rules mlr
+                    ON  mlr.location_code = tcc.location_code
+                    AND mlr.external_id   = tct.account_head_id
+                    AND mlr.source_type   = 'Static'
+                    AND mlr.applies_to_cashflow = 'Y'
             WHERE
                 tcc.location_code = :locationCode
                     AND DATE(tcc.cashflow_date) = :cashflowDate
-                    AND tcc.cashflow_id = tct.cashflow_id
-                    AND ml.lookup_type = 'CashFlow'
-                    AND ml.description = tct.type
-                    AND ml.location_code = tcc.location_code
                     AND tcc.closing_status = 'CLOSED'
-            ORDER BY CONVERT( ml.attribute1 , SIGNED)`,
+            ORDER BY COALESCE(mlr.display_sequence, 999999), tct.type`,
         {
           replacements: { locationCode: locationCode, cashflowDate: cashhflowDate },
           type: Sequelize.QueryTypes.SELECT

--- a/db/migrations/cashflow-account-heads-correction-backfill.sql
+++ b/db/migrations/cashflow-account-heads-correction-backfill.sql
@@ -1,0 +1,158 @@
+-- ============================================================
+-- Correction: backfill account_head_id + entry_type, repoint the trigger
+-- Generated: 2026-08-17
+-- Updated:   2026-08-17 — added system-type fallback for entry_type. Some
+-- GL-enabled locations (e.g. NS) have real cashflow transactions using the
+-- 10 system-protected types but never had a matching m_lookup(CashFlow) row
+-- for them, so the m_lookup-only join left entry_type NULL even though
+-- account_head_id resolved fine via the guaranteed system-type seeding.
+-- The fallback below uses the same universal name -> direction mapping
+-- already used in cashflow-account-heads-correction-seed.sql (confirmed
+-- 100% consistent tag across every location for these 10 types).
+--
+-- entry_type is meant to be set at cashflow-entry time going forward (which
+-- section of the screen the user filled in) — that UI change is separate,
+-- future work. Until it ships, this trigger derives entry_type from
+-- m_lookup.tag (falling back to the system-type mapping), so every row
+-- always has a value and the GL engine never needs to guess or join
+-- anything at processing time — it only ever reads columns already on the
+-- row.
+-- ============================================================
+
+-- ── Step 1: backfill existing rows ─────────────────────────────────────────
+
+UPDATE t_cashflow_transaction tct
+JOIN t_cashflow_closing tcc ON tcc.cashflow_id = tct.cashflow_id
+JOIN m_account_heads mah ON mah.location_code = tcc.location_code AND mah.account_head_name = tct.type
+SET tct.account_head_id = mah.account_head_id
+WHERE tct.account_head_id IS NULL;
+
+UPDATE t_cashflow_transaction tct
+JOIN t_cashflow_closing tcc ON tcc.cashflow_id = tct.cashflow_id
+JOIN m_lookup ml ON ml.lookup_type = 'CashFlow' AND ml.description = tct.type
+    AND (ml.location_code = tcc.location_code OR ml.location_code IS NULL)
+SET tct.entry_type = CASE ml.tag WHEN 'IN' THEN 'CREDIT' WHEN 'OUT' THEN 'DEBIT' END
+WHERE tct.entry_type IS NULL;
+
+-- System-type fallback — closes the NS-style gap (m_lookup missing rows for
+-- types m_account_heads was guaranteed-seeded with).
+UPDATE t_cashflow_transaction tct
+SET tct.entry_type = CASE tct.type
+    WHEN 'Balance B/F' THEN 'CREDIT'
+    WHEN 'Collection' THEN 'CREDIT'
+    WHEN '2T Oil' THEN 'CREDIT'
+    WHEN 'Discount' THEN 'DEBIT'
+    WHEN 'Cashier A/C (+)' THEN 'CREDIT'
+    WHEN 'Cashier A/C (-)' THEN 'DEBIT'
+    WHEN 'Cash Receipt' THEN 'CREDIT'
+    WHEN 'Expense' THEN 'DEBIT'
+    WHEN 'Salary Payout' THEN 'DEBIT'
+    WHEN 'Salary Recovery' THEN 'CREDIT'
+    ELSE NULL
+END
+WHERE tct.entry_type IS NULL;
+
+-- ── Step 2: repoint the auto-populate trigger ──────────────────────────────
+
+DROP TRIGGER IF EXISTS trg_cashflow_txn_ledger_rule_insert;
+DROP TRIGGER IF EXISTS trg_cashflow_txn_ledger_rule_update;
+
+DELIMITER $$
+
+CREATE TRIGGER trg_cashflow_txn_account_head_insert
+BEFORE INSERT ON t_cashflow_transaction
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+
+    IF NEW.type IS NOT NULL THEN
+        SELECT location_code INTO v_location_code
+        FROM t_cashflow_closing WHERE cashflow_id = NEW.cashflow_id;
+
+        IF v_location_code IS NOT NULL THEN
+            IF NEW.account_head_id IS NULL THEN
+                SELECT account_head_id INTO @v_ah
+                FROM m_account_heads
+                WHERE location_code = v_location_code AND account_head_name = NEW.type
+                LIMIT 1;
+                SET NEW.account_head_id = @v_ah;
+            END IF;
+
+            IF NEW.entry_type IS NULL THEN
+                SELECT CASE tag WHEN 'IN' THEN 'CREDIT' WHEN 'OUT' THEN 'DEBIT' END INTO @v_et
+                FROM m_lookup
+                WHERE lookup_type = 'CashFlow' AND description = NEW.type
+                  AND (location_code = v_location_code OR location_code IS NULL)
+                ORDER BY (location_code = v_location_code) DESC
+                LIMIT 1;
+                IF @v_et IS NULL THEN
+                    SET @v_et = CASE NEW.type
+                        WHEN 'Balance B/F' THEN 'CREDIT'
+                        WHEN 'Collection' THEN 'CREDIT'
+                        WHEN '2T Oil' THEN 'CREDIT'
+                        WHEN 'Discount' THEN 'DEBIT'
+                        WHEN 'Cashier A/C (+)' THEN 'CREDIT'
+                        WHEN 'Cashier A/C (-)' THEN 'DEBIT'
+                        WHEN 'Cash Receipt' THEN 'CREDIT'
+                        WHEN 'Expense' THEN 'DEBIT'
+                        WHEN 'Salary Payout' THEN 'DEBIT'
+                        WHEN 'Salary Recovery' THEN 'CREDIT'
+                        ELSE NULL
+                    END;
+                END IF;
+                SET NEW.entry_type = @v_et;
+            END IF;
+        END IF;
+    END IF;
+END$$
+
+CREATE TRIGGER trg_cashflow_txn_account_head_update
+BEFORE UPDATE ON t_cashflow_transaction
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+
+    IF NOT (OLD.type <=> NEW.type) THEN
+        SELECT location_code INTO v_location_code
+        FROM t_cashflow_closing WHERE cashflow_id = NEW.cashflow_id;
+
+        IF v_location_code IS NOT NULL THEN
+            SELECT account_head_id INTO @v_ah
+            FROM m_account_heads
+            WHERE location_code = v_location_code AND account_head_name = NEW.type
+            LIMIT 1;
+            SET NEW.account_head_id = @v_ah;
+
+            SELECT CASE tag WHEN 'IN' THEN 'CREDIT' WHEN 'OUT' THEN 'DEBIT' END INTO @v_et
+            FROM m_lookup
+            WHERE lookup_type = 'CashFlow' AND description = NEW.type
+              AND (location_code = v_location_code OR location_code IS NULL)
+            ORDER BY (location_code = v_location_code) DESC
+            LIMIT 1;
+            IF @v_et IS NULL THEN
+                SET @v_et = CASE NEW.type
+                    WHEN 'Balance B/F' THEN 'CREDIT'
+                    WHEN 'Collection' THEN 'CREDIT'
+                    WHEN '2T Oil' THEN 'CREDIT'
+                    WHEN 'Discount' THEN 'DEBIT'
+                    WHEN 'Cashier A/C (+)' THEN 'CREDIT'
+                    WHEN 'Cashier A/C (-)' THEN 'DEBIT'
+                    WHEN 'Cash Receipt' THEN 'CREDIT'
+                    WHEN 'Expense' THEN 'DEBIT'
+                    WHEN 'Salary Payout' THEN 'DEBIT'
+                    WHEN 'Salary Recovery' THEN 'CREDIT'
+                    ELSE NULL
+                END;
+            END IF;
+            SET NEW.entry_type = @v_et;
+        END IF;
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- ── Verify ──────────────────────────────────────────────────────────────────
+SELECT COUNT(*) total_rows,
+       SUM(account_head_id IS NOT NULL) has_account_head,
+       SUM(entry_type IS NOT NULL) has_entry_type
+FROM t_cashflow_transaction;

--- a/db/migrations/cashflow-account-heads-correction-schema-prod.sql
+++ b/db/migrations/cashflow-account-heads-correction-schema-prod.sql
@@ -1,0 +1,32 @@
+-- ============================================================
+-- Prod-adapted variant of cashflow-account-heads-correction-schema.sql
+-- Generated: 2026-08-19
+--
+-- The original file's DROP COLUMN steps (t_cashflow_transaction.ledger_rule_id,
+-- m_ledger_rules.usable_in_cashflow/is_system_type) assume beta's now-superseded
+-- FIRST attempt (cashflow-into-ledger-rules-*.sql) was run there first. It never
+-- was on prod — verified 2026-08-19, none of those columns exist — so this
+-- variant only adds columns, nothing to drop. It also adds
+-- m_ledger_rules.display_sequence, which on beta came from that same
+-- superseded first-attempt migration and therefore also needs adding fresh
+-- here (verified missing on prod).
+--
+-- Run this INSTEAD OF cashflow-account-heads-correction-schema.sql on prod.
+-- ============================================================
+
+-- ── t_cashflow_transaction ──────────────────────────────────────────────────
+
+ALTER TABLE t_cashflow_transaction
+    ADD COLUMN account_head_id INT NULL COMMENT 'FK to m_account_heads.account_head_id',
+    ADD COLUMN entry_type ENUM('CREDIT', 'DEBIT') NULL COMMENT 'Set at entry time (which section of the cashflow screen); GL engine reads this directly, no lookup';
+
+-- ── m_ledger_rules ───────────────────────────────────────────────────────────
+
+ALTER TABLE m_ledger_rules
+    ADD COLUMN applies_to_cashflow CHAR(1) NOT NULL DEFAULT 'N' COMMENT 'Y = this rule row scopes its Account Head to Cashflow instead of a bank',
+    ADD COLUMN display_sequence INT NULL COMMENT 'Sort order for display, replaces m_lookup.attribute1';
+
+-- ── m_account_heads ──────────────────────────────────────────────────────────
+
+ALTER TABLE m_account_heads
+    ADD COLUMN is_system_type CHAR(1) NOT NULL DEFAULT 'N' COMMENT 'Y = seeded by generate_cashflow, cannot be deleted';

--- a/db/migrations/cashflow-account-heads-correction-schema.sql
+++ b/db/migrations/cashflow-account-heads-correction-schema.sql
@@ -1,0 +1,52 @@
+-- ============================================================
+-- Correction: cashflow types belong on m_account_heads, not m_ledger_rules
+-- Generated: 2026-08-17
+--
+-- The previous migration (cashflow-into-ledger-rules-*.sql) inserted
+-- cashflow types directly into m_ledger_rules as raw strings — wrong
+-- table. The real model, per the actual Accounting Masters screen already
+-- in use:
+--   m_account_heads = just a ledger name (+ optional gl_group_id sync to
+--                     gl_ledgers). No usage rules live here.
+--   m_ledger_rules  = the real rules — each row scopes ONE Account Head to
+--                     ONE context (a specific bank, OR cashflow — never
+--                     both in one row) with that context's own
+--                     allowed_entry_type. One Account Head can have
+--                     several rule rows, one per context.
+--   gl_static_ledger_map = unchanged — still the sole bridge from a label
+--                     name to POST/SKIP/CONTRA. The GL engine never reads
+--                     m_ledger_rules or m_account_heads for direction or
+--                     ledger resolution; it only reads
+--                     t_cashflow_transaction (account_head_id + entry_type,
+--                     both already resolved before processing time) and
+--                     gl_static_ledger_map.
+-- ============================================================
+
+-- ── t_cashflow_transaction ──────────────────────────────────────────────────
+
+ALTER TABLE t_cashflow_transaction
+    ADD COLUMN account_head_id INT NULL COMMENT 'FK to m_account_heads.account_head_id — replaces ledger_rule_id',
+    ADD COLUMN entry_type ENUM('CREDIT', 'DEBIT') NULL COMMENT 'Set at entry time (which section of the cashflow screen); GL engine reads this directly, no lookup';
+
+-- ledger_rule_id pointed at the wrong table entirely — drop it, nothing
+-- downstream depends on it (the code using it was never deployed to prod).
+ALTER TABLE t_cashflow_transaction DROP COLUMN ledger_rule_id;
+
+-- ── m_ledger_rules ───────────────────────────────────────────────────────────
+
+ALTER TABLE m_ledger_rules
+    ADD COLUMN applies_to_cashflow CHAR(1) NOT NULL DEFAULT 'N' COMMENT 'Y = this rule row scopes its Account Head to Cashflow instead of a bank';
+
+-- usable_in_cashflow / is_system_type were added to the wrong table in the
+-- earlier migration — is_system_type moves to m_account_heads below;
+-- usable_in_cashflow is superseded by applies_to_cashflow (a real rule row,
+-- not a flag on every row). display_sequence stays — still useful for
+-- ordering the cashflow dropdown.
+ALTER TABLE m_ledger_rules
+    DROP COLUMN usable_in_cashflow,
+    DROP COLUMN is_system_type;
+
+-- ── m_account_heads ──────────────────────────────────────────────────────────
+
+ALTER TABLE m_account_heads
+    ADD COLUMN is_system_type CHAR(1) NOT NULL DEFAULT 'N' COMMENT 'Y = seeded by generate_cashflow, cannot be deleted';

--- a/db/migrations/cashflow-account-heads-correction-seed.sql
+++ b/db/migrations/cashflow-account-heads-correction-seed.sql
@@ -1,0 +1,85 @@
+-- ============================================================
+-- Correction: seed m_account_heads + cashflow-scoped m_ledger_rules
+-- Generated: 2026-08-17
+-- No unique key on (location_code, account_head_name) in m_account_heads —
+-- guarded with NOT EXISTS throughout, safe to re-run.
+-- ============================================================
+
+-- ── Step 1: Account Heads — one per distinct real cashflow type ────────────
+-- Reuse an existing Account Head with the same name if one's already there
+-- (e.g. from bank-categorization work); only create when genuinely new.
+
+INSERT INTO m_account_heads
+    (location_code, account_head_name, allowed_entry_type, is_system_type,
+     effective_start_date, created_by, updated_by)
+SELECT cf.location_code, cf.description,
+       CASE cf.tag WHEN 'IN' THEN 'CREDIT' WHEN 'OUT' THEN 'DEBIT' END,
+       CASE WHEN cf.description IN
+           ('Balance B/F','Collection','2T Oil','Discount','Cashier A/C (+)','Cashier A/C (-)','Cash Receipt','Expense','Salary Payout','Salary Recovery')
+           THEN 'Y' ELSE 'N' END,
+       '2025-04-01', 'MIGRATION', 'MIGRATION'
+FROM (
+    SELECT DISTINCT ml.location_code, ml.description, ml.tag
+    FROM m_lookup ml
+    WHERE ml.lookup_type = 'CashFlow'
+      AND EXISTS (SELECT 1 FROM t_cashflow_transaction tct WHERE tct.type = ml.description)
+) cf
+WHERE NOT EXISTS (
+    SELECT 1 FROM m_account_heads mah
+    WHERE mah.location_code = cf.location_code AND mah.account_head_name = cf.description
+);
+
+-- ── Step 2: guarantee the 10 system-generated types exist for every
+--    GL-enabled location, same reasoning as before (generate_cashflow can
+--    fire any of them for any location). Tag confirmed 100% consistent
+--    across every location that's used each type. ─────────────────────────
+
+INSERT INTO m_account_heads
+    (location_code, account_head_name, allowed_entry_type, is_system_type,
+     effective_start_date, created_by, updated_by)
+SELECT loc.location_code, t.name, t.entry_type, 'Y', '2025-04-01', 'MIGRATION', 'MIGRATION'
+FROM (SELECT DISTINCT location_code FROM gl_ledgers) loc
+CROSS JOIN (
+    SELECT 'Balance B/F' name, 'CREDIT' entry_type
+    UNION ALL SELECT 'Collection', 'CREDIT'
+    UNION ALL SELECT '2T Oil', 'CREDIT'
+    UNION ALL SELECT 'Discount', 'DEBIT'
+    UNION ALL SELECT 'Cashier A/C (+)', 'CREDIT'
+    UNION ALL SELECT 'Cashier A/C (-)', 'DEBIT'
+    UNION ALL SELECT 'Cash Receipt', 'CREDIT'
+    UNION ALL SELECT 'Expense', 'DEBIT'
+    UNION ALL SELECT 'Salary Payout', 'DEBIT'
+    UNION ALL SELECT 'Salary Recovery', 'CREDIT'
+) t
+WHERE NOT EXISTS (
+    SELECT 1 FROM m_account_heads mah
+    WHERE mah.location_code = loc.location_code AND mah.account_head_name = t.name
+);
+
+-- ── Step 3: a cashflow-scoped Ledger Rule (applies_to_cashflow='Y') for
+--    every Account Head that's actually used as a cashflow type — bank_id
+--    NULL (not bank-scoped), external_id = the Account Head, ledger_name
+--    denormalized to match createStaticRule's existing convention. ────────
+
+INSERT INTO m_ledger_rules
+    (location_code, source_type, external_id, ledger_name, allowed_entry_type,
+     applies_to_cashflow, display_sequence, created_by, updated_by)
+SELECT mah.location_code, 'Static', mah.account_head_id, mah.account_head_name,
+       mah.allowed_entry_type, 'Y', seq.display_sequence, 'MIGRATION', 'MIGRATION'
+FROM m_account_heads mah
+LEFT JOIN (
+    SELECT DISTINCT location_code, description, MIN(attribute1 + 0) AS display_sequence
+    FROM m_lookup WHERE lookup_type = 'CashFlow'
+    GROUP BY location_code, description
+) seq ON seq.location_code = mah.location_code AND seq.description = mah.account_head_name
+WHERE mah.created_by = 'MIGRATION'
+  AND NOT EXISTS (
+      SELECT 1 FROM m_ledger_rules mlr
+      WHERE mlr.location_code = mah.location_code AND mlr.external_id = mah.account_head_id
+        AND mlr.source_type = 'Static' AND mlr.applies_to_cashflow = 'Y'
+  );
+
+-- ── Verify ──────────────────────────────────────────────────────────────────
+SELECT COUNT(*) AS account_heads_created FROM m_account_heads WHERE created_by = 'MIGRATION';
+SELECT COUNT(*) AS system_type_account_heads FROM m_account_heads WHERE is_system_type = 'Y';
+SELECT COUNT(*) AS cashflow_scoped_rules FROM m_ledger_rules WHERE applies_to_cashflow = 'Y';

--- a/db/migrations/cashflow-account-heads-gap-fix.sql
+++ b/db/migrations/cashflow-account-heads-gap-fix.sql
@@ -1,0 +1,81 @@
+-- ============================================================
+-- Gap fix: cashflow-account-heads-correction-seed.sql left two holes
+-- Generated: 2026-08-17
+--
+-- Found by spot-checking SFS: comparing m_lookup(CashFlow) against
+-- m_account_heads + cashflow-scoped m_ledger_rules turned up two distinct
+-- gaps, both across every location, not just SFS:
+--
+-- 1. 30 Account Heads (all created_by='system', i.e. pre-existing from the
+--    bank-categorization work, predating this session) share a name with a
+--    real cashflow type but never got a cashflow-scoped Ledger Rule — the
+--    original seed's Step 3 only covered heads it had just created
+--    (created_by='MIGRATION'), wrongly skipping heads that already existed.
+--
+-- 2. 3 m_lookup(CashFlow) rows have no Account Head at all (MC/'MPDC
+--    Cement', SFS/'To Bank SBI 8015', SFS/'PROFFSONAL CHARGES') — the
+--    original seed only created a head when EXISTS-matched against real
+--    t_cashflow_transaction usage, but these are valid configured dropdown
+--    options that simply haven't been used yet. Since the cashflow entry
+--    screen now sources its dropdown from Account Heads (not m_lookup
+--    directly), an unused-but-valid option silently disappearing from the
+--    dropdown is a real regression.
+--
+-- Safe to re-run — guarded with NOT EXISTS throughout.
+-- ============================================================
+
+-- ── Step 1: create Account Heads for the 3 m_lookup rows with none ────────
+
+INSERT INTO m_account_heads
+    (location_code, account_head_name, allowed_entry_type, is_system_type,
+     effective_start_date, created_by, updated_by)
+SELECT ml.location_code, ml.description,
+       CASE ml.tag WHEN 'IN' THEN 'CREDIT' WHEN 'OUT' THEN 'DEBIT' END,
+       'N', '2025-04-01', 'MIGRATION', 'MIGRATION'
+FROM m_lookup ml
+WHERE ml.lookup_type = 'CashFlow'
+  AND ml.location_code IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM m_account_heads mah
+      WHERE mah.location_code = ml.location_code AND mah.account_head_name = ml.description
+  );
+
+-- ── Step 2: cashflow-scoped Ledger Rule for every Account Head that
+--    matches a real m_lookup CashFlow entry and doesn't have one yet —
+--    regardless of who/what created the Account Head. ─────────────────────
+
+INSERT INTO m_ledger_rules
+    (location_code, source_type, external_id, ledger_name, allowed_entry_type,
+     applies_to_cashflow, display_sequence, created_by, updated_by)
+SELECT DISTINCT mah.location_code, 'Static', mah.account_head_id, mah.account_head_name,
+       mah.allowed_entry_type, 'Y', seq.display_sequence, 'MIGRATION', 'MIGRATION'
+FROM m_account_heads mah
+INNER JOIN m_lookup ml
+        ON ml.lookup_type = 'CashFlow'
+       AND ml.location_code = mah.location_code
+       AND ml.description   = mah.account_head_name
+LEFT JOIN (
+    SELECT DISTINCT location_code, description, MIN(attribute1 + 0) AS display_sequence
+    FROM m_lookup WHERE lookup_type = 'CashFlow'
+    GROUP BY location_code, description
+) seq ON seq.location_code = mah.location_code AND seq.description = mah.account_head_name
+WHERE NOT EXISTS (
+    SELECT 1 FROM m_ledger_rules mlr
+    WHERE mlr.location_code = mah.location_code AND mlr.external_id = mah.account_head_id
+      AND mlr.source_type = 'Static' AND mlr.applies_to_cashflow = 'Y'
+);
+
+-- ── Verify ──────────────────────────────────────────────────────────────────
+SELECT COUNT(*) AS account_heads_created_this_pass FROM m_account_heads WHERE created_by = 'MIGRATION' AND creation_date >= NOW() - INTERVAL 5 MINUTE;
+
+SELECT
+  COUNT(*) AS total_lookup_rows,
+  SUM(mah.account_head_id IS NULL) AS still_missing_account_head,
+  SUM(mah.account_head_id IS NOT NULL AND mlr.rule_id IS NULL) AS still_missing_rule
+FROM m_lookup ml
+LEFT JOIN m_account_heads mah
+       ON mah.location_code = ml.location_code AND mah.account_head_name = ml.description
+LEFT JOIN m_ledger_rules mlr
+       ON mlr.location_code = ml.location_code AND mlr.external_id = mah.account_head_id
+      AND mlr.source_type = 'Static' AND mlr.applies_to_cashflow = 'Y'
+WHERE ml.lookup_type = 'CashFlow' AND ml.location_code IS NOT NULL;

--- a/db/migrations/cashflow-into-ledger-rules-backfill.sql
+++ b/db/migrations/cashflow-into-ledger-rules-backfill.sql
@@ -1,0 +1,75 @@
+-- ============================================================
+-- Fold cashflow types into m_ledger_rules — backfill + auto-populate
+-- Generated: 2026-08-16
+--
+-- generate_cashflow (the stored procedure behind calc_flag='Y' rows)
+-- inserts t_cashflow_transaction rows by raw string only — it has no idea
+-- ledger_rule_id exists. Rather than touch that procedure (long-standing,
+-- clearly load-bearing — note generate_cashflow_old sitting next to it),
+-- this trigger bridges string -> id after the fact for every insert,
+-- system-generated or manual alike.
+-- ============================================================
+
+-- ── Step 1: backfill existing rows ─────────────────────────────────────────
+
+UPDATE t_cashflow_transaction tct
+JOIN t_cashflow_closing tcc ON tcc.cashflow_id = tct.cashflow_id
+JOIN m_ledger_rules mlr ON mlr.location_code = tcc.location_code
+    AND mlr.ledger_name = tct.type AND mlr.source_type = 'Static'
+SET tct.ledger_rule_id = mlr.rule_id
+WHERE tct.ledger_rule_id IS NULL;
+
+-- ── Step 2: auto-populate on every future insert/update ────────────────────
+
+DROP TRIGGER IF EXISTS trg_cashflow_txn_ledger_rule_insert;
+DROP TRIGGER IF EXISTS trg_cashflow_txn_ledger_rule_update;
+
+DELIMITER $$
+
+CREATE TRIGGER trg_cashflow_txn_ledger_rule_insert
+BEFORE INSERT ON t_cashflow_transaction
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+    DECLARE v_rule_id INT;
+
+    IF NEW.ledger_rule_id IS NULL AND NEW.type IS NOT NULL THEN
+        SELECT location_code INTO v_location_code
+        FROM t_cashflow_closing WHERE cashflow_id = NEW.cashflow_id;
+
+        IF v_location_code IS NOT NULL THEN
+            SELECT rule_id INTO v_rule_id
+            FROM m_ledger_rules
+            WHERE location_code = v_location_code AND ledger_name = NEW.type AND source_type = 'Static'
+            LIMIT 1;
+            SET NEW.ledger_rule_id = v_rule_id;
+        END IF;
+    END IF;
+END$$
+
+CREATE TRIGGER trg_cashflow_txn_ledger_rule_update
+BEFORE UPDATE ON t_cashflow_transaction
+FOR EACH ROW
+BEGIN
+    DECLARE v_location_code VARCHAR(50);
+    DECLARE v_rule_id INT;
+
+    IF NOT (OLD.type <=> NEW.type) THEN
+        SELECT location_code INTO v_location_code
+        FROM t_cashflow_closing WHERE cashflow_id = NEW.cashflow_id;
+
+        IF v_location_code IS NOT NULL THEN
+            SELECT rule_id INTO v_rule_id
+            FROM m_ledger_rules
+            WHERE location_code = v_location_code AND ledger_name = NEW.type AND source_type = 'Static'
+            LIMIT 1;
+            SET NEW.ledger_rule_id = v_rule_id;
+        END IF;
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- ── Verify ──────────────────────────────────────────────────────────────────
+SELECT COUNT(*) AS total_rows, SUM(ledger_rule_id IS NOT NULL) AS backfilled
+FROM t_cashflow_transaction;

--- a/db/migrations/cashflow-into-ledger-rules-migrate-contra.sql
+++ b/db/migrations/cashflow-into-ledger-rules-migrate-contra.sql
@@ -1,0 +1,15 @@
+-- ============================================================
+-- Migrate existing gl_cashflow_ledger_map rows into gl_static_ledger_map
+-- as CONTRA entries — folds the cashflow-specific bank-contra table into
+-- the unified Static Ledger Map, same mechanism real bank contras use.
+-- Generated: 2026-08-16
+-- ============================================================
+
+INSERT INTO gl_static_ledger_map (location_code, ledger_name, treatment, bank_id, created_by, updated_by)
+SELECT location_code, cashflow_type, 'CONTRA', bank_id, 'MIGRATION', 'MIGRATION'
+FROM gl_cashflow_ledger_map
+WHERE bank_id IS NOT NULL
+ON DUPLICATE KEY UPDATE treatment = 'CONTRA', bank_id = VALUES(bank_id), updated_by = 'MIGRATION';
+
+-- ── Verify ──────────────────────────────────────────────────────────────────
+SELECT map_id, location_code, ledger_name, treatment, bank_id FROM gl_static_ledger_map WHERE treatment = 'CONTRA';

--- a/db/migrations/cashflow-into-ledger-rules-schema.sql
+++ b/db/migrations/cashflow-into-ledger-rules-schema.sql
@@ -1,0 +1,41 @@
+-- ============================================================
+-- Fold cashflow types into m_ledger_rules (Static Ledger)
+-- Generated: 2026-08-16
+--
+-- Cashflow types (m_lookup lookup_type='CashFlow') and bank/SOA Static
+-- labels (m_ledger_rules) were built independently, years apart, for two
+-- separate screens. Both are "a business owner names a category of money
+-- movement" — m_ledger_rules already has everything cashflow needs
+-- (allowed_entry_type as the credit/debit rule, effective dates for
+-- retiring a type, bank_id for the contra case). This migration makes
+-- m_ledger_rules the single source of truth going forward.
+--
+-- m_lookup(CashFlow) is NOT dropped — report DAOs (report-cashflow-dao.js,
+-- cashflow-detailed-dao.js) still read it for sort order today; those get
+-- migrated separately. This migration only adds the new structures and
+-- backfills them; nothing existing is removed.
+-- ============================================================
+
+-- ── Step 1: m_ledger_rules — new columns ───────────────────────────────────
+
+ALTER TABLE m_ledger_rules
+    ADD COLUMN usable_in_cashflow CHAR(1) NOT NULL DEFAULT 'N' COMMENT 'Y = selectable on the cashflow entry screen',
+    ADD COLUMN display_sequence   INT NULL COMMENT 'Sort order for display, replaces m_lookup.attribute1',
+    ADD COLUMN is_system_type     CHAR(1) NOT NULL DEFAULT 'N' COMMENT 'Y = seeded by generate_cashflow, cannot be deleted';
+
+-- ── Step 2: t_cashflow_transaction — new column ────────────────────────────
+-- No hard FK (matches this codebase's existing convention on gl_ledgers,
+-- gl_product_ledger_map etc.) — resolved by application code / triggers.
+
+ALTER TABLE t_cashflow_transaction
+    ADD COLUMN ledger_rule_id INT NULL COMMENT 'FK to m_ledger_rules.rule_id — replaces matching type by name';
+
+-- ── Step 3: gl_static_ledger_map — CONTRA support ──────────────────────────
+-- Generalizes the table beyond POST/SKIP so a Static label (cashflow-
+-- sourced or bank-sourced) can represent "the counterpart is a specific
+-- bank account" — the same mechanism gl_cashflow_ledger_map used only for
+-- cashflow. Existing POST/SKIP rows are unaffected by this ALTER.
+
+ALTER TABLE gl_static_ledger_map
+    MODIFY COLUMN treatment ENUM('POST', 'SKIP', 'CONTRA') NULL,
+    ADD COLUMN bank_id INT NULL COMMENT 'Required when treatment=CONTRA — resolves via gl_ledgers.source_type=BANK/source_id=bank_id, same as real bank contras';

--- a/db/migrations/cashflow-into-ledger-rules-seed.sql
+++ b/db/migrations/cashflow-into-ledger-rules-seed.sql
@@ -1,0 +1,91 @@
+-- ============================================================
+-- Fold cashflow types into m_ledger_rules — seed data
+-- Generated: 2026-08-16
+--
+-- Note: m_ledger_rules has no real uniqueness on (location_code,
+-- ledger_name) for source_type='Static' rows today — its declared unique
+-- key is (location_code, bank_id, source_type, external_id), and Static
+-- rows have NULL bank_id/external_id, which MySQL does not treat as
+-- colliding. So this migration guards duplicates itself (NOT EXISTS) —
+-- safe to re-run.
+-- ============================================================
+
+-- ── Step 1: existing Static rules that already share a name with a
+--    real cashflow type — just mark them usable in cashflow ────────────────
+
+UPDATE m_ledger_rules mlr
+JOIN (
+    SELECT DISTINCT ml.location_code, ml.description,
+           MIN(ml.attribute1 + 0) AS seq,
+           CASE ml.tag WHEN 'IN' THEN 'CREDIT' WHEN 'OUT' THEN 'DEBIT' END AS entry_type
+    FROM m_lookup ml
+    WHERE ml.lookup_type = 'CashFlow'
+      AND EXISTS (SELECT 1 FROM t_cashflow_transaction tct WHERE tct.type = ml.description)
+    GROUP BY ml.location_code, ml.description, ml.tag
+) cf ON cf.location_code = mlr.location_code AND cf.description = mlr.ledger_name
+SET mlr.usable_in_cashflow = 'Y',
+    mlr.display_sequence   = COALESCE(mlr.display_sequence, cf.seq),
+    mlr.is_system_type     = CASE WHEN mlr.ledger_name IN
+        ('Balance B/F','Collection','2T Oil','Discount','Cashier A/C (+)','Cashier A/C (-)','Cash Receipt','Expense','Salary Payout','Salary Recovery')
+        THEN 'Y' ELSE mlr.is_system_type END,
+    mlr.updated_by = 'MIGRATION'
+WHERE mlr.source_type = 'Static';
+
+-- ── Step 2: everything else — create a new Static rule ─────────────────────
+
+INSERT INTO m_ledger_rules
+    (location_code, source_type, ledger_name, allowed_entry_type, usable_in_cashflow,
+     display_sequence, is_system_type, created_by, updated_by)
+SELECT cf.location_code, 'Static', cf.description, cf.entry_type, 'Y',
+       cf.seq,
+       CASE WHEN cf.description IN
+           ('Balance B/F','Collection','2T Oil','Discount','Cashier A/C (+)','Cashier A/C (-)','Cash Receipt','Expense','Salary Payout','Salary Recovery')
+           THEN 'Y' ELSE 'N' END,
+       'MIGRATION', 'MIGRATION'
+FROM (
+    SELECT DISTINCT ml.location_code, ml.description,
+           MIN(ml.attribute1 + 0) AS seq,
+           CASE ml.tag WHEN 'IN' THEN 'CREDIT' WHEN 'OUT' THEN 'DEBIT' END AS entry_type
+    FROM m_lookup ml
+    WHERE ml.lookup_type = 'CashFlow'
+      AND EXISTS (SELECT 1 FROM t_cashflow_transaction tct WHERE tct.type = ml.description)
+    GROUP BY ml.location_code, ml.description, ml.tag
+) cf
+WHERE NOT EXISTS (
+    SELECT 1 FROM m_ledger_rules mlr
+    WHERE mlr.location_code = cf.location_code AND mlr.ledger_name = cf.description AND mlr.source_type = 'Static'
+);
+
+-- ── Step 3: guarantee the 9 system-generated types exist for EVERY
+--    GL-enabled location, even ones that haven't triggered one yet —
+--    generate_cashflow can produce any of these for any location the
+--    moment a shift closes there. Tag is 100% consistent across every
+--    location that has used each type (verified against real data before
+--    writing this), so a single confirmed mapping is safe to apply broadly. ─
+
+INSERT INTO m_ledger_rules
+    (location_code, source_type, ledger_name, allowed_entry_type, usable_in_cashflow, is_system_type, created_by, updated_by)
+SELECT loc.location_code, 'Static', t.name, t.entry_type, 'Y', 'Y', 'MIGRATION', 'MIGRATION'
+FROM (SELECT DISTINCT location_code FROM gl_ledgers) loc
+CROSS JOIN (
+    SELECT 'Balance B/F' name, 'CREDIT' entry_type
+    UNION ALL SELECT 'Collection', 'CREDIT'
+    UNION ALL SELECT '2T Oil', 'CREDIT'
+    UNION ALL SELECT 'Discount', 'DEBIT'
+    UNION ALL SELECT 'Cashier A/C (+)', 'CREDIT'
+    UNION ALL SELECT 'Cashier A/C (-)', 'DEBIT'
+    UNION ALL SELECT 'Cash Receipt', 'CREDIT'
+    UNION ALL SELECT 'Expense', 'DEBIT'
+    UNION ALL SELECT 'Salary Payout', 'DEBIT'
+    UNION ALL SELECT 'Salary Recovery', 'CREDIT'
+) t
+WHERE NOT EXISTS (
+    SELECT 1 FROM m_ledger_rules mlr
+    WHERE mlr.location_code = loc.location_code AND mlr.ledger_name = t.name AND mlr.source_type = 'Static'
+);
+
+-- ── Verify ──────────────────────────────────────────────────────────────────
+SELECT COUNT(*) AS total_cashflow_usable_rules FROM m_ledger_rules WHERE usable_in_cashflow = 'Y';
+SELECT COUNT(*) AS total_system_type_rows FROM m_ledger_rules WHERE is_system_type = 'Y';
+SELECT ledger_name, COUNT(DISTINCT location_code) AS loc_count
+FROM m_ledger_rules WHERE is_system_type = 'Y' GROUP BY ledger_name ORDER BY ledger_name;

--- a/db/migrations/gl-correction-queue-trigger-fix.sql
+++ b/db/migrations/gl-correction-queue-trigger-fix.sql
@@ -1,0 +1,88 @@
+-- ============================================================
+-- Fix trg_static_ledger_map_gl_update: two bugs found while investigating
+-- why SFS's cashflow/bank vouchers weren't showing up correctly on the P&L
+-- Generated: 2026-08-18 (documents a fix already applied live on beta)
+--
+-- Bug 1: `IF OLD.treatment IS NOT NULL` skipped queuing a correction
+-- whenever a label's FIRST-EVER review happened after vouchers were already
+-- posted using the unreviewed fallback (Unclassified Bank Transaction /
+-- Unclassified Cashflow). That's exactly the case that needs catching —
+-- vouchers post using the fallback long before anyone reviews the label.
+--
+-- Bug 2: the trigger only ever matched BANK_TXN events (joins to
+-- t_bank_transaction) — no branch for CASHFLOW_TXN at all, since it
+-- predated this session's cashflow/Account Heads work.
+--
+-- Both fixed below. This does NOT retroactively catch vouchers that were
+-- already missed before this fix (see
+-- cashflow-account-heads-correction-backfill.sql and the manual backfill
+-- run for SFS this session for that).
+-- ============================================================
+
+DROP TRIGGER IF EXISTS trg_static_ledger_map_gl_update;
+
+DELIMITER $$
+
+CREATE TRIGGER trg_static_ledger_map_gl_update
+AFTER UPDATE ON gl_static_ledger_map
+FOR EACH ROW
+BEGIN
+    DECLARE v_old_ledger_name VARCHAR(250);
+    DECLARE v_new_ledger_name VARCHAR(250);
+    DECLARE v_old_desc VARCHAR(255);
+    DECLARE v_new_desc VARCHAR(255);
+
+    IF NOT (OLD.treatment <=> NEW.treatment)
+       OR NOT (OLD.gl_ledger_id <=> NEW.gl_ledger_id)
+       OR NOT (OLD.skip_reason <=> NEW.skip_reason)
+    THEN
+        IF OLD.treatment = 'SKIP' THEN
+            SET v_old_desc = CONCAT('Skip: ', COALESCE(OLD.skip_reason, ''));
+        ELSEIF OLD.treatment = 'POST' THEN
+            SELECT ledger_name INTO v_old_ledger_name FROM gl_ledgers WHERE ledger_id = OLD.gl_ledger_id;
+            SET v_old_desc = CONCAT('Post to: ', COALESCE(v_old_ledger_name, CONCAT('(deleted ledger #', OLD.gl_ledger_id, ')')));
+        ELSE
+            SET v_old_desc = 'Unreviewed';
+        END IF;
+
+        IF NEW.treatment = 'SKIP' THEN
+            SET v_new_desc = CONCAT('Skip: ', COALESCE(NEW.skip_reason, ''));
+        ELSEIF NEW.treatment = 'POST' THEN
+            SELECT ledger_name INTO v_new_ledger_name FROM gl_ledgers WHERE ledger_id = NEW.gl_ledger_id;
+            SET v_new_desc = CONCAT('Post to: ', COALESCE(v_new_ledger_name, CONCAT('(deleted ledger #', NEW.gl_ledger_id, ')')));
+        ELSE
+            SET v_new_desc = 'Unreviewed';
+        END IF;
+
+        INSERT INTO gl_correction_queue
+            (location_code, mapping_source, mapping_key, old_description, new_description,
+             source_type, source_id, voucher_id, fy_id, status, created_by)
+        SELECT mb.location_code, 'STATIC_LEDGER_MAP', NEW.ledger_name, v_old_desc, v_new_desc,
+               ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', NEW.updated_by
+        FROM gl_accounting_events ge
+        JOIN t_bank_transaction tbt ON tbt.t_bank_id = ge.source_id AND ge.source_type = 'BANK_TXN'
+        JOIN m_bank mb ON mb.bank_id = tbt.bank_id
+        WHERE ge.event_status = 'PROCESSED' AND mb.location_code = NEW.location_code AND tbt.ledger_name = NEW.ledger_name
+
+        UNION
+
+        SELECT mb.location_code, 'STATIC_LEDGER_MAP', NEW.ledger_name, v_old_desc, v_new_desc,
+               ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', NEW.updated_by
+        FROM gl_accounting_events ge
+        JOIN t_bank_transaction tbt ON tbt.t_bank_id = ge.source_id AND ge.source_type = 'BANK_TXN'
+        JOIN m_bank mb ON mb.bank_id = tbt.bank_id
+        JOIN t_bank_transaction_splits tbs ON tbs.t_bank_id = tbt.t_bank_id
+        WHERE ge.event_status = 'PROCESSED' AND mb.location_code = NEW.location_code AND tbs.ledger_name = NEW.ledger_name
+
+        UNION
+
+        SELECT tcc.location_code, 'STATIC_LEDGER_MAP', NEW.ledger_name, v_old_desc, v_new_desc,
+               ge.source_type, ge.source_id, ge.voucher_id, ge.fy_id, 'PENDING', NEW.updated_by
+        FROM gl_accounting_events ge
+        JOIN t_cashflow_transaction tct ON tct.transaction_id = ge.source_id AND ge.source_type = 'CASHFLOW_TXN'
+        JOIN t_cashflow_closing tcc ON tcc.cashflow_id = tct.cashflow_id
+        WHERE ge.event_status = 'PROCESSED' AND tcc.location_code = NEW.location_code AND tct.type = NEW.ledger_name;
+    END IF;
+END$$
+
+DELIMITER ;

--- a/db/migrations/gl-stock-opening-balance.sql
+++ b/db/migrations/gl-stock-opening-balance.sql
@@ -1,0 +1,35 @@
+-- ============================================================
+-- Stock-adjusted COGS: FY opening balance seed table
+-- Generated: 2026-08-18
+--
+-- Holds the ONE persisted number this feature needs per (location, product,
+-- financial year): the opening stock quantity + value at FY start. Everything
+-- else (COGS for any date range inside the FY, closing balance at any point)
+-- is computed on the fly by services/stock-valuation-service.js, replaying
+-- purchases and sales chronologically from this opening balance forward.
+--
+-- source='SEED' = manually estimated because no prior-FY closing balance
+-- exists yet (first year a location's stock is tracked this way).
+-- source='FY_CLOSE' = will be written once, permanently, when a FY is
+-- closed — the computed closing balance becomes the next FY's opening row.
+-- Until a FY is closed, nothing here changes; mid-FY, everything replays
+-- on the fly from this starting point.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS gl_stock_opening_balance (
+    id              INT NOT NULL AUTO_INCREMENT,
+    location_code   VARCHAR(50) NOT NULL,
+    product_id      INT NOT NULL,
+    fy_id           INT NOT NULL,
+    opening_qty     DECIMAL(15,3) NOT NULL,
+    opening_value   DECIMAL(15,2) NOT NULL,
+    source          ENUM('SEED', 'FY_CLOSE') NOT NULL DEFAULT 'SEED',
+    notes           VARCHAR(255) DEFAULT NULL,
+    created_by      VARCHAR(45) DEFAULT NULL,
+    creation_date   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_stock_opening (location_code, product_id, fy_id),
+    KEY fk_stock_opening_product (product_id),
+    CONSTRAINT fk_stock_opening_fy FOREIGN KEY (fy_id) REFERENCES gl_financial_years (fy_id),
+    CONSTRAINT fk_stock_opening_product FOREIGN KEY (product_id) REFERENCES m_product (product_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/db/txn-cashflow.js
+++ b/db/txn-cashflow.js
@@ -21,6 +21,11 @@ module.exports = function(sequelize, DataTypes) {
             field: 'type',
             type: DataTypes.STRING
         },
+        account_head_id: {
+            field: 'account_head_id',
+            type: DataTypes.INTEGER,
+            allowNull: true
+        },
         amount: {
             field: 'amount',
             type: DataTypes.DECIMAL

--- a/public/javascripts/app-master-page-scripts.js
+++ b/public/javascripts/app-master-page-scripts.js
@@ -302,6 +302,7 @@ function formCashFlowTxn(txnId, prefix, rowNum, user) {
         'cashflowId': document.getElementById('cashflowId_hiddenId').value,
         'description': document.getElementById(prefix + 'remarks-' + rowNum).value,
         'type': typeObj.options[typeObj.selectedIndex].text,
+        'account_head_id': typeObj.value,
         'amount': document.getElementById(prefix + 'amt-' + rowNum).value,
         'calcFlag': 'N',
         'created_by': user.User_Name,

--- a/routes/gl-routes.js
+++ b/routes/gl-routes.js
@@ -7,6 +7,7 @@ const security = require('../utils/app-security');
 const db = require('../db/db-connection');
 const createAccountingService = require('../services/create-accounting-service');
 const glBatchService = require('../services/gl-batch-service');
+const stockValuationService = require('../services/stock-valuation-service');
 
 // GET /gl/api/ledgers/search?location=&group=&q=
 // Returns [{ledger_id, ledger_name}] — used by Select2 ajax typeahead on product ledger fields
@@ -463,6 +464,60 @@ router.get('/profit-loss', [isLoginEnsured, security.isAdmin()], async function(
                 g.rows.push({ ledger_id: row.ledger_id, ledger_name: row.ledger_name, amount: net });
                 g.subtotal    += net;
                 totalExpenses += net;
+            }
+        }
+
+        // Stock-adjusted COGS — only for products with a gl_stock_opening_balance
+        // seed for the FY covering fromDate. Never changes the per-ledger figures
+        // above (those still match the trial balance); adds one visible
+        // adjustment line per group instead, so the swap from raw invoiced
+        // purchases to actual COGS (opening + purchases - closing) is auditable,
+        // not a silent number change. See services/stock-valuation-service.js.
+        const [fy] = await db.sequelize.query(`
+            SELECT fy_id FROM gl_financial_years
+            WHERE location_code = :locationCode AND :fromDate BETWEEN start_date AND end_date
+            LIMIT 1
+        `, { replacements: { locationCode, fromDate }, type: db.Sequelize.QueryTypes.SELECT });
+
+        if (fy) {
+            const stockResults = await stockValuationService.computeStockCOGS(locationCode, fy.fy_id, fromDate, toDate);
+
+            if (stockResults.length) {
+                const productLedgers = await db.sequelize.query(`
+                    SELECT product_id, ledger_id FROM gl_product_ledger_map
+                    WHERE location_code = :locationCode AND map_type = 'PURCHASE'
+                `, { replacements: { locationCode }, type: db.Sequelize.QueryTypes.SELECT });
+                const ledgerByProduct = new Map(productLedgers.map(r => [r.product_id, r.ledger_id]));
+
+                // Multiple products can share one purchase ledger (e.g. MS and
+                // HSD both post to "PURCHASE DIESEL EBMS" for SFS) — aggregate
+                // computed COGS by ledger before comparing against that
+                // ledger's raw total, or a shared ledger gets compared against
+                // itself twice and produces nonsense.
+                const stockCogsByLedger = new Map();
+                for (const r of stockResults) {
+                    const ledgerId = ledgerByProduct.get(r.productId);
+                    if (!ledgerId) continue;
+                    stockCogsByLedger.set(ledgerId, (stockCogsByLedger.get(ledgerId) || 0) + r.cogs);
+                }
+
+                let totalAdjustment = 0;
+                for (const [ledgerId, cogs] of stockCogsByLedger) {
+                    const rawRow = rows.find(row => row.ledger_id === ledgerId);
+                    const rawAmount = rawRow ? (parseFloat(rawRow.total_dr) - parseFloat(rawRow.total_cr)) : 0;
+                    totalAdjustment += (cogs - rawAmount);
+                }
+
+                if (Math.abs(totalAdjustment) > 0.01 && expenseGroupMap.has('Purchase Accounts')) {
+                    const g = expenseGroupMap.get('Purchase Accounts');
+                    g.rows.push({
+                        ledger_id: null,
+                        ledger_name: 'Stock Adjustment (Opening + Purchases − Closing vs. Invoiced)',
+                        amount: totalAdjustment
+                    });
+                    g.subtotal    += totalAdjustment;
+                    totalExpenses += totalAdjustment;
+                }
             }
         }
 

--- a/services/create-accounting-service.js
+++ b/services/create-accounting-service.js
@@ -12,11 +12,11 @@
 //   LUBES_INVOICE       (source_id = lubes_hdr_id)     — Purchase DR + Input CGST/SGST DR / Supplier CR
 //   TANK_INVOICE        (source_id = t_tank_invoice.id)— Purchase DR + Charges DR / Supplier CR
 //   CASHFLOW_TXN        (source_id = transaction_id)   — calc_flag='N' cashflow-close lines only.
-//                                                         Ledger resolved by (in order): explicit
-//                                                         gl_cashflow_ledger_map row, exact ledger-name
-//                                                         match on the cashflow type, else falls back to
-//                                                         the per-location "Unclassified Cashflow" ledger
-//                                                         (never blocks processing — see resolveCashflowLedger).
+//                                                         Direction + ledger resolution both come from
+//                                                         ledger_rule_id -> m_ledger_rules (shared with
+//                                                         BANK_TXN's Static labels — see resolveStaticLedger).
+//                                                         Never blocks processing; unmapped labels fall
+//                                                         back to "Unclassified Cashflow".
 //   ADJUSTMENT          (source_id = adjustment_id)    — customer/vendor/bank corrections + opening
 //                                                         balances (adjustment_type=201 → "Opening Balance
 //                                                         Equity", off the P&L; other types resolve by
@@ -1206,16 +1206,20 @@ async function processTankInvoiceEvent(event, processedBy) {
 
 // ─── CASHFLOW_TXN Handler ─────────────────────────────────────────────────────
 // Only calc_flag='N' rows reach this handler (calc_flag='Y' rows never raise an
-// event — see trg_cashflow_txn_gl_insert). tag='OUT' → cash left the drawer
-// (DR resolved ledger / CR Cash-in-Hand). tag='IN' → cash came in (reverse).
-// See resolveCashflowLedger for how the counterpart ledger is resolved.
+// event — see trg_cashflow_txn_gl_insert). Direction and ledger resolution both
+// come from t_cashflow_transaction.ledger_rule_id -> m_ledger_rules — the same
+// Static Ledger label system BANK_TXN uses (see resolveStaticLedger), not a
+// separate cashflow-only mapping. tag='OUT' → cash left the drawer (DR resolved
+// ledger / CR Cash-in-Hand). tag='IN' → cash came in (reverse).
 
 async function processCashflowTxnEvent(event, processedBy) {
     const { location_code, fy_id, source_id: transactionId, event_date } = event;
 
     const rows = await db.sequelize.query(`
-        SELECT tct.transaction_id, tct.type, tct.description, tct.amount, tct.calc_flag
+        SELECT tct.transaction_id, tct.type, tct.description, tct.amount, tct.calc_flag,
+               mlr.ledger_name AS rule_ledger_name, mlr.allowed_entry_type
         FROM t_cashflow_transaction tct
+        LEFT JOIN m_ledger_rules mlr ON mlr.rule_id = tct.ledger_rule_id
         WHERE tct.transaction_id = :transactionId
     `, { replacements: { transactionId }, type: QueryTypes.SELECT });
 
@@ -1234,22 +1238,43 @@ async function processCashflowTxnEvent(event, processedBy) {
         return { voucherCount: 0 };
     }
 
-    const tagRows = await db.sequelize.query(`
-        SELECT tag FROM m_lookup
-        WHERE lookup_type = 'CashFlow' AND description = :type
-          AND (location_code = :locationCode OR location_code IS NULL)
-        ORDER BY (location_code = :locationCode) DESC
-        LIMIT 1
-    `, { replacements: { type: row.type, locationCode: location_code }, type: QueryTypes.SELECT });
-
-    if (!tagRows.length) throw new Error(`Cashflow type '${row.type}' has no matching m_lookup CashFlow entry — cannot determine IN/OUT direction`);
-    const tag = tagRows[0].tag;
-    if (tag !== 'IN' && tag !== 'OUT') throw new Error(`Cashflow type '${row.type}' has an unexpected tag '${tag}' (expected IN/OUT)`);
+    let tag;
+    if (row.allowed_entry_type === 'CREDIT') {
+        tag = 'IN';
+    } else if (row.allowed_entry_type === 'DEBIT') {
+        tag = 'OUT';
+    } else if (row.allowed_entry_type === 'BOTH') {
+        // No per-entry Cr/Dr column exists yet on t_cashflow_transaction — a
+        // BOTH-direction rule can't be resolved automatically. Not hit by any
+        // real data today (verified: every CashFlow type in use is strictly
+        // IN or OUT), so this is a deliberate stop, not a silent guess.
+        throw new Error(`Cashflow type '${row.type}' is mapped to ledger rule '${row.rule_ledger_name}' with allowed_entry_type=BOTH — direction can't be inferred per-entry. Split into separate CREDIT/DEBIT rules, or add an entry-level direction column.`);
+    } else {
+        // Legacy fallback — row predates the ledger_rule_id backfill/trigger
+        // (shouldn't happen post-migration; kept as a safety net).
+        const tagRows = await db.sequelize.query(`
+            SELECT tag FROM m_lookup
+            WHERE lookup_type = 'CashFlow' AND description = :type
+              AND (location_code = :locationCode OR location_code IS NULL)
+            ORDER BY (location_code = :locationCode) DESC
+            LIMIT 1
+        `, { replacements: { type: row.type, locationCode: location_code }, type: QueryTypes.SELECT });
+        if (!tagRows.length) throw new Error(`Cashflow type '${row.type}' has no ledger rule and no legacy m_lookup CashFlow entry — cannot determine direction`);
+        tag = tagRows[0].tag;
+        if (tag !== 'IN' && tag !== 'OUT') throw new Error(`Cashflow type '${row.type}' has an unexpected legacy tag '${tag}' (expected IN/OUT)`);
+    }
 
     const cashLedgerId = await resolveCashLedger(location_code);
     if (!cashLedgerId) throw new Error(`Cash-in-Hand ledger not found for location ${location_code}`);
 
-    const { ledgerId: counterLedgerId, isContra } = await resolveCashflowLedger(location_code, row.type, processedBy);
+    const staticLedgerName = row.rule_ledger_name || row.type;
+    const { treatment, ledgerId: counterLedgerId, isContra } =
+        await resolveStaticLedger(location_code, staticLedgerName, true, 'Unclassified Cashflow');
+
+    if (treatment === 'SKIP') {
+        await markEventProcessed(event.event_id, null, processedBy);
+        return { voucherCount: 0 };
+    }
 
     const narration = `${row.type}${row.description ? ' | ' + row.description : ''} | ₹${amount.toFixed(2)} | ${event_date}`;
     const voucherType = isContra ? 'CONTRA' : 'JOURNAL';
@@ -1274,36 +1299,6 @@ async function processCashflowTxnEvent(event, processedBy) {
 
     await markEventProcessed(event.event_id, vid, processedBy);
     return { voucherCount: 1 };
-}
-
-// Resolves the counterpart ledger for a calc_flag='N' cashflow type, in order:
-//   1. gl_cashflow_ledger_map.bank_id  → that bank's own GL ledger (contra — deposit/withdrawal)
-//   2. gl_cashflow_ledger_map.ledger_id → explicit override
-//   3. exact ledger-name match on the cashflow type text (same convention as TANK_INVOICE charge_type)
-//   4. per-location "Unclassified Cashflow" ledger — never blocks processing; reprocess later once mapped
-async function resolveCashflowLedger(locationCode, cashflowType, processedBy) {
-    const mapRows = await db.sequelize.query(`
-        SELECT ledger_id, bank_id FROM gl_cashflow_ledger_map
-        WHERE location_code = :locationCode AND cashflow_type = :cashflowType
-        LIMIT 1
-    `, { replacements: { locationCode, cashflowType }, type: QueryTypes.SELECT });
-
-    if (mapRows.length && mapRows[0].bank_id) {
-        const ledgerId = await resolveLedger(locationCode, 'BANK', mapRows[0].bank_id);
-        if (!ledgerId) throw new Error(`gl_cashflow_ledger_map for '${cashflowType}' points at bank_id=${mapRows[0].bank_id}, but that bank has no GL ledger`);
-        return { ledgerId, isContra: true };
-    }
-
-    if (mapRows.length && mapRows[0].ledger_id) {
-        return { ledgerId: mapRows[0].ledger_id, isContra: false };
-    }
-
-    const byName = await resolveLedgerByName(locationCode, cashflowType);
-    if (byName) return { ledgerId: byName.ledger_id, isContra: false };
-
-    const fallback = await resolveLedgerByName(locationCode, 'Unclassified Cashflow');
-    if (!fallback) throw new Error(`No 'Unclassified Cashflow' ledger set up for location ${locationCode} — run db/migrations/gl-cashflow-adjustments-triggers.sql`);
-    return { ledgerId: fallback.ledger_id, isContra: false };
 }
 
 // ─── ADJUSTMENT Handler ───────────────────────────────────────────────────────
@@ -1727,9 +1722,9 @@ async function resolveLedgerByName(locationCode, ledgerName) {
 // allowSkip=false (used for split legs) treats a SKIP-mapped label as
 // Unclassified instead, since one leg of a split can't be silently dropped
 // without unbalancing the voucher.
-async function resolveStaticLedger(locationCode, ledgerName, allowSkip = true) {
+async function resolveStaticLedger(locationCode, ledgerName, allowSkip = true, fallbackLedgerName = 'Unclassified Bank Transaction') {
     const rows = await db.sequelize.query(`
-        SELECT treatment, gl_ledger_id FROM gl_static_ledger_map
+        SELECT treatment, gl_ledger_id, bank_id FROM gl_static_ledger_map
         WHERE location_code = :locationCode AND ledger_name = :ledgerName
         LIMIT 1
     `, { replacements: { locationCode, ledgerName }, type: QueryTypes.SELECT });
@@ -1746,12 +1741,19 @@ async function resolveStaticLedger(locationCode, ledgerName, allowSkip = true) {
         `, { replacements: { locationCode, ledgerName }, type: QueryTypes.INSERT });
         mapped = null;
     }
-    if (allowSkip && mapped?.treatment === 'SKIP') return { treatment: 'SKIP', ledgerId: null };
-    if (mapped?.treatment === 'POST' && mapped.gl_ledger_id) return { treatment: 'POST', ledgerId: mapped.gl_ledger_id };
+    if (allowSkip && mapped?.treatment === 'SKIP') return { treatment: 'SKIP', ledgerId: null, isContra: false };
 
-    const fallback = await resolveLedgerByName(locationCode, 'Unclassified Bank Transaction');
-    if (!fallback) throw new Error(`No 'Unclassified Bank Transaction' ledger set up for location ${locationCode} — run db/migrations/gl-static-ledger-map.sql`);
-    return { treatment: 'POST', ledgerId: fallback.ledger_id };
+    if (mapped?.treatment === 'CONTRA' && mapped.bank_id) {
+        const ledgerId = await resolveLedger(locationCode, 'BANK', mapped.bank_id);
+        if (!ledgerId) throw new Error(`gl_static_ledger_map for '${ledgerName}' points at bank_id=${mapped.bank_id}, but that bank has no GL ledger`);
+        return { treatment: 'CONTRA', ledgerId, isContra: true };
+    }
+
+    if (mapped?.treatment === 'POST' && mapped.gl_ledger_id) return { treatment: 'POST', ledgerId: mapped.gl_ledger_id, isContra: false };
+
+    const fallback = await resolveLedgerByName(locationCode, fallbackLedgerName);
+    if (!fallback) throw new Error(`No '${fallbackLedgerName}' ledger set up for location ${locationCode} — run db/migrations/gl-static-ledger-map.sql`);
+    return { treatment: 'POST', ledgerId: fallback.ledger_id, isContra: false };
 }
 
 async function resolveCashLedger(locationCode) {

--- a/services/create-accounting-service.js
+++ b/services/create-accounting-service.js
@@ -12,11 +12,11 @@
 //   LUBES_INVOICE       (source_id = lubes_hdr_id)     — Purchase DR + Input CGST/SGST DR / Supplier CR
 //   TANK_INVOICE        (source_id = t_tank_invoice.id)— Purchase DR + Charges DR / Supplier CR
 //   CASHFLOW_TXN        (source_id = transaction_id)   — calc_flag='N' cashflow-close lines only.
-//                                                         Direction + ledger resolution both come from
-//                                                         ledger_rule_id -> m_ledger_rules (shared with
-//                                                         BANK_TXN's Static labels — see resolveStaticLedger).
-//                                                         Never blocks processing; unmapped labels fall
-//                                                         back to "Unclassified Cashflow".
+//                                                         Direction comes from entry_type on the row itself;
+//                                                         ledger resolution goes through the linked Account
+//                                                         Head's name -> resolveStaticLedger (shared with
+//                                                         BANK_TXN's Static labels). Never blocks processing;
+//                                                         unmapped labels fall back to "Unclassified Cashflow".
 //   ADJUSTMENT          (source_id = adjustment_id)    — customer/vendor/bank corrections + opening
 //                                                         balances (adjustment_type=201 → "Opening Balance
 //                                                         Equity", off the P&L; other types resolve by
@@ -1206,20 +1206,22 @@ async function processTankInvoiceEvent(event, processedBy) {
 
 // ─── CASHFLOW_TXN Handler ─────────────────────────────────────────────────────
 // Only calc_flag='N' rows reach this handler (calc_flag='Y' rows never raise an
-// event — see trg_cashflow_txn_gl_insert). Direction and ledger resolution both
-// come from t_cashflow_transaction.ledger_rule_id -> m_ledger_rules — the same
-// Static Ledger label system BANK_TXN uses (see resolveStaticLedger), not a
-// separate cashflow-only mapping. tag='OUT' → cash left the drawer (DR resolved
-// ledger / CR Cash-in-Hand). tag='IN' → cash came in (reverse).
+// event — see trg_cashflow_txn_gl_insert). Direction comes straight off
+// t_cashflow_transaction.entry_type (resolved before processing time by the
+// account-head trigger, or by the entry UI once that ships). Ledger resolution
+// goes through the Account Head's name -> resolveStaticLedger -> gl_static_ledger_map,
+// same as BANK_TXN. The engine never joins m_ledger_rules or m_account_heads for
+// direction — allowed_entry_type there is a data-entry-time constraint, not a
+// per-row fact.
 
 async function processCashflowTxnEvent(event, processedBy) {
     const { location_code, fy_id, source_id: transactionId, event_date } = event;
 
     const rows = await db.sequelize.query(`
         SELECT tct.transaction_id, tct.type, tct.description, tct.amount, tct.calc_flag,
-               mlr.ledger_name AS rule_ledger_name, mlr.allowed_entry_type
+               tct.entry_type, mah.account_head_name
         FROM t_cashflow_transaction tct
-        LEFT JOIN m_ledger_rules mlr ON mlr.rule_id = tct.ledger_rule_id
+        LEFT JOIN m_account_heads mah ON mah.account_head_id = tct.account_head_id
         WHERE tct.transaction_id = :transactionId
     `, { replacements: { transactionId }, type: QueryTypes.SELECT });
 
@@ -1238,36 +1240,15 @@ async function processCashflowTxnEvent(event, processedBy) {
         return { voucherCount: 0 };
     }
 
-    let tag;
-    if (row.allowed_entry_type === 'CREDIT') {
-        tag = 'IN';
-    } else if (row.allowed_entry_type === 'DEBIT') {
-        tag = 'OUT';
-    } else if (row.allowed_entry_type === 'BOTH') {
-        // No per-entry Cr/Dr column exists yet on t_cashflow_transaction — a
-        // BOTH-direction rule can't be resolved automatically. Not hit by any
-        // real data today (verified: every CashFlow type in use is strictly
-        // IN or OUT), so this is a deliberate stop, not a silent guess.
-        throw new Error(`Cashflow type '${row.type}' is mapped to ledger rule '${row.rule_ledger_name}' with allowed_entry_type=BOTH — direction can't be inferred per-entry. Split into separate CREDIT/DEBIT rules, or add an entry-level direction column.`);
-    } else {
-        // Legacy fallback — row predates the ledger_rule_id backfill/trigger
-        // (shouldn't happen post-migration; kept as a safety net).
-        const tagRows = await db.sequelize.query(`
-            SELECT tag FROM m_lookup
-            WHERE lookup_type = 'CashFlow' AND description = :type
-              AND (location_code = :locationCode OR location_code IS NULL)
-            ORDER BY (location_code = :locationCode) DESC
-            LIMIT 1
-        `, { replacements: { type: row.type, locationCode: location_code }, type: QueryTypes.SELECT });
-        if (!tagRows.length) throw new Error(`Cashflow type '${row.type}' has no ledger rule and no legacy m_lookup CashFlow entry — cannot determine direction`);
-        tag = tagRows[0].tag;
-        if (tag !== 'IN' && tag !== 'OUT') throw new Error(`Cashflow type '${row.type}' has an unexpected legacy tag '${tag}' (expected IN/OUT)`);
+    if (row.entry_type !== 'CREDIT' && row.entry_type !== 'DEBIT') {
+        throw new Error(`Cashflow transaction ${transactionId} (type '${row.type}') has no entry_type set — cannot determine direction`);
     }
+    const tag = row.entry_type === 'CREDIT' ? 'IN' : 'OUT';
 
     const cashLedgerId = await resolveCashLedger(location_code);
     if (!cashLedgerId) throw new Error(`Cash-in-Hand ledger not found for location ${location_code}`);
 
-    const staticLedgerName = row.rule_ledger_name || row.type;
+    const staticLedgerName = row.account_head_name || row.type;
     const { treatment, ledgerId: counterLedgerId, isContra } =
         await resolveStaticLedger(location_code, staticLedgerName, true, 'Unclassified Cashflow');
 

--- a/services/stock-valuation-service.js
+++ b/services/stock-valuation-service.js
@@ -165,10 +165,19 @@ async function computeProductStockCOGS(locationCode, fyId, productId, fromDate, 
         runningValue += purchaseValue;
 
         let cogsToday = 0;
-        if (qtySold > 0) {
-            const avgCost = runningQty > 0 ? runningValue / runningQty : 0;
-            cogsToday     = qtySold * avgCost;
-            runningQty   -= qtySold;
+        if (qtySold > 0 && runningQty > 0) {
+            const avgCost   = runningValue / runningQty;
+            // Clamp at what's actually tracked — a partial/in-progress month
+            // where sales have been recorded faster than purchases were
+            // entered (e.g. this month's invoices not in yet) must never
+            // drive the balance negative: that corrupts every average-cost
+            // calculation from that point forward. The uncovered portion is
+            // left unrecognized (zero-cost) rather than invented — it gets
+            // picked up correctly once the missing purchase is entered and
+            // this is recomputed.
+            const qtyCovered = Math.min(qtySold, runningQty);
+            cogsToday     = qtyCovered * avgCost;
+            runningQty   -= qtyCovered;
             runningValue -= cogsToday;
         }
 

--- a/services/stock-valuation-service.js
+++ b/services/stock-valuation-service.js
@@ -1,0 +1,199 @@
+// services/stock-valuation-service.js
+// On-the-fly stock-adjusted COGS — no persisted running balance (see
+// gl_stock_opening_balance for why: this domain backdates invoices
+// routinely, and a live-updated balance would need the same
+// correction-cascade machinery already built for gl_static_ledger_map).
+//
+// Instead: one seed row per (location, product, FY) in
+// gl_stock_opening_balance, then every call here replays that FY's
+// purchases and sales chronologically (day-by-day: purchases before that
+// day's sales) using weighted-average costing, bounded by FY start — so
+// cost stays manageable within a single financial year. At FY close, the
+// computed closing balance gets written down once as the next FY's opening
+// row (source='FY_CLOSE') — not implemented yet, deferred until a FY
+// actually needs closing.
+//
+// Known gap: BOWSER_CASH_SALE / BOWSER_DIGITAL_SALE are payment-mode-only
+// records (no product_id or quantity), so their fuel volume can't be
+// subtracted from the running balance. Immaterial where those modes aren't
+// used; overstates closing stock / understates COGS slightly otherwise.
+
+const db = require('../db/db-connection');
+const { QueryTypes } = require('sequelize');
+
+async function getOpeningBalances(locationCode, fyId) {
+    return db.sequelize.query(`
+        SELECT sob.product_id, p.product_name, sob.opening_qty, sob.opening_value
+        FROM gl_stock_opening_balance sob
+        JOIN m_product p ON p.product_id = sob.product_id
+        WHERE sob.location_code = :locationCode AND sob.fy_id = :fyId
+    `, { replacements: { locationCode, fyId }, type: QueryTypes.SELECT });
+}
+
+// { d: 'YYYY-MM-DD', qty, value } per day, purchases only, for one product.
+async function getDailyPurchases(locationCode, productId, fromDate, toDate) {
+    const tankRows = await db.sequelize.query(`
+        SELECT DATE(ti.invoice_date) AS d,
+               SUM(CASE WHEN td.qty_unit = 'KL' THEN td.quantity * 1000 ELSE td.quantity END) AS qty,
+               SUM(td.total_line_amount + COALESCE(chg.charge_total, 0)) AS value
+        FROM t_tank_invoice_dtl td
+        JOIN t_tank_invoice ti ON ti.id = td.invoice_id
+        LEFT JOIN (
+            SELECT invoice_dtl_id, SUM(charge_amount) AS charge_total
+            FROM t_tank_invoice_charges
+            GROUP BY invoice_dtl_id
+        ) chg ON chg.invoice_dtl_id = td.id
+        WHERE ti.location_id = :locationCode AND td.product_id = :productId
+          AND ti.invoice_date BETWEEN :fromDate AND :toDate
+        GROUP BY DATE(ti.invoice_date)
+    `, { replacements: { locationCode, productId, fromDate, toDate }, type: QueryTypes.SELECT });
+
+    const lubesRows = await db.sequelize.query(`
+        SELECT DATE(h.invoice_date) AS d, SUM(l.qty) AS qty, SUM(l.taxable_value) AS value
+        FROM t_lubes_inv_lines l
+        JOIN t_lubes_inv_hdr h ON h.lubes_hdr_id = l.lubes_hdr_id
+        WHERE h.location_code = :locationCode AND l.product_id = :productId
+          AND h.closing_status = 'CLOSED'
+          AND h.invoice_date BETWEEN :fromDate AND :toDate
+        GROUP BY DATE(h.invoice_date)
+    `, { replacements: { locationCode, productId, fromDate, toDate }, type: QueryTypes.SELECT });
+
+    return [...tankRows, ...lubesRows];
+}
+
+// { d: 'YYYY-MM-DD', qty } per day, sold quantity only, for one product —
+// value isn't needed here, COGS is computed from the running average, not
+// from what any individual channel recorded as revenue.
+async function getDailySoldQty(locationCode, productId, fromDate, toDate) {
+    const dayBill = await db.sequelize.query(`
+        SELECT tdb.bill_date AS d, SUM(tdi.quantity) AS qty
+        FROM t_day_bill_items tdi
+        JOIN t_day_bill_header tdh ON tdh.header_id = tdi.header_id
+        JOIN t_day_bill tdb ON tdb.day_bill_id = tdh.day_bill_id
+        WHERE tdb.location_code = :locationCode AND tdi.product_id = :productId
+          AND tdb.bill_date BETWEEN :fromDate AND :toDate
+        GROUP BY tdb.bill_date
+    `, { replacements: { locationCode, productId, fromDate, toDate }, type: QueryTypes.SELECT });
+
+    const creditSale = await db.sequelize.query(`
+        SELECT DATE(cl.closing_date) AS d, SUM(tc.qty) AS qty
+        FROM t_credits tc
+        JOIN t_closing cl ON cl.closing_id = tc.closing_id
+        WHERE cl.location_code = :locationCode AND tc.product_id = :productId
+          AND DATE(cl.closing_date) BETWEEN :fromDate AND :toDate
+        GROUP BY DATE(cl.closing_date)
+    `, { replacements: { locationCode, productId, fromDate, toDate }, type: QueryTypes.SELECT });
+
+    const cashSale = await db.sequelize.query(`
+        SELECT DATE(cl.closing_date) AS d, SUM(cs.qty) AS qty
+        FROM t_cashsales cs
+        JOIN t_closing cl ON cl.closing_id = cs.closing_id
+        WHERE cl.location_code = :locationCode AND cs.product_id = :productId
+          AND DATE(cl.closing_date) BETWEEN :fromDate AND :toDate
+        GROUP BY DATE(cl.closing_date)
+    `, { replacements: { locationCode, productId, fromDate, toDate }, type: QueryTypes.SELECT });
+
+    const bowserCredit = await db.sequelize.query(`
+        SELECT DATE(tbc.closing_date) AS d, SUM(bc.quantity) AS qty
+        FROM t_bowser_credits bc
+        JOIN t_bowser_closing tbc ON tbc.bowser_closing_id = bc.bowser_closing_id
+        WHERE tbc.location_code = :locationCode AND bc.product_id = :productId
+          AND DATE(tbc.closing_date) BETWEEN :fromDate AND :toDate
+        GROUP BY DATE(tbc.closing_date)
+    `, { replacements: { locationCode, productId, fromDate, toDate }, type: QueryTypes.SELECT });
+
+    return [...dayBill, ...creditSale, ...cashSale, ...bowserCredit];
+}
+
+function toDateStr(d) {
+    return typeof d === 'string' ? d.substring(0, 10) : d.toISOString().substring(0, 10);
+}
+
+// Merges same-day purchase/sale rows, replays weighted-average costing from
+// the opening balance forward, and returns COGS for [fromDate, toDate] plus
+// the closing balance as of toDate. fromDate/toDate must fall inside the FY
+// gl_stock_opening_balance was seeded for.
+async function computeProductStockCOGS(locationCode, fyId, productId, fromDate, toDate) {
+    const [fy] = await db.sequelize.query(`
+        SELECT start_date FROM gl_financial_years WHERE fy_id = :fyId
+    `, { replacements: { fyId }, type: QueryTypes.SELECT });
+    if (!fy) throw new Error(`Financial year not found: fy_id=${fyId}`);
+    const fyStart = toDateStr(fy.start_date);
+
+    const [opening] = await db.sequelize.query(`
+        SELECT opening_qty, opening_value FROM gl_stock_opening_balance
+        WHERE location_code = :locationCode AND product_id = :productId AND fy_id = :fyId
+    `, { replacements: { locationCode, productId, fyId }, type: QueryTypes.SELECT });
+    if (!opening) return null; // not a stock-tracked product for this FY — caller falls back to raw purchases
+
+    const [purchases, soldQty] = await Promise.all([
+        getDailyPurchases(locationCode, productId, fyStart, toDate),
+        getDailySoldQty(locationCode, productId, fyStart, toDate)
+    ]);
+
+    const byDay = new Map(); // 'YYYY-MM-DD' -> { purchaseQty, purchaseValue, soldQty }
+    const ensureDay = (d) => {
+        if (!byDay.has(d)) byDay.set(d, { purchaseQty: 0, purchaseValue: 0, soldQty: 0 });
+        return byDay.get(d);
+    };
+    for (const r of purchases) {
+        const day = ensureDay(toDateStr(r.d));
+        day.purchaseQty   += parseFloat(r.qty)   || 0;
+        day.purchaseValue += parseFloat(r.value) || 0;
+    }
+    for (const r of soldQty) {
+        const day = ensureDay(toDateStr(r.d));
+        day.soldQty += parseFloat(r.qty) || 0;
+    }
+
+    const orderedDays = [...byDay.keys()].sort();
+    const fromDateStr = toDateStr(fromDate);
+    const toDateStr_   = toDateStr(toDate);
+
+    let runningQty   = parseFloat(opening.opening_qty);
+    let runningValue = parseFloat(opening.opening_value);
+    let cogsBeforeFrom = 0;
+    let cogsThroughTo   = 0;
+
+    for (const day of orderedDays) {
+        if (day > toDateStr_) break;
+
+        const { purchaseQty, purchaseValue, soldQty: qtySold } = byDay.get(day);
+
+        // Purchases land before that day's sales — stock arrives, then gets sold.
+        runningQty   += purchaseQty;
+        runningValue += purchaseValue;
+
+        let cogsToday = 0;
+        if (qtySold > 0) {
+            const avgCost = runningQty > 0 ? runningValue / runningQty : 0;
+            cogsToday     = qtySold * avgCost;
+            runningQty   -= qtySold;
+            runningValue -= cogsToday;
+        }
+
+        cogsThroughTo += cogsToday;
+        if (day < fromDateStr) cogsBeforeFrom += cogsToday;
+    }
+
+    return {
+        productId,
+        cogs: cogsThroughTo - cogsBeforeFrom,
+        closingQty: runningQty,
+        closingValue: runningValue
+    };
+}
+
+// All stock-tracked products (i.e. every product with a gl_stock_opening_balance
+// row) for a location + FY, in one call — what the P&L route actually needs.
+async function computeStockCOGS(locationCode, fyId, fromDate, toDate) {
+    const openings = await getOpeningBalances(locationCode, fyId);
+    const results = [];
+    for (const o of openings) {
+        const r = await computeProductStockCOGS(locationCode, fyId, o.product_id, fromDate, toDate);
+        if (r) results.push({ ...r, productName: o.product_name });
+    }
+    return results;
+}
+
+module.exports = { computeStockCOGS, computeProductStockCOGS };

--- a/views/account-heads.pug
+++ b/views/account-heads.pug
@@ -63,6 +63,7 @@ block content
                                     th Active
                                     th Effective From
                                     th Effective To
+                                    th GL Group
                                     if canEdit
                                         th Edit
                                     if canDisable
@@ -71,7 +72,10 @@ block content
                                 each head, index in accountHeads
                                     tr.head-row
                                         th(scope="row")= index + 1
-                                        td.searchable= head.account_head_name
+                                        td.searchable
+                                            = head.account_head_name
+                                            if head.is_system_type === 'Y'
+                                                i.bi.bi-lock-fill.text-muted.ml-1(title="System-generated — used by cashflow auto-generation, name/deactivation locked")
                                         td.searchable= head.account_head_type
                                         td
                                             span.badge(class=head.allowed_entry_type === 'CREDIT' ? 'badge-success' : (head.allowed_entry_type === 'DEBIT' ? 'badge-danger' : 'badge-secondary'))= head.allowed_entry_type
@@ -79,6 +83,13 @@ block content
                                         td= head.active_flag
                                         td= head.effective_start_date ? new Date(head.effective_start_date).toLocaleDateString('en-GB') : '-'
                                         td= head.effective_end_date   ? new Date(head.effective_end_date).toLocaleDateString('en-GB')   : '-'
+                                        td
+                                            select.form-control.form-control-sm.gl-group-select(
+                                                data-id=head.account_head_id,
+                                                style="min-width:160px;")
+                                                option(value="") — Not Set —
+                                                each g in glGroups
+                                                    option(value=g.group_id, selected=(head.gl_group_id === g.group_id))= g.group_name
                                         if canEdit
                                             td
                                                 button.btn.btn-primary.btn-sm.btn-edit-head(
@@ -89,19 +100,27 @@ block content
                                                     data-entry-type=head.allowed_entry_type,
                                                     data-notes=head.notes_required_flag,
                                                     data-active=head.active_flag,
+                                                    data-system=head.is_system_type,
                                                     data-start=head.effective_start_date ? head.effective_start_date.toString().substring(0,10) : '',
                                                     data-end=head.effective_end_date     ? head.effective_end_date.toString().substring(0,10)   : '')
                                                     i.bi.bi-pencil
                                         if canDisable
                                             td
-                                                button.btn.btn-danger.btn-sm(type="button", onclick=`confirmDeactivate(${head.account_head_id})`)
-                                                    i.bi.bi-trash
+                                                if head.is_system_type === 'Y'
+                                                    button.btn.btn-danger.btn-sm(type="button", disabled, title="System-generated — cannot be deactivated")
+                                                        i.bi.bi-trash
+                                                else
+                                                    button.btn.btn-danger.btn-sm(type="button", onclick=`confirmDeactivate(${head.account_head_id})`)
+                                                        i.bi.bi-trash
 
                 .mobile-cards-view.d-block.d-lg-none
                     each head in accountHeads
                         .card.shadow-sm.mb-2.head-card
                             .card-header.d-flex.justify-content-between.align-items-center
-                                h6.mb-0.text-uppercase= head.account_head_name
+                                h6.mb-0.text-uppercase
+                                    = head.account_head_name
+                                    if head.is_system_type === 'Y'
+                                        i.bi.bi-lock-fill.text-muted.ml-1
                                 .actions
                                     if canEdit
                                         button.btn.btn-primary.btn-sm.mr-1.btn-edit-head(
@@ -112,12 +131,17 @@ block content
                                             data-entry-type=head.allowed_entry_type,
                                             data-notes=head.notes_required_flag,
                                             data-active=head.active_flag,
+                                            data-system=head.is_system_type,
                                             data-start=head.effective_start_date ? head.effective_start_date.toString().substring(0,10) : '',
                                             data-end=head.effective_end_date     ? head.effective_end_date.toString().substring(0,10)   : '')
                                             i.bi.bi-pencil
                                     if canDisable
-                                        button.btn.btn-danger.btn-sm(type="button", onclick=`confirmDeactivate(${head.account_head_id})`)
-                                            i.bi.bi-trash
+                                        if head.is_system_type === 'Y'
+                                            button.btn.btn-danger.btn-sm(type="button", disabled, title="System-generated — cannot be deactivated")
+                                                i.bi.bi-trash
+                                        else
+                                            button.btn.btn-danger.btn-sm(type="button", onclick=`confirmDeactivate(${head.account_head_id})`)
+                                                i.bi.bi-trash
                             .card-body.p-2
                                 p.mb-1
                                     b Head Type:&nbsp;
@@ -147,7 +171,8 @@ block content
                                     i.bi.bi-x-circle
                     .col-auto
                         select.form-control#filterBank
-                            option(value="") All Banks
+                            option(value="") All Banks / Cashflow
+                            option(value="CASHFLOW") Cashflow
                             each bank in banks
                                 option(value=bank.bank_id)
                                     = bank.account_number ? `${bank.bank_name} (...${bank.account_number.slice(-4)})` : bank.bank_name
@@ -166,7 +191,7 @@ block content
                                 tr
                                     th #
                                     th Type
-                                    th Bank
+                                    th Bank / Context
                                     th Ledger Name
                                     th Entry Type
                                     th Max Amt
@@ -177,7 +202,7 @@ block content
                             tbody#rulesTableBody
                                 each rule, index in allRules
                                     - const isStatic = rule.source_type === 'Static'
-                                    tr.rule-row(data-bank-id=rule.bank_id, data-source-type=rule.source_type)
+                                    tr.rule-row(data-bank-id=rule.bank_id, data-source-type=rule.source_type, data-applies-cashflow=rule.applies_to_cashflow)
                                         th(scope="row")= index + 1
                                         td
                                             span.badge(class=isStatic ? 'badge-info' : (rule.source_type === 'Credit' ? 'badge-success' : (rule.source_type === 'Bank' ? 'badge-primary' : 'badge-warning')))= rule.source_type
@@ -211,6 +236,7 @@ block content
                                                         data-notes=rule.notes_required_flag,
                                                         data-max-amount=rule.max_amount || '',
                                                         data-allow-split=(rule.allow_split_flag || 'N'),
+                                                        data-applies-cashflow=rule.applies_to_cashflow,
                                                         data-start=rule.effective_start_date ? rule.effective_start_date.toString().substring(0,10) : '',
                                                         data-end=rule.effective_end_date     ? rule.effective_end_date.toString().substring(0,10)   : '')
                                                         i.bi.bi-pencil
@@ -229,7 +255,7 @@ block content
                 .mobile-cards-view.d-block.d-lg-none
                     each rule in allRules
                         - const isStatic = rule.source_type === 'Static'
-                        .card.shadow-sm.mb-2.rule-card(data-bank-id=rule.bank_id, data-source-type=rule.source_type)
+                        .card.shadow-sm.mb-2.rule-card(data-bank-id=rule.bank_id, data-source-type=rule.source_type, data-applies-cashflow=rule.applies_to_cashflow)
                             .card-header.d-flex.justify-content-between.align-items-center
                                 div
                                     span.badge.mr-1(class=isStatic ? 'badge-info' : (rule.source_type === 'Credit' ? 'badge-success' : 'badge-warning'))= rule.source_type
@@ -247,6 +273,7 @@ block content
                                                 data-notes=rule.notes_required_flag,
                                                 data-max-amount=rule.max_amount || '',
                                                 data-allow-split=(rule.allow_split_flag || 'N'),
+                                                data-applies-cashflow=rule.applies_to_cashflow,
                                                 data-start=rule.effective_start_date ? rule.effective_start_date.toString().substring(0,10) : '',
                                                 data-end=rule.effective_end_date     ? rule.effective_end_date.toString().substring(0,10)   : '')
                                                 i.bi.bi-pencil
@@ -332,6 +359,9 @@ block content
                 .modal-body
                     form#editHeadForm(method='POST', action='/account-heads/update')
                         input(type="hidden", name="account_head_id", id="edit_account_head_id")
+                        p.text-muted.small.mb-2#editHeadSystemNote(style="display:none;")
+                            i.bi.bi-lock-fill.mr-1
+                            | System-generated — name is locked (used by cashflow auto-generation).
                         .form-group
                             label Account Head Name *
                             input.form-control(type="text", name="account_head_name", id="edit_account_head_name", required, style="text-transform:uppercase;", autocomplete="off")
@@ -380,15 +410,24 @@ block content
                     button.close(type="button", data-dismiss="modal", aria-label="Close")
                         span(aria-hidden="true") &times;
                 .modal-body
-                    p.text-muted.small Select the bank and the account head it should map to for statement uploads.
+                    p.text-muted.small Select what this rule applies to and the account head it should map to.
                     form#addRuleForm(method='POST', action='/account-heads/rules')
                         input(type="hidden", name="account_head_id", id="add_rule_head_id")
                         input(type="hidden", name="ledger_name",     id="add_rule_ledger_name")
+                        input(type="hidden", name="applies_to_cashflow", id="add_rule_applies_cashflow", value="N")
+                        .form-group
+                            label Applies To *
+                            .form-check.form-check-inline
+                                input.form-check-input.add-rule-context(type="radio", name="context_type", id="add_rule_context_bank", value="BANK", checked)
+                                label.form-check-label(for="add_rule_context_bank") Bank
+                            .form-check.form-check-inline
+                                input.form-check-input.add-rule-context(type="radio", name="context_type", id="add_rule_context_cashflow", value="CASHFLOW")
+                                label.form-check-label(for="add_rule_context_cashflow") Cashflow
                         .form-row
-                            .col-md-6
+                            .col-md-6#add_rule_bank_wrapper
                                 .form-group
                                     label Bank *
-                                    select.form-control(name="bank_id", required)
+                                    select.form-control(name="bank_id", id="add_rule_bank_select", required)
                                         option(value="") — Select Bank —
                                         each bank in banks
                                             option(value=bank.bank_id)
@@ -449,8 +488,17 @@ block content
                         input(type="hidden", name="rule_id",         id="edit_rule_id")
                         input(type="hidden", name="account_head_id", id="edit_rule_head_id")
                         input(type="hidden", name="ledger_name",     id="edit_rule_ledger_name")
+                        input(type="hidden", name="applies_to_cashflow", id="edit_rule_applies_cashflow", value="N")
+                        .form-group
+                            label Applies To *
+                            .form-check.form-check-inline
+                                input.form-check-input.edit-rule-context(type="radio", name="context_type", id="edit_rule_context_bank", value="BANK")
+                                label.form-check-label(for="edit_rule_context_bank") Bank
+                            .form-check.form-check-inline
+                                input.form-check-input.edit-rule-context(type="radio", name="context_type", id="edit_rule_context_cashflow", value="CASHFLOW")
+                                label.form-check-label(for="edit_rule_context_cashflow") Cashflow
                         .form-row
-                            .col-md-6
+                            .col-md-6#edit_rule_bank_wrapper
                                 .form-group
                                     label Bank *
                                     select.form-control(name="bank_id", id="edit_rule_bank_id", required)
@@ -599,19 +647,25 @@ block content
             const ruleRows    = document.querySelectorAll('#rulesTableBody tr.rule-row');
             const ruleCards   = document.querySelectorAll('.rule-card');
 
+            function ruleBankMatches(el, bankId) {
+                if (!bankId) return true;
+                if (bankId === 'CASHFLOW') return el.dataset.appliesCashflow === 'Y';
+                return el.dataset.bankId === bankId;
+            }
+
             function applyRuleFilters() {
                 const term   = searchRules.value.toLowerCase().trim();
                 const bankId = filterBank.value;
                 const type   = filterType.value;
                 ruleRows.forEach(r => {
                     const textOk = !term   || Array.from(r.querySelectorAll('.searchable')).map(el => el.textContent.toLowerCase()).join(' ').includes(term);
-                    const bankOk = !bankId || r.dataset.bankId === bankId;
+                    const bankOk = ruleBankMatches(r, bankId);
                     const typeOk = !type   || r.dataset.sourceType === type;
                     r.style.display = (textOk && bankOk && typeOk) ? '' : 'none';
                 });
                 ruleCards.forEach(c => {
                     const textOk = !term   || c.textContent.toLowerCase().includes(term);
-                    const bankOk = !bankId || c.dataset.bankId === bankId;
+                    const bankOk = ruleBankMatches(c, bankId);
                     const typeOk = !type   || c.dataset.sourceType === type;
                     c.style.display = (textOk && bankOk && typeOk) ? '' : 'none';
                 });
@@ -636,10 +690,24 @@ block content
                 document.getElementById('add_rule_ledger_name').value = opt.dataset.name || '';
             });
 
+            // ── Add Rule: Bank vs Cashflow context toggle ──────────────────
+            function setAddRuleContext(isCashflow) {
+                document.getElementById('add_rule_applies_cashflow').value = isCashflow ? 'Y' : 'N';
+                document.getElementById('add_rule_bank_wrapper').style.display = isCashflow ? 'none' : '';
+                document.getElementById('add_rule_bank_select').required = !isCashflow;
+                if (isCashflow) document.getElementById('add_rule_bank_select').value = '';
+            }
+            document.querySelectorAll('.add-rule-context').forEach(function (radio) {
+                radio.addEventListener('change', function () {
+                    setAddRuleContext(this.value === 'CASHFLOW');
+                });
+            });
+
             $('#addRuleModal').on('hidden.bs.modal', function () {
                 document.getElementById('addRuleForm').reset();
                 document.getElementById('add_rule_head_id').value     = '';
                 document.getElementById('add_rule_ledger_name').value = '';
+                setAddRuleContext(false);
             });
 
             // ── Edit Account Head ─────────────────────────────────────────
@@ -655,7 +723,24 @@ block content
                 document.getElementById('edit_active_flag').value          = d.active;
                 document.getElementById('edit_effective_start_date').value = d.start;
                 document.getElementById('edit_effective_end_date').value   = d.end;
+                const isSystem = d.system === 'Y';
+                document.getElementById('edit_account_head_name').readOnly = isSystem;
+                document.getElementById('editHeadSystemNote').style.display = isSystem ? '' : 'none';
                 $('#editHeadModal').modal('show');
+            });
+
+            // ── Edit Rule: Bank vs Cashflow context toggle ─────────────────
+            function setEditRuleContext(isCashflow) {
+                document.getElementById('edit_rule_applies_cashflow').value = isCashflow ? 'Y' : 'N';
+                document.getElementById('edit_rule_bank_wrapper').style.display = isCashflow ? 'none' : '';
+                document.getElementById('edit_rule_bank_id').required = !isCashflow;
+                if (isCashflow) document.getElementById('edit_rule_bank_id').value = '';
+                document.getElementById(isCashflow ? 'edit_rule_context_cashflow' : 'edit_rule_context_bank').checked = true;
+            }
+            document.querySelectorAll('.edit-rule-context').forEach(function (radio) {
+                radio.addEventListener('change', function () {
+                    setEditRuleContext(this.value === 'CASHFLOW');
+                });
             });
 
             // ── Edit Static Rule ──────────────────────────────────────────
@@ -664,7 +749,6 @@ block content
                 if (!btn) return;
                 const d = btn.dataset;
                 document.getElementById('edit_rule_id').value          = d.id;
-                document.getElementById('edit_rule_bank_id').value     = d.bankId;
                 document.getElementById('edit_rule_head_id').value     = d.accountHeadId;
                 document.getElementById('edit_rule_ledger_name').value = d.ledgerName;
                 document.getElementById('edit_rule_head_select').value = d.accountHeadId;
@@ -674,6 +758,9 @@ block content
                 document.getElementById('edit_rule_max_amount').value  = d.maxAmount;
                 document.getElementById('edit_rule_start').value       = d.start;
                 document.getElementById('edit_rule_end').value         = d.end;
+                const isCashflow = d.appliesCashflow === 'Y';
+                setEditRuleContext(isCashflow);
+                document.getElementById('edit_rule_bank_id').value = isCashflow ? '' : (d.bankId || '');
                 $('#editRuleModal').modal('show');
             });
 
@@ -736,3 +823,32 @@ block content
                 form.submit();
             }
         }
+
+        // GL Group auto-save — fires on dropdown change
+        document.querySelectorAll('.gl-group-select').forEach(function(sel) {
+            sel.addEventListener('change', function() {
+                const id      = this.dataset.id;
+                const groupId = this.value;
+                const orig    = this;
+                orig.disabled = true;
+                fetch('/account-heads/' + id + '/gl-group', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ gl_group_id: groupId || null })
+                })
+                .then(r => r.json())
+                .then(data => {
+                    orig.disabled = false;
+                    if (data.success) {
+                        orig.style.borderColor = '#28a745';
+                        setTimeout(() => orig.style.borderColor = '', 1500);
+                    } else {
+                        alert('Failed to save GL group: ' + (data.error || 'Unknown error'));
+                    }
+                })
+                .catch(() => {
+                    orig.disabled = false;
+                    alert('Network error saving GL group');
+                });
+            });
+        });

--- a/views/gl-profit-loss.pug
+++ b/views/gl-profit-loss.pug
@@ -56,7 +56,10 @@ block content
                                 each row in g.rows
                                     tr
                                         td.pl-4
-                                            a(href='/gl/ledger?ledger_id=' + row.ledger_id + '&from_date=' + fromDate + '&to_date=' + toDate)= row.ledger_name
+                                            if row.ledger_id
+                                                a(href='/gl/ledger?ledger_id=' + row.ledger_id + '&from_date=' + fromDate + '&to_date=' + toDate)= row.ledger_name
+                                            else
+                                                span.text-muted= row.ledger_name
                                         td.text-right.small= fmt(row.amount)
                                 tr.group-subtotal
                                     td.text-right.font-weight-bold.text-muted.small #{g.group_name} Total
@@ -79,7 +82,10 @@ block content
                                 each row in g.rows
                                     tr
                                         td.pl-4
-                                            a(href='/gl/ledger?ledger_id=' + row.ledger_id + '&from_date=' + fromDate + '&to_date=' + toDate)= row.ledger_name
+                                            if row.ledger_id
+                                                a(href='/gl/ledger?ledger_id=' + row.ledger_id + '&from_date=' + fromDate + '&to_date=' + toDate)= row.ledger_name
+                                            else
+                                                span.text-muted= row.ledger_name
                                         td.text-right.small= fmt(row.amount)
                                 tr.group-subtotal
                                     td.text-right.font-weight-bold.text-muted.small #{g.group_name} Total


### PR DESCRIPTION
## Summary
This bundles everything from this session's cashflow/GL accounting work, tested and validated on beta:

1. **Cashflow types moved onto Account Heads/Ledger Rules** — replaces the old `m_lookup(CashFlow)`-driven system. `t_cashflow_transaction` gains `account_head_id`/`entry_type`, auto-populated by trigger. `processCashflowTxnEvent` simplified to read those directly, no more joins to `m_ledger_rules`.
2. **Correction-queue trigger fix** — was skipping corrections on a label's first-ever review, and had no branch for `CASHFLOW_TXN` at all.
3. **Stock-adjusted COGS on the P&L** — computes actual COGS (opening + purchases − closing, weighted-average costed) on the fly per financial year, shown as a transparent adjustment line. Includes a fix for a runaway-COGS bug found when the replay hits a real data gap (e.g. a partial month with no purchase invoices entered yet).
4. **Day Close report, Cashflow Detailed report, and Bank Deposit Recon report** moved off `m_lookup` onto `entry_type`/`display_sequence` (Tally export v2 intentionally left alone).
5. **Ordering fix** — cashflow entry page (both the dropdown and existing rows) now orders by `display_sequence`, matching the reports.
6. **Stale-session-variable trigger bug fix** — a real MySQL gotcha (`SELECT...INTO @var` doesn't reset `@var` on zero matching rows) that could silently corrupt `entry_type` once a lookup fails to match — found and fixed during beta testing.
7. Prod-adapted schema migration (prod never got an earlier superseded migration beta went through, so its DROP COLUMN steps don't apply).

## Scope for this deploy (per user instruction)
- Code + generic DB schema/seed migrations only — this seeds every location's cashflow types into Account Heads/Ledger Rules.
- **NOT included**: `gl_static_ledger_map` accounting/GL-posting classification (deferred, separate per-location work) and no location's GL accounting gate gets turned on by this.

## Test plan
- [x] All 6+ PRs individually tested against real beta data throughout this session (see individual PR descriptions #799-805)
- [x] Prod schema/data state verified directly before this PR — confirmed compatible, no surprises
- [ ] Post-deploy: verify cashflow entry screen and reports render correctly on prod for a few locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)