### PR TITLE
Bank upload: fix false date-mismatch block on summary rows

### DIFF
--- a/controllers/transaction-upload-controller.js
+++ b/controllers/transaction-upload-controller.js
@@ -862,8 +862,12 @@ previewTransactions: async (req, res) => {
                 // it. Rows with no amount (headers, opening/closing balance,
                 // blank separators) or with both debit AND credit set
                 // (total/summary rows) are expected to fail date parsing and
-                // are skipped exactly as before.
-                if ((debitAmount > 0) !== (creditAmount > 0) && rawDateValue) {
+                // are skipped exactly as before. A label like "TOTAL" with
+                // only one side non-zero (e.g. an all-credit statement
+                // period) would otherwise also trip this — require the date
+                // cell to contain at least a digit before treating it as a
+                // plausible-but-misformatted date.
+                if ((debitAmount > 0) !== (creditAmount > 0) && rawDateValue && /\d/.test(String(rawDateValue))) {
                     dateFormatMismatches.push({ row: i + 1, value: rawDateValue, debitAmount, creditAmount });
                 }
                 continue;  // skip opening/closing balance and summary rows


### PR DESCRIPTION
## Summary
- A statement's TOTAL/summary row with a text-only date cell (e.g. "TOTAL") and exactly one of debit/credit non-zero was misidentified as a genuine transaction with a bad date, blocking the entire upload.
- Only surfaces when a statement period is all-credit or all-debit (first hit: CUB, SFS, 21-22 Aug 2026 statement) — normal TOTAL rows have both debit and credit set and were already skipped.
- Fix: require the date cell to contain at least one digit before treating it as a plausible-but-misformatted date. Verified against retained prod upload samples (CUB, IOB/MUE) — no regression, and the original Jul 9 fix's protection against silent bad-date imports is preserved.

## Test plan
- [x] Reproduced against the actual failing CUB file pulled from prod's retained-debug folder — confirms fix resolves it
- [x] Re-ran logic against a real MUE/IOB sample file — 0 flags before and after (no regression)
- [ ] Re-upload the CUB statement on beta after deploy to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)