### PR TITLE
DSM bill photo: automatic edge-detect crop (jscanify/OpenCV.js)

### DIFF
--- a/controllers/dsm-entry-controller.js
+++ b/controllers/dsm-entry-controller.js
@@ -20,6 +20,11 @@ module.exports = {
             // OCR auto-fill (e.g. handwritten bills, or before the regex extraction
             // has been tuned against a sample from that location's bill format).
             const allowBillOcr = allowBillPhoto && (await getLocationConfigValue(locationCode, 'ALLOW_DSM_BILL_OCR', 'N')) === 'Y';
+            // Separate gate again: loads a heavy (~8-10MB) client-side CV library
+            // (OpenCV.js + jscanify) to auto-detect/crop the bill's edges. Kept
+            // independent so it can be switched off per-location without
+            // affecting photo capture or OCR if it misbehaves on a device.
+            const allowBillAutoCrop = allowBillPhoto && (await getLocationConfigValue(locationCode, 'ALLOW_DSM_BILL_AUTOCROP', 'N')) === 'Y';
 
             // Check for active shift
             const activeClosing = await dsmEntryDao.getActiveClosing(cashierId, locationCode);
@@ -36,6 +41,7 @@ module.exports = {
                     entries,
                     allowBillPhoto,
                     allowBillOcr,
+                    allowBillAutoCrop,
                     pageData: JSON.stringify({
                         activeClosing: null,
                         products: [],
@@ -43,7 +49,8 @@ module.exports = {
                         entries,
                         allVehicles: [],
                         allowBillPhoto,
-                        allowBillOcr
+                        allowBillOcr,
+                        allowBillAutoCrop
                     })
                 });
             }
@@ -62,7 +69,8 @@ module.exports = {
                 entries,
                 allVehicles,
                 allowBillPhoto,
-                allowBillOcr
+                allowBillOcr,
+                allowBillAutoCrop
             };
 
             return res.render("dsm-entry", {
@@ -74,6 +82,7 @@ module.exports = {
                 entries,
                 allowBillPhoto,
                 allowBillOcr,
+                allowBillAutoCrop,
                 pageData: JSON.stringify(pageData)
             });
 

--- a/db/migrations/dsm-bill-autocrop-config.sql
+++ b/db/migrations/dsm-bill-autocrop-config.sql
@@ -1,0 +1,21 @@
+-- Config gate for automatic bill-edge detection/crop on the DSM bill-photo
+-- feature, separate from ALLOW_DSM_BILL_PHOTO and ALLOW_DSM_BILL_OCR. Loads
+-- OpenCV.js + jscanify (client-side, ~8-10MB) to auto-detect and crop/deskew
+-- the bill like Adobe Scan. Kept as its own gate since it's the least proven
+-- of the three (needs real low-end-Android testing) and may need to be
+-- switched off quickly per-location without touching photo capture or OCR.
+
+INSERT INTO m_location_config_catalog (setting_name, short_description, detailed_description, created_by, updated_by)
+VALUES
+('ALLOW_DSM_BILL_AUTOCROP', 'Enable automatic bill-edge crop on DSM bill photos',
+ 'Y/N. When Y (and ALLOW_DSM_BILL_PHOTO is also Y), the DSM entry screen loads OpenCV.js + jscanify to auto-detect the bill''s edges and crop/straighten the photo before compression, like Adobe Scan. Falls back to the full uncropped photo whenever detection fails or looks unconfident -- never blocks saving. Default N. Adds a heavy (~8-10MB) client-side library load, gated separately so it can be disabled per-location without affecting photo capture or OCR. Checked in dsm-entry-controller.js.',
+ 'system', 'system')
+ON DUPLICATE KEY UPDATE
+    short_description    = VALUES(short_description),
+    detailed_description = VALUES(detailed_description),
+    updated_by            = 'system';
+
+-- SFS: enabled to trial on real beta devices (2026-08-21). Unproven on
+-- low-end Android -- watch for load-time/performance complaints.
+INSERT IGNORE INTO m_location_config (location_code, setting_name, setting_value, effective_start_date, effective_end_date, created_by, updated_by, creation_date, updation_date)
+VALUES ('SFS', 'ALLOW_DSM_BILL_AUTOCROP', 'Y', CURDATE(), '9999-12-31', 'system', 'system', NOW(), NOW());

--- a/views/dsm-entry.pug
+++ b/views/dsm-entry.pug
@@ -778,6 +778,23 @@ html(lang='en')
             handlePhotoFileSelected(this.files[0], 'CAMERA');
         });
 
+        // Loads a File/Blob into an HTMLImageElement. Standalone from
+        // compressImage so the auto-crop step (which needs a decoded image
+        // before compression happens) can reuse it.
+        function loadImageFromFile(file) {
+            return new Promise(function(resolve, reject) {
+                const reader = new FileReader();
+                reader.onerror = reject;
+                reader.onload = function(e) {
+                    const img = new Image();
+                    img.onerror = reject;
+                    img.onload = function() { resolve(img); };
+                    img.src = e.target.result;
+                };
+                reader.readAsDataURL(file);
+            });
+        }
+
         // Resize/compress client-side before upload — DSM phones are often old
         // Android devices on weak connections, so this cuts upload time and
         // bandwidth before the server-side size limit is even checked.
@@ -786,46 +803,101 @@ html(lang='en')
         // before JPEG encoding. Done via getImageData/putImageData rather than
         // ctx.filter = 'grayscale(1)' since the filter API isn't supported on
         // older Android WebViews these DSM phones may be running.
-        function compressImage(file, maxDim, quality) {
+        //
+        // `source` is either a File/Blob (the common case) or an already-decoded
+        // HTMLImageElement/HTMLCanvasElement (used when auto-crop has already
+        // produced one) — either way it ends up through the same resize/
+        // grayscale/encode pipeline.
+        async function compressImage(source, maxDim, quality) {
             maxDim = maxDim || 1600;
             quality = quality || 0.6;
+            const img = (source instanceof Blob) ? await loadImageFromFile(source) : source;
+            const srcWidth = img.naturalWidth || img.width;
+            const srcHeight = img.naturalHeight || img.height;
+
+            let width = srcWidth, height = srcHeight;
+            if (width > height && width > maxDim) {
+                height = Math.round(height * (maxDim / width));
+                width = maxDim;
+            } else if (height > maxDim) {
+                width = Math.round(width * (maxDim / height));
+                height = maxDim;
+            }
+            const canvas = document.createElement('canvas');
+            canvas.width = width;
+            canvas.height = height;
+            const ctx = canvas.getContext('2d');
+            ctx.drawImage(img, 0, 0, width, height);
+
+            const imageData = ctx.getImageData(0, 0, width, height);
+            const px = imageData.data;
+            for (let i = 0; i < px.length; i += 4) {
+                const gray = (px[i] * 0.299 + px[i + 1] * 0.587 + px[i + 2] * 0.114) | 0;
+                px[i] = px[i + 1] = px[i + 2] = gray;
+            }
+            ctx.putImageData(imageData, 0, 0);
+
             return new Promise(function(resolve, reject) {
-                const reader = new FileReader();
-                reader.onerror = reject;
-                reader.onload = function(e) {
-                    const img = new Image();
-                    img.onerror = reject;
-                    img.onload = function() {
-                        let width = img.width, height = img.height;
-                        if (width > height && width > maxDim) {
-                            height = Math.round(height * (maxDim / width));
-                            width = maxDim;
-                        } else if (height > maxDim) {
-                            width = Math.round(width * (maxDim / height));
-                            height = maxDim;
-                        }
-                        const canvas = document.createElement('canvas');
-                        canvas.width = width;
-                        canvas.height = height;
-                        const ctx = canvas.getContext('2d');
-                        ctx.drawImage(img, 0, 0, width, height);
-
-                        const imageData = ctx.getImageData(0, 0, width, height);
-                        const px = imageData.data;
-                        for (let i = 0; i < px.length; i += 4) {
-                            const gray = (px[i] * 0.299 + px[i + 1] * 0.587 + px[i + 2] * 0.114) | 0;
-                            px[i] = px[i + 1] = px[i + 2] = gray;
-                        }
-                        ctx.putImageData(imageData, 0, 0);
-
-                        canvas.toBlob(function(blob) {
-                            if (blob) resolve(blob); else reject(new Error('Compression failed'));
-                        }, 'image/jpeg', quality);
-                    };
-                    img.src = e.target.result;
-                };
-                reader.readAsDataURL(file);
+                canvas.toBlob(function(blob) {
+                    if (blob) resolve(blob); else reject(new Error('Compression failed'));
+                }, 'image/jpeg', quality);
             });
+        }
+
+        // ─── Automatic bill-edge detection/crop (Adobe-Scan-style) ─────────────
+        // Gated by ALLOW_DSM_BILL_AUTOCROP. Loads OpenCV.js + jscanify lazily —
+        // triggered once as soon as the New Entry photo section is available so
+        // the ~8-10MB download has a head start before the DSM actually takes a
+        // photo, rather than blocking on first tap.
+        let scannerLoadPromise = null;
+
+        function loadDocumentScanner() {
+            if (scannerLoadPromise) return scannerLoadPromise;
+            scannerLoadPromise = new Promise(function(resolve) {
+                const cvScript = document.createElement('script');
+                cvScript.src = 'https://docs.opencv.org/4.9.0/opencv.js';
+                cvScript.async = true;
+                cvScript.onerror = function() { resolve(false); };
+                cvScript.onload = function() {
+                    if (!window.cv) { resolve(false); return; }
+                    window.cv['onRuntimeInitialized'] = function() {
+                        const jsScanScript = document.createElement('script');
+                        jsScanScript.src = 'https://cdn.jsdelivr.net/npm/jscanify@1.3.1/src/jscanify.min.js';
+                        jsScanScript.async = true;
+                        jsScanScript.onerror = function() { resolve(false); };
+                        jsScanScript.onload = function() { resolve(!!window.jscanify); };
+                        document.head.appendChild(jsScanScript);
+                    };
+                };
+                document.head.appendChild(cvScript);
+            });
+            return scannerLoadPromise;
+        }
+
+        // Auto-detects and crops the bill from a decoded image, like Adobe Scan.
+        // Returns a cropped HTMLCanvasElement, or null if the scanner isn't
+        // ready/available or detection isn't confident — callers MUST fall back
+        // to the original uncropped image in that case, never block on this.
+        async function autoCropBillPhoto(imgEl) {
+            try {
+                const ready = await loadDocumentScanner();
+                if (!ready || !window.jscanify) return null;
+
+                const scanner = new window.jscanify();
+                const resultCanvas = scanner.extractPaper(imgEl, imgEl.naturalWidth, imgEl.naturalHeight);
+                if (!resultCanvas || !resultCanvas.width || !resultCanvas.height) return null;
+
+                // Reject an implausibly small crop relative to the original —
+                // more likely a false detection than the actual bill.
+                const cropArea = resultCanvas.width * resultCanvas.height;
+                const originalArea = imgEl.naturalWidth * imgEl.naturalHeight;
+                if (cropArea < originalArea * 0.15) return null;
+
+                return resultCanvas;
+            } catch (e) {
+                console.error('Auto-crop error:', e);
+                return null;
+            }
         }
 
         async function handlePhotoFileSelected(file, captureSource) {
@@ -920,11 +992,28 @@ html(lang='en')
             clearPendingPhoto();
         });
 
+        // Pre-warm the ~8-10MB scanner download in the background as soon as
+        // this section is live, rather than waiting for the first photo tap.
+        if (pageData.allowBillAutoCrop) {
+            loadDocumentScanner();
+        }
+
         async function stagePendingPhoto(file, captureSource) {
             if (!file) return;
             const myToken = ++photoStageToken;
             try {
-                const blob = await compressImage(file);
+                let source = file;
+                if (pageData.allowBillAutoCrop) {
+                    setOcrStatus('Detecting bill edges...', '');
+                    const img = await loadImageFromFile(file);
+                    if (myToken !== photoStageToken) return;
+                    const cropped = await autoCropBillPhoto(img);
+                    if (myToken !== photoStageToken) return;
+                    source = cropped || img; // fall back to the already-decoded full photo if crop failed
+                    setOcrStatus('', '');
+                }
+
+                const blob = await compressImage(source);
                 if (myToken !== photoStageToken) return; // a newer photo was staged/cleared while this one compressed
                 pendingPhotoBlob = blob;
                 pendingPhotoCaptureSource = captureSource;


### PR DESCRIPTION
## Summary
Adobe-Scan-style automatic bill cropping, gated by its own \`ALLOW_DSM_BILL_AUTOCROP\` config (ANDed with \`ALLOW_DSM_BILL_PHOTO\`), independent of OCR. Chosen over a manual drag-corner crop because DSM cashiers often have both hands full (phone, DU nozzle, cash) -- a single tap-and-done flow matters more than precision here.

- Loads OpenCV.js + jscanify lazily, pre-warmed in the background as soon as the New Entry photo section is live (not blocking page load)
- Runs edge detection + perspective crop on capture, before compression
- Always falls back to the full uncropped photo if the library isn't ready or the detected crop looks implausible (<15% of original area) -- never blocks Save
- \`compressImage()\` refactored to accept either a raw File or an already-decoded image/canvas, so cropped and uncropped paths share one compression pipeline

**Caveat**: I can't run a browser from this environment, so the OpenCV.js/jscanify integration (CDN URLs, init timing, \`extractPaper\` behavior) is unverified against a real device. Needs hands-on beta testing, especially load time and CPU cost on low-end Android.

## Test plan
- [ ] Take a bill photo on beta, confirm it gets auto-cropped to roughly the bill's edges
- [ ] Check console for script-load errors (wrong CDN path, jscanify API mismatch, etc.)
- [ ] Time how long the first photo takes on a slow/old device (background pre-warm should hide most of the ~8-10MB download)
- [ ] Photo something with no clear rectangular document (e.g. open background) -- confirm it falls back to the full photo instead of erroring or blocking save