### PR TITLE
DSM bill photo: gate behind ALLOW_DSM_BILL_PHOTO config

### DIFF
--- a/controllers/dsm-entry-controller.js
+++ b/controllers/dsm-entry-controller.js
@@ -15,6 +15,8 @@ module.exports = {
             const locationCode = user.location_code;
             const cashierId = user.Person_id;
 
+            const allowBillPhoto = (await getLocationConfigValue(locationCode, 'ALLOW_DSM_BILL_PHOTO', 'N')) === 'Y';
+
             // Check for active shift
             const activeClosing = await dsmEntryDao.getActiveClosing(cashierId, locationCode);
 
@@ -28,12 +30,14 @@ module.exports = {
                     products: [],
                     credits: [],
                     entries,
+                    allowBillPhoto,
                     pageData: JSON.stringify({
                         activeClosing: null,
                         products: [],
                         credits: [],
                         entries,
-                        allVehicles: []
+                        allVehicles: [],
+                        allowBillPhoto
                     })
                 });
             }
@@ -50,7 +54,8 @@ module.exports = {
                 products,
                 credits,
                 entries,
-                allVehicles
+                allVehicles,
+                allowBillPhoto
             };
 
             return res.render("dsm-entry", {
@@ -60,6 +65,7 @@ module.exports = {
                 products,
                 credits,
                 entries,
+                allowBillPhoto,
                 pageData: JSON.stringify(pageData)
             });
 
@@ -203,13 +209,19 @@ module.exports = {
     // matches the existing delete-entry ownership rule on this screen.
     uploadPhoto: async (req, res) => {
         try {
+            const user = req.user;
+            const locationCode = user.location_code;
+            const cashierId = user.Person_id;
+
+            const allowBillPhoto = (await getLocationConfigValue(locationCode, 'ALLOW_DSM_BILL_PHOTO', 'N')) === 'Y';
+            if (!allowBillPhoto) {
+                return res.status(403).json({ success: false, message: "Bill photo capture is not enabled for this location." });
+            }
+
             if (!req.file) {
                 return res.status(400).json({ success: false, message: "No photo uploaded." });
             }
 
-            const user = req.user;
-            const locationCode = user.location_code;
-            const cashierId = user.Person_id;
             const tcreditId = parseInt(req.params.tcreditId);
 
             if (!tcreditId) {

--- a/db/migrations/dsm-bill-photo-config.sql
+++ b/db/migrations/dsm-bill-photo-config.sql
@@ -1,0 +1,18 @@
+-- Config gate for the DSM credit-entry bill-photo capture feature.
+-- Default is disabled (matches ALLOW_QUICK_ADD_VEHICLE convention — no
+-- global '*' row, code falls back to 'N' when no row exists). Enable
+-- per-location by inserting a 'Y' row.
+
+INSERT INTO m_location_config_catalog (setting_name, short_description, detailed_description, created_by, updated_by)
+VALUES
+('ALLOW_DSM_BILL_PHOTO', 'Enable bill photo capture on DSM entry screen',
+ 'Y/N. When Y, the DSM credit-entry screen (/dsm-entry) shows Upload/Take Photo controls to attach a photo of the printed thermal bill to each credit entry, plus a camera icon on saved entries to view/swap/remove it. Default N (disabled). Checked in dsm-entry-controller.js.',
+ 'system', 'system')
+ON DUPLICATE KEY UPDATE
+    short_description    = VALUES(short_description),
+    detailed_description = VALUES(detailed_description),
+    updated_by            = 'system';
+
+-- SFS is the pilot location for this feature (active beta testing 2026-08-21).
+INSERT IGNORE INTO m_location_config (location_code, setting_name, setting_value, effective_start_date, effective_end_date, created_by, updated_by, creation_date, updation_date)
+VALUES ('SFS', 'ALLOW_DSM_BILL_PHOTO', 'Y', CURDATE(), '9999-12-31', 'system', 'system', NOW(), NOW());

--- a/views/dsm-entry.pug
+++ b/views/dsm-entry.pug
@@ -468,17 +468,19 @@ html(lang='en')
 
     //- Bill photo modal (view / upload / take photo / replace / remove) — rendered
     //- at top level so it's available whether or not there's an active shift.
-    #billPhotoModal.modal.fade(tabindex='-1' role='dialog')
-        .modal-dialog.modal-dialog-centered(role='document')
-            .modal-content
-                .modal-header
-                    h6.modal-title Bill Photo
-                    button.close(type='button' data-dismiss='modal' aria-label='Close')
-                        span(aria-hidden='true') &times;
-                .modal-body#billPhotoModalBody
-                .modal-footer#billPhotoModalFooter
-    input#billPhotoUploadInput(type='file' accept='image/*' style='display:none')
-    input#billPhotoCameraInput(type='file' accept='image/*' capture='environment' style='display:none')
+    //- Gated by ALLOW_DSM_BILL_PHOTO location config.
+    if allowBillPhoto
+        #billPhotoModal.modal.fade(tabindex='-1' role='dialog')
+            .modal-dialog.modal-dialog-centered(role='document')
+                .modal-content
+                    .modal-header
+                        h6.modal-title Bill Photo
+                        button.close(type='button' data-dismiss='modal' aria-label='Close')
+                            span(aria-hidden='true') &times;
+                    .modal-body#billPhotoModalBody
+                    .modal-footer#billPhotoModalFooter
+        input#billPhotoUploadInput(type='file' accept='image/*' style='display:none')
+        input#billPhotoCameraInput(type='file' accept='image/*' capture='environment' style='display:none')
 
     if !activeClosing
         .dsm-container
@@ -501,11 +503,12 @@ html(lang='en')
                                     |  · #{entry.qty} L
                                     span.entry-shift  · Shift ##{entry.closing_id}
                             .entry-amount ₹#{parseFloat(entry.amount).toLocaleString('en-IN')}
-                            .entry-photo(data-id=entry.tcredit_id data-photo=entry.photo_doc_id || '' data-editable='0')
-                                if entry.photo_doc_id
-                                    img.entry-photo-thumb(src=`/documents/${entry.photo_doc_id}` alt='Bill photo')
-                                else
-                                    i.bi.bi-camera.entry-photo-icon
+                            if allowBillPhoto
+                                .entry-photo(data-id=entry.tcredit_id data-photo=entry.photo_doc_id || '' data-editable='0')
+                                    if entry.photo_doc_id
+                                        img.entry-photo-thumb(src=`/documents/${entry.photo_doc_id}` alt='Bill photo')
+                                    else
+                                        i.bi.bi-camera.entry-photo-icon
                             span.entry-locked(title='Shift closed — cannot delete') 🔒
 
     else
@@ -636,21 +639,23 @@ html(lang='en')
                 //- (there's no tcredit_id to attach to until then). Staged as a
                 //- compressed blob in memory; the after-save camera icon on the
                 //- entry card remains available for viewing/swapping/removing it.
-                .mb-3
-                    label.form-label Bill Photo
-                    #newEntryPhotoPreview(style='display:none')
-                        img#newEntryPhotoImg(style='width:100%;border-radius:8px;margin-bottom:8px' alt='Bill photo')
-                        button#btnNewEntryPhotoRemove.btn.btn-link.text-danger.btn-sm.p-0(type='button') Remove Photo
-                    #newEntryPhotoButtons
-                        .d-flex(style='gap:8px')
-                            button#btnNewEntryUpload.btn.btn-outline-primary.flex-fill(type='button')
-                                i.bi.bi-folder2-open
-                                |  Upload
-                            button#btnNewEntryCamera.btn.btn-outline-primary.flex-fill(type='button')
-                                i.bi.bi-camera
-                                |  Take Photo
-                    input#newEntryUploadInput(type='file' accept='image/*' style='display:none')
-                    input#newEntryCameraInput(type='file' accept='image/*' capture='environment' style='display:none')
+                //- Gated by ALLOW_DSM_BILL_PHOTO location config.
+                if allowBillPhoto
+                    .mb-3
+                        label.form-label Bill Photo
+                        #newEntryPhotoPreview(style='display:none')
+                            img#newEntryPhotoImg(style='width:100%;border-radius:8px;margin-bottom:8px' alt='Bill photo')
+                            button#btnNewEntryPhotoRemove.btn.btn-link.text-danger.btn-sm.p-0(type='button') Remove Photo
+                        #newEntryPhotoButtons
+                            .d-flex(style='gap:8px')
+                                button#btnNewEntryUpload.btn.btn-outline-primary.flex-fill(type='button')
+                                    i.bi.bi-folder2-open
+                                    |  Upload
+                                button#btnNewEntryCamera.btn.btn-outline-primary.flex-fill(type='button')
+                                    i.bi.bi-camera
+                                    |  Take Photo
+                        input#newEntryUploadInput(type='file' accept='image/*' style='display:none')
+                        input#newEntryCameraInput(type='file' accept='image/*' capture='environment' style='display:none')
 
                 button#btnSave.btn.btn-save(type='button' disabled) Save Entry
 
@@ -671,11 +676,12 @@ html(lang='en')
                                         |  · #{entry.qty} L
                                         span.entry-shift  · Shift ##{entry.closing_id}
                                 .entry-amount ₹#{parseFloat(entry.amount).toLocaleString('en-IN')}
-                                .entry-photo(data-id=entry.tcredit_id data-photo=entry.photo_doc_id || '' data-editable=entry.closing_status === 'DRAFT' ? '1' : '0')
-                                    if entry.photo_doc_id
-                                        img.entry-photo-thumb(src=`/documents/${entry.photo_doc_id}` alt='Bill photo')
-                                    else
-                                        i.bi.bi-camera.entry-photo-icon
+                                if allowBillPhoto
+                                    .entry-photo(data-id=entry.tcredit_id data-photo=entry.photo_doc_id || '' data-editable=entry.closing_status === 'DRAFT' ? '1' : '0')
+                                        if entry.photo_doc_id
+                                            img.entry-photo-thumb(src=`/documents/${entry.photo_doc_id}` alt='Bill photo')
+                                        else
+                                            i.bi.bi-camera.entry-photo-icon
                                 if entry.closing_status === 'DRAFT'
                                     button.btn-delete(type='button' data-id=entry.tcredit_id title='Delete') ✕
                                 else
@@ -764,10 +770,10 @@ html(lang='en')
             if (removeBtn) removeBtn.addEventListener('click', removeCurrentPhoto);
         }
 
-        billPhotoUploadInput.addEventListener('change', function() {
+        billPhotoUploadInput?.addEventListener('change', function() {
             handlePhotoFileSelected(this.files[0], 'UPLOAD');
         });
-        billPhotoCameraInput.addEventListener('change', function() {
+        billPhotoCameraInput?.addEventListener('change', function() {
             handlePhotoFileSelected(this.files[0], 'CAMERA');
         });
 
@@ -932,6 +938,8 @@ html(lang='en')
             pendingPhotoBlob = null;
             pendingPhotoCaptureSource = null;
             if (pendingPhotoObjectUrl) { URL.revokeObjectURL(pendingPhotoObjectUrl); pendingPhotoObjectUrl = null; }
+            // resetForm() always calls this — no-op when the photo section isn't rendered (config off)
+            if (!newEntryPhotoImg) return;
             newEntryPhotoImg.src = '';
             newEntryPhotoPreview.style.display = 'none';
             newEntryPhotoButtons.style.display = '';
@@ -1498,12 +1506,13 @@ html(lang='en')
                         ${e.bill_no || e.notes ? `<div class="entry-meta">${e.bill_no ? 'Bill: ' + e.bill_no : ''}${e.bill_no && e.notes ? ' · ' : ''}${e.notes ? e.notes : ''}</div>` : ''}
                     </div>
                     <div class="entry-amount">₹${parseFloat(e.amount).toLocaleString('en-IN')}</div>
+                    ${pageData.allowBillPhoto ? `
                     <div class="entry-photo" data-id="${e.tcredit_id}" data-photo="${e.photo_doc_id || ''}" data-editable="${e.closing_status === 'DRAFT' ? '1' : '0'}">
                         ${e.photo_doc_id
                             ? `<img class="entry-photo-thumb" src="/documents/${e.photo_doc_id}" alt="Bill photo">`
                             : `<i class="bi bi-camera entry-photo-icon"></i>`
                         }
-                    </div>
+                    </div>` : ''}
                     ${e.closing_status === 'DRAFT'
                         ? `<button class="btn-delete" type="button" data-id="${e.tcredit_id}" title="Delete">✕</button>`
                         : `<span class="entry-locked" title="Shift closed — cannot delete">🔒</span>`


### PR DESCRIPTION
## Summary
- New \`ALLOW_DSM_BILL_PHOTO\` location-config key gates the entire bill-photo feature on the DSM entry screen (New Entry capture buttons, after-save camera icon, modal) — default disabled, matching the \`ALLOW_QUICK_ADD_VEHICLE\` convention.
- \`POST /dsm-entry/:tcreditId/photo\` also checks the flag server-side as a backstop.
- Migration seeds the config-catalog description and enables it for SFS (already run on dev).

## Test plan
- [ ] SFS (enabled): bill photo UI still works as before
- [ ] A location without the config row: New Entry form has no photo section, entry cards have no camera icon, no JS errors in console