### PR TITLE
Products: fix Non-Fuel flag resetting on edit for non-SuperUser

### DIFF
--- a/views/products.pug
+++ b/views/products.pug
@@ -556,10 +556,10 @@ block content
                 if (tankCheckbox) {
                     tankCheckbox.checked = !!product.is_tank_product;
                 }
-                const lubeCheckbox = document.getElementById('edit-is-lube-product');
-                if (lubeCheckbox) {
-                    lubeCheckbox.checked = !!product.is_lube_product;
-                }
+            }
+            const lubeCheckbox = document.getElementById('edit-is-lube-product');
+            if (lubeCheckbox) {
+                lubeCheckbox.checked = !!product.is_lube_product;
             }
 
             $('#editProductModal').modal('show');


### PR DESCRIPTION
## Summary
- Edit modal's Non-Fuel Product checkbox was only synced to the product's real value for SuperUser; non-SuperUsers always saw it unchecked, and the save handler always sends the checkbox state, so any edit (e.g. a price change) by a non-SuperUser silently reset lube products to non-lube.
- Fix: sync the checkbox from `product.is_lube_product` for all roles (still `disabled` for non-SuperUser, so they still cannot change it themselves).

## Test plan
- [ ] Log in as non-SuperUser, edit a lube product's price, save, confirm Non-Fuel flag stays set
- [ ] Confirm non-SuperUser still cannot toggle the checkbox (disabled)
- [ ] Confirm SuperUser edit flow unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)