### PR TITLE
DSM bill photo: OCR auto-fill (Phase 1, Tesseract only)

### DIFF
--- a/views/dsm-entry.pug
+++ b/views/dsm-entry.pug
@@ -644,7 +644,8 @@ html(lang='en')
                     .mb-3
                         label.form-label Bill Photo
                         #newEntryPhotoPreview(style='display:none')
-                            img#newEntryPhotoImg(style='width:100%;border-radius:8px;margin-bottom:8px' alt='Bill photo')
+                            img#newEntryPhotoImg(style='width:100%;border-radius:8px;margin-bottom:6px' alt='Bill photo')
+                            #newEntryPhotoOcrStatus(style='font-size:12px;color:#6c757d;min-height:16px;margin-bottom:4px')
                             button#btnNewEntryPhotoRemove.btn.btn-link.text-danger.btn-sm.p-0(type='button') Remove Photo
                         #newEntryPhotoButtons
                             .d-flex(style='gap:8px')
@@ -893,6 +894,7 @@ html(lang='en')
         let pendingPhotoBlob = null;
         let pendingPhotoCaptureSource = null;
         let pendingPhotoObjectUrl = null;
+        let photoStageToken = 0; // bumped on every stage/clear — guards against a late-resolving OCR overwriting a newer/cleared photo's fields
 
         const newEntryPhotoPreview  = document.getElementById('newEntryPhotoPreview');
         const newEntryPhotoImg      = document.getElementById('newEntryPhotoImg');
@@ -920,14 +922,19 @@ html(lang='en')
 
         async function stagePendingPhoto(file, captureSource) {
             if (!file) return;
+            const myToken = ++photoStageToken;
             try {
-                pendingPhotoBlob = await compressImage(file);
+                const blob = await compressImage(file);
+                if (myToken !== photoStageToken) return; // a newer photo was staged/cleared while this one compressed
+                pendingPhotoBlob = blob;
                 pendingPhotoCaptureSource = captureSource;
                 if (pendingPhotoObjectUrl) URL.revokeObjectURL(pendingPhotoObjectUrl);
                 pendingPhotoObjectUrl = URL.createObjectURL(pendingPhotoBlob);
                 newEntryPhotoImg.src = pendingPhotoObjectUrl;
                 newEntryPhotoPreview.style.display = '';
                 newEntryPhotoButtons.style.display = 'none';
+                setOcrStatus('', '');
+                readBillPhoto(blob, myToken);
             } catch (e) {
                 console.error('Photo staging error:', e);
                 showToast('Could not process photo. Try again.', 'danger');
@@ -935,6 +942,7 @@ html(lang='en')
         }
 
         function clearPendingPhoto() {
+            photoStageToken++; // invalidate any in-flight OCR for the photo being cleared
             pendingPhotoBlob = null;
             pendingPhotoCaptureSource = null;
             if (pendingPhotoObjectUrl) { URL.revokeObjectURL(pendingPhotoObjectUrl); pendingPhotoObjectUrl = null; }
@@ -943,6 +951,86 @@ html(lang='en')
             newEntryPhotoImg.src = '';
             newEntryPhotoPreview.style.display = 'none';
             newEntryPhotoButtons.style.display = '';
+            setOcrStatus('', '');
+        }
+
+        // Best-effort OCR over the staged photo: flags an unreadable/blurry shot,
+        // and auto-fills Bill No / Amount when confident — DSM can always edit
+        // before saving. Tesseract handles printed thermal-receipt text
+        // reasonably; it does NOT usefully read handwritten bills (a different
+        // problem, deferred — see project_dsm_bill_photo memory).
+        async function readBillPhoto(blob, token) {
+            setOcrStatus('Reading bill...', '');
+            try {
+                const { data: { text } } = await Tesseract.recognize(blob, 'eng', { logger: () => {} });
+                if (token !== photoStageToken) return; // superseded by a newer/cleared photo
+
+                const cleaned = (text || '').trim();
+                const alnumCount = (cleaned.match(/[A-Za-z0-9]/g) || []).length;
+                if (alnumCount < 6) {
+                    setOcrStatus('Could not read bill clearly — you can still save, or retake for a clearer shot.', 'error');
+                    return;
+                }
+
+                const amount = extractBillAmount(cleaned);
+                const billNo = extractBillNo(cleaned);
+                const amountInput = document.getElementById('amountInput');
+                const billNoInput = document.getElementById('billNoInput');
+                const filled = [];
+
+                if (amount && amountInput && (!amountInput.value || parseFloat(amountInput.value) === 0)) {
+                    amountInput.value = amount.toFixed(2);
+                    amountInput.dispatchEvent(new Event('input'));
+                    filled.push('Amount');
+                }
+                if (billNo && billNoInput && (!billNoInput.value || billNoInput.value === '0')) {
+                    billNoInput.value = billNo;
+                    filled.push('Bill No');
+                }
+
+                setOcrStatus(
+                    filled.length ? `Auto-filled ${filled.join(' & ')} from photo — please verify.` : 'Bill read OK.',
+                    'success'
+                );
+                checkFormReady();
+            } catch (e) {
+                if (token !== photoStageToken) return;
+                console.error('Bill OCR error:', e);
+                setOcrStatus('', '');
+            }
+        }
+
+        function setOcrStatus(msg, type) {
+            const el = document.getElementById('newEntryPhotoOcrStatus');
+            if (!el) return;
+            el.textContent = msg;
+            el.style.color = type === 'error' ? '#dc3545' : type === 'success' ? '#198754' : '#6c757d';
+        }
+
+        // Prefer a number on a line with "total"/"amount"/etc; fall back to the
+        // largest plausible currency-looking number anywhere in the text.
+        function extractBillAmount(text) {
+            const keywordRe = /(total|amount|amt|net\s*amt|grand\s*total)/i;
+            const numRe = /(?:₹|rs\.?|inr)?\s*([0-9]{1,3}(?:,[0-9]{3})*(?:\.[0-9]{1,2})?|[0-9]+\.[0-9]{1,2})/i;
+
+            for (const line of text.split('\n')) {
+                if (keywordRe.test(line)) {
+                    const m = line.match(numRe);
+                    if (m) {
+                        const val = parseFloat(m[1].replace(/,/g, ''));
+                        if (val > 0) return val;
+                    }
+                }
+            }
+
+            const allMatches = text.match(/[0-9]{1,3}(?:,[0-9]{3})*\.[0-9]{2}/g) || [];
+            const values = allMatches.map(s => parseFloat(s.replace(/,/g, ''))).filter(v => v > 0 && v < 1000000);
+            return values.length ? Math.max(...values) : null;
+        }
+
+        function extractBillNo(text) {
+            const m = text.match(/(?:bill|invoice|receipt)\s*(?:no\.?|number|#)?\s*[:\-]?\s*([A-Za-z0-9\/\-]{2,20})/i);
+            return m && m[1] ? m[1] : null;
         }
 
         // Uploads the staged photo against a just-saved entry. Returns the new


### PR DESCRIPTION
## Summary
Phase 1 of OCR on the DSM bill photo (see discussion in chat) — uses the Tesseract.js already loaded on this page for plate scanning, no new dependency or cost.

- Runs on the staged photo right after capture (Upload or Take Photo)
- Auto-fills Bill No / Amount **only into empty fields** — never overwrites what the DSM already typed
- Shows "Could not read bill clearly — retake?" when OCR finds almost no text
- Token-guarded against a late-resolving OCR result stomping a newer/cleared photo's fields

**Explicitly deferred, needs its own decision**: handwritten bills (Tesseract can't read handwriting) and real content moderation (blocking unsolicited/irrelevant photos) both need a vision-capable model call per upload — different cost profile, separate phase.

## Test plan
- [ ] Photo a printed thermal bill, confirm Bill No/Amount get filled and a "verify" toast/status shows
- [ ] Type an Amount manually first, then attach a photo — confirm OCR does NOT overwrite it
- [ ] Photo something blurry/blank, confirm the retake prompt shows and Save still works anyway