### PR TITLE
DSM bill photo: separate ALLOW_DSM_BILL_OCR gate

### DIFF
--- a/controllers/dsm-entry-controller.js
+++ b/controllers/dsm-entry-controller.js
@@ -16,6 +16,10 @@ module.exports = {
             const cashierId = user.Person_id;
 
             const allowBillPhoto = (await getLocationConfigValue(locationCode, 'ALLOW_DSM_BILL_PHOTO', 'N')) === 'Y';
+            // Separate from allowBillPhoto: a location can capture photos without
+            // OCR auto-fill (e.g. handwritten bills, or before the regex extraction
+            // has been tuned against a sample from that location's bill format).
+            const allowBillOcr = allowBillPhoto && (await getLocationConfigValue(locationCode, 'ALLOW_DSM_BILL_OCR', 'N')) === 'Y';
 
             // Check for active shift
             const activeClosing = await dsmEntryDao.getActiveClosing(cashierId, locationCode);
@@ -31,13 +35,15 @@ module.exports = {
                     credits: [],
                     entries,
                     allowBillPhoto,
+                    allowBillOcr,
                     pageData: JSON.stringify({
                         activeClosing: null,
                         products: [],
                         credits: [],
                         entries,
                         allVehicles: [],
-                        allowBillPhoto
+                        allowBillPhoto,
+                        allowBillOcr
                     })
                 });
             }
@@ -55,7 +61,8 @@ module.exports = {
                 credits,
                 entries,
                 allVehicles,
-                allowBillPhoto
+                allowBillPhoto,
+                allowBillOcr
             };
 
             return res.render("dsm-entry", {
@@ -66,6 +73,7 @@ module.exports = {
                 credits,
                 entries,
                 allowBillPhoto,
+                allowBillOcr,
                 pageData: JSON.stringify(pageData)
             });
 

--- a/db/migrations/dsm-bill-ocr-config.sql
+++ b/db/migrations/dsm-bill-ocr-config.sql
@@ -1,0 +1,21 @@
+-- Config gate for OCR auto-fill on the DSM bill-photo feature, separate from
+-- ALLOW_DSM_BILL_PHOTO (photo capture) — a location can capture photos without
+-- OCR (e.g. handwritten bills, or before the extraction regex has been tuned
+-- against a sample of that location's bill format). Server-side (getPage)
+-- ANDs this with allowBillPhoto, so this row is a no-op unless photo capture
+-- is also enabled.
+
+INSERT INTO m_location_config_catalog (setting_name, short_description, detailed_description, created_by, updated_by)
+VALUES
+('ALLOW_DSM_BILL_OCR', 'Enable OCR auto-fill for DSM bill photos',
+ 'Y/N. When Y (and ALLOW_DSM_BILL_PHOTO is also Y), the DSM entry screen runs Tesseract OCR on a captured bill photo and auto-fills Bill No / Amount into empty fields, plus flags an unreadable photo for retake. Default N. Requires the extraction regex to have been checked against a sample bill from this location first — Tesseract reads printed text only, not handwriting. Checked in dsm-entry-controller.js.',
+ 'system', 'system')
+ON DUPLICATE KEY UPDATE
+    short_description    = VALUES(short_description),
+    detailed_description = VALUES(detailed_description),
+    updated_by            = 'system';
+
+-- SFS: enabled to continue beta testing (2026-08-21). Regex NOT yet tuned
+-- against a confirmed SFS bill sample — revisit once one is reviewed.
+INSERT IGNORE INTO m_location_config (location_code, setting_name, setting_value, effective_start_date, effective_end_date, created_by, updated_by, creation_date, updation_date)
+VALUES ('SFS', 'ALLOW_DSM_BILL_OCR', 'Y', CURDATE(), '9999-12-31', 'system', 'system', NOW(), NOW());

--- a/views/dsm-entry.pug
+++ b/views/dsm-entry.pug
@@ -934,7 +934,7 @@ html(lang='en')
                 newEntryPhotoPreview.style.display = '';
                 newEntryPhotoButtons.style.display = 'none';
                 setOcrStatus('', '');
-                readBillPhoto(blob, myToken);
+                if (pageData.allowBillOcr) readBillPhoto(blob, myToken);
             } catch (e) {
                 console.error('Photo staging error:', e);
                 showToast('Could not process photo. Try again.', 'danger');


### PR DESCRIPTION
## Summary
Splits OCR auto-fill out from photo capture into its own config key, \`ALLOW_DSM_BILL_OCR\` (ANDed with \`ALLOW_DSM_BILL_PHOTO\` server-side). Lets a location capture bill photos without OCR running on them -- needed for handwritten-bill locations and any location whose bill format hasn't been reviewed/tuned yet. Enabled for SFS.

## Test plan
- [ ] SFS: OCR auto-fill still runs as before
- [ ] A location with photo=Y, ocr=N: photo capture/upload works, no OCR status text ever appears, no auto-fill