### PR TITLE
Suppliers: Remittance Bank column + Edit modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -1570,16 +1570,20 @@ app.post('/lubes-invoice/save-from-pdf', isLoginEnsured, function(req, res, next
 
 // Get suppliers list
 app.get('/suppliers', [isLoginEnsured, security.isAdmin()], function (req, res) {
-    supplierController.findSuppliers(req.user.location_code).then(data => {
-        res.render('suppliers', { 
-            title: 'Suppliers', 
-            user: req.user, 
-            suppliers: data 
+    Promise.all([
+        supplierController.findSuppliers(req.user.location_code),
+        supplierController.findBanksByLocation(req.user.location_code)
+    ]).then(([suppliers, banks]) => {
+        res.render('suppliers', {
+            title: 'Suppliers',
+            user: req.user,
+            suppliers: suppliers,
+            banks: banks
         });
     }).catch(err => {
         console.error('Error fetching suppliers:', err);
-        res.status(500).render('error', { 
-            message: 'Error fetching suppliers' 
+        res.status(500).render('error', {
+            message: 'Error fetching suppliers'
         });
     });
 });
@@ -1591,11 +1595,15 @@ app.post('/suppliers', [isLoginEnsured, security.isAdmin()], function (req, res)
     SupplierDao.findSupplierByName(newSupplier.supplier_name, newSupplier.location_code).then(
         (data) => {
             if (data && data.length > 0) {
-                supplierController.findSuppliers(newSupplier.location_code).then((data) => {
+                Promise.all([
+                    supplierController.findSuppliers(newSupplier.location_code),
+                    supplierController.findBanksByLocation(newSupplier.location_code)
+                ]).then(([suppliers, banks]) => {
                     res.status(400).render('suppliers', {
                         title: 'Suppliers',
                         user: req.user,
-                        suppliers: data,
+                        suppliers: suppliers,
+                        banks: banks,
                         messages: { warning: msg.WARN_SUPPLIER_DUPLICATE }
                     });
                 });

--- a/app.js
+++ b/app.js
@@ -1620,9 +1620,33 @@ app.post('/suppliers', [isLoginEnsured, security.isAdmin()], function (req, res)
         }
     ).catch(err => {
         console.error('Error checking supplier existence:', err);
-        res.status(500).render('error', { 
-            message: 'Error processing supplier creation' 
+        res.status(500).render('error', {
+            message: 'Error processing supplier creation'
         });
+    });
+});
+
+// Update existing supplier
+app.put('/suppliers/:id', [isLoginEnsured, security.isAdmin()], function (req, res) {
+    supplierController.findById(req.params.id).then(existing => {
+        if (!existing) {
+            return res.status(404).json({ success: false, message: 'Supplier not found' });
+        }
+        supplierController.updateSupplier({
+            id: req.params.id,
+            name: req.body.name,
+            shortName: req.body.shortName,
+            gstin: req.body.gstin,
+            remittanceBankId: req.body.remittanceBankId
+        }, req.user.username).then(() => {
+            res.json({ success: true });
+        }).catch(err => {
+            console.error('Error updating supplier:', err);
+            res.status(500).json({ success: false, message: 'Error updating supplier' });
+        });
+    }).catch(err => {
+        console.error('Error checking supplier existence:', err);
+        res.status(500).json({ success: false, message: 'Error updating supplier' });
     });
 });
 

--- a/controllers/supplier-controller.js
+++ b/controllers/supplier-controller.js
@@ -16,6 +16,7 @@ module.exports = {
                             effective_start_date: dateFormat(supplier.effective_start_date, "dd-mm-yyyy"),
                             createdBy: supplier.created_by,
                             creation_date: dateFormat(supplier.creation_date, "dd-mm-yyyy"),
+                            gstin: supplier.gstin,
                             remittanceBankId: supplier.remittance_bank_id,
                             bankName: supplier.RemittanceBank ? (supplier.RemittanceBank.account_nickname || supplier.RemittanceBank.bank_name) : null
                         });
@@ -89,8 +90,8 @@ module.exports = {
                 supplier_id: supplierData.id,
                 supplier_name: supplierData.name,
                 supplier_short_name: supplierData.shortName,
-                location_code: supplierData.locationCode,
-                location_id: supplierData.locationId,
+                gstin: supplierData.gstin || null,
+                remittance_bank_id: supplierData.remittanceBankId || null,
                 updated_by: username,
                 updation_date: new Date()
             };
@@ -104,6 +105,10 @@ module.exports = {
                     reject(err);
                 });
         });
+    },
+
+    findById: (supplierId) => {
+        return SupplierDao.findById(supplierId);
     },
 
     disableSupplier: (supplierId, username) => {

--- a/controllers/supplier-controller.js
+++ b/controllers/supplier-controller.js
@@ -15,7 +15,9 @@ module.exports = {
                             locationCode: supplier.location_code,
                             effective_start_date: dateFormat(supplier.effective_start_date, "dd-mm-yyyy"),
                             createdBy: supplier.created_by,
-                            creation_date: dateFormat(supplier.creation_date, "dd-mm-yyyy")
+                            creation_date: dateFormat(supplier.creation_date, "dd-mm-yyyy"),
+                            remittanceBankId: supplier.remittance_bank_id,
+                            bankName: supplier.RemittanceBank ? (supplier.RemittanceBank.account_nickname || supplier.RemittanceBank.bank_name) : null
                         });
                     });
                     resolve(suppliers);
@@ -25,6 +27,10 @@ module.exports = {
                     reject(err);
                 });
         });
+    },
+
+    findBanksByLocation: (locationCode) => {
+        return SupplierDao.findBanksByLocation(locationCode);
     },
 
     findDisabledSuppliers: (locationCode) => {

--- a/dao/supplier-dao.js
+++ b/dao/supplier-dao.js
@@ -1,5 +1,6 @@
 const db = require("../db/db-connection");
 const Supplier = db.m_supplier;
+const Bank = db.m_bank;
 const { Op } = require("sequelize");
 const utils = require("../utils/app-utils");
 const Sequelize = require("sequelize");
@@ -16,13 +17,23 @@ module.exports = {
                         { 'effective_end_date': { [Op.gte]: currentDate } }
                     ]
                 },
+                include: [{ model: Bank, as: 'RemittanceBank', attributes: ['bank_id', 'bank_name', 'account_nickname'] }],
                 order: [
                     ['effective_start_date', 'ASC']
                 ]
             });
         } else {
-            return Supplier.findAll();
+            return Supplier.findAll({
+                include: [{ model: Bank, as: 'RemittanceBank', attributes: ['bank_id', 'bank_name', 'account_nickname'] }]
+            });
         }
+    },
+
+    findBanksByLocation: (locationCode) => {
+        return Bank.findAll({
+            where: { location_code: locationCode },
+            order: [['account_nickname', 'ASC'], ['bank_name', 'ASC']]
+        });
     },
 
     findSupplierByName: (supplierName, locationCode) => {

--- a/db/db-connection.js
+++ b/db/db-connection.js
@@ -135,6 +135,8 @@ db.location.hasMany(db.txn_truck_expense, {foreignKey:'expense_cost_center_id'})
 db.txn_truck_expense.belongsTo(db.location, {foreignKey:'expense_cost_center_id'});
 db.m_bank.hasMany(db.txn_bank_account, {foreignKey: 'bank_id'});
 db.txn_bank_account.belongsTo(db.m_bank,{foreignKey: 'bank_id'});
+db.m_bank.hasMany(db.m_supplier, {foreignKey: 'remittance_bank_id'});
+db.m_supplier.belongsTo(db.m_bank, {foreignKey: 'remittance_bank_id', as: 'RemittanceBank'});
 db.location.hasMany(db.m_bank, {foreignKey: 'location_id'});
 db.m_bank.belongsTo(db.location, {foreignKey: 'location_id'});
 db.location.hasMany(db.txn_bank_account, {foreignKey: 'location_id'});

--- a/db/suppliers.js
+++ b/db/suppliers.js
@@ -25,6 +25,11 @@ module.exports = function(sequelize, DataTypes) {
             allowNull: true,
             comment: 'Supplier GSTIN for GST ITC claims'
         },
+        remittance_bank_id: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+            field: 'remittance_bank_id'
+        },
         location_id: {
             type: DataTypes.INTEGER,
             allowNull: true,

--- a/db/ui-db-field-mapping.js
+++ b/db/ui-db-field-mapping.js
@@ -216,12 +216,13 @@ module.exports = {
             supplier_short_name: req.body.supplier_short_name_0,
             location_code: req.user.location_code,
             location_id: req.user.location_id,
+            remittance_bank_id: req.body.remittance_bank_id_0 || null,
             created_by: req.user.username,
             creation_date: now,
             effective_start_date: now,
             effective_end_date: '9999-12-31 23:59:59'
         };
-    },    
+    },
     newVehicle: function (req, rowIndex = 0) {
         const data = {
             creditlist_id: req.body.creditlist_id,

--- a/public/javascripts/app-master-page-scripts.js
+++ b/public/javascripts/app-master-page-scripts.js
@@ -139,6 +139,10 @@ function hideMasterEntryRow(prefix, rowId) {
         for (let input of inputs) {
             input.value = '';
         }
+        const selects = row.getElementsByTagName('select');
+        for (let select of selects) {
+            select.value = '';
+        }
     }
 }
 

--- a/views/mixins/mixins.pug
+++ b/views/mixins/mixins.pug
@@ -204,7 +204,7 @@ mixin addNewVehicle(rowCnt)
         input(type='hidden', name='vehicles_' + rowCnt + '_hiddenId', id='vehicles_' + rowCnt + '_hiddenId')
 
 
-mixin addNewSupplier(rowCnt)
+mixin addNewSupplier(rowCnt, banks)
     - let id = 'suppliers-table-row-' + rowCnt;
     tr(class='d-md-none' id=id)
         th(scope="row")
@@ -212,6 +212,12 @@ mixin addNewSupplier(rowCnt)
             input.form-control(type='text', name='supplier_name_'+ rowCnt, id='supplier_name_'+ rowCnt, placeholder="Supplier Name", required)
         td(scope="row")
             input.form-control(type='text', name='supplier_short_name_'+ rowCnt, id='supplier_short_name_'+ rowCnt, placeholder="Short Name", required)
+        td(scope="row")
+            select.form-control(name='remittance_bank_id_'+ rowCnt, id='remittance_bank_id_'+ rowCnt)
+                option(value="") Select Bank
+                if banks
+                    each bank in banks
+                        option(value=bank.bank_id)= bank.account_nickname || bank.bank_name
         td(scope="row")
             button.close(type="button" aria-label="Close" onclick='hideMasterEntryRow(\'suppliers\', \'' + id + '\')', id = id + '_close')
                 span(aria-hidden="true") &times;

--- a/views/suppliers.pug
+++ b/views/suppliers.pug
@@ -11,7 +11,7 @@ block content
                     th(scope="col") Short Name
                     th(scope="col") Remittance Bank
                     th(scope="col") Start Date
-                    th(scope="col") Disable Supplier
+                    th(scope="col") Actions
             tbody
                 each val, index in suppliers
                     tr(id='supplier-' + index)
@@ -22,6 +22,9 @@ block content
                         td= val.effective_start_date
                         td
                             div.align-items-start
+                                button.btn.btn-primary(id="edit-supplier-"+index, title="Edit Supplier", data-toggle="modal", data-target="#editSupplierModal", onclick="openEditSupplierModal('"+index+"')")
+                                    span.oi.oi-pencil
+                                span &nbsp;
                                 button.btn.btn-info(id="disable-supplier-"+index, onclick="disableSupplier('"+index+"', '"+ val.id +"')")
                                     span.oi.oi-delete
                 - var rowCnt = 0
@@ -33,3 +36,75 @@ block content
             button.btn.btn-info(type="button", onClick="showSupplierMasterEntryRow(this, 'suppliers')", id='suppliers-add-new', title="Only one can be added at a time.") Add New
             span &nbsp;&nbsp;&nbsp;&nbsp;
             button.btn.btn-primary(type="submit", disabled=true, title="Enabled on 'Add New'", id='suppliers-save') Save
+
+    // Edit Supplier Modal
+    .modal.fade#editSupplierModal(tabindex="-1", role="dialog")
+        .modal-dialog(role="document")
+            .modal-content
+                .modal-header
+                    h5.modal-title Edit Supplier
+                    button.close(type="button", data-dismiss="modal", aria-label="Close")
+                        span(aria-hidden="true") &times;
+                .modal-body
+                    form#editSupplierForm
+                        input(type="hidden", name="supplier_id", id="edit_supplier_id")
+                        .form-group
+                            label Name *
+                            input.form-control(type="text", name="name", id="edit_supplier_name", required)
+                        .form-group
+                            label Short Name *
+                            input.form-control(type="text", name="shortName", id="edit_supplier_short_name", required)
+                        .form-group
+                            label GSTIN
+                            input.form-control(type="text", name="gstin", id="edit_supplier_gstin", maxlength="15")
+                        .form-group
+                            label Remittance Bank
+                            select.form-control(name="remittanceBankId", id="edit_supplier_remittance_bank_id")
+                                option(value="") Select Bank
+                                if banks
+                                    each bank in banks
+                                        option(value=bank.bank_id)= bank.account_nickname || bank.bank_name
+                .modal-footer
+                    button.btn.btn-secondary(type="button", data-dismiss="modal") Cancel
+                    button.btn.btn-primary(type="button", onclick="saveSupplierEdit()") Save
+
+    script.
+        let suppliersData = !{JSON.stringify(suppliers || [])};
+
+        function openEditSupplierModal(index) {
+            const supplier = suppliersData[index];
+            if (!supplier) return;
+            document.getElementById('edit_supplier_id').value = supplier.id;
+            document.getElementById('edit_supplier_name').value = supplier.name || '';
+            document.getElementById('edit_supplier_short_name').value = supplier.shortName || '';
+            document.getElementById('edit_supplier_gstin').value = supplier.gstin || '';
+            document.getElementById('edit_supplier_remittance_bank_id').value = supplier.remittanceBankId || '';
+        }
+
+        function saveSupplierEdit() {
+            const supplierId = document.getElementById('edit_supplier_id').value;
+            const payload = {
+                name: document.getElementById('edit_supplier_name').value,
+                shortName: document.getElementById('edit_supplier_short_name').value,
+                gstin: document.getElementById('edit_supplier_gstin').value,
+                remittanceBankId: document.getElementById('edit_supplier_remittance_bank_id').value
+            };
+
+            fetch('/suppliers/' + supplierId, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    window.location.reload();
+                } else {
+                    alert(data.message || 'Error updating supplier');
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('Error updating supplier');
+            });
+        }

--- a/views/suppliers.pug
+++ b/views/suppliers.pug
@@ -9,6 +9,7 @@ block content
                     th(scope="col") #
                     th(scope="col") Name
                     th(scope="col") Short Name
+                    th(scope="col") Remittance Bank
                     th(scope="col") Start Date
                     th(scope="col") Disable Supplier
             tbody
@@ -17,6 +18,7 @@ block content
                         th(scope="row")= index + 1
                         td= val.name
                         td= val.shortName
+                        td= val.bankName || '-'
                         td= val.effective_start_date
                         td
                             div.align-items-start
@@ -24,7 +26,7 @@ block content
                                     span.oi.oi-delete
                 - var rowCnt = 0
                 while rowCnt < 1
-                    +addNewSupplier(rowCnt++)
+                    +addNewSupplier(rowCnt++, banks)
         div(align="center")
             button.btn.btn-primary(type="button", onClick="window.location.href='/enable-supplier'", id="enable-supplier", title="Enable Supplier") Enable Supplier
             span &nbsp;&nbsp;&nbsp;&nbsp;


### PR DESCRIPTION
## Summary
- `m_supplier.remittance_bank_id` existed in prod DB (feeding ledger-rules sync triggers for GL accounting) but was never surfaced in the app.
- Adds a Remittance Bank column to the Suppliers master page, with a bank dropdown on add-new.
- Adds an Edit modal (Name, Short Name, GSTIN, Remittance Bank) per row, since the page previously had no way to edit an existing supplier.

## Test plan
- [x] Verified prod DB already has `remittance_bank_id` column + INSERT/UPDATE ledger-rule sync triggers on `m_supplier` (read-only check)
- [x] Deployed and tested on beta
- [x] Template compiles, associations load without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)