### PR TITLE
Products: fix Non-Fuel flag resetting on edit for non-SuperUser

### DIFF
--- a/views/products.pug
+++ b/views/products.pug
@@ -556,10 +556,10 @@ block content
                 if (tankCheckbox) {
                     tankCheckbox.checked = !!product.is_tank_product;
                 }
-                const lubeCheckbox = document.getElementById('edit-is-lube-product');
-                if (lubeCheckbox) {
-                    lubeCheckbox.checked = !!product.is_lube_product;
-                }
+            }
+            const lubeCheckbox = document.getElementById('edit-is-lube-product');
+            if (lubeCheckbox) {
+                lubeCheckbox.checked = !!product.is_lube_product;
             }
 
             $('#editProductModal').modal('show');


### PR DESCRIPTION
## Summary
- Edit modal's Non-Fuel Product checkbox was only synced to the product's real value for SuperUser; non-SuperUsers always saw it unchecked, and the save handler always sends the checkbox state, so any edit (e.g. a price change) by a non-SuperUser silently reset lube products to non-lube.
- Fix: sync the checkbox from `product.is_lube_product` for all roles (still `disabled` for non-SuperUser, so they still cannot change it themselves).
- Already verified on beta via PR #833.

## Test plan
- [x] Verified on beta
- [ ] Confirm on prod after deploy: non-SuperUser can edit a lube product's price without the Non-Fuel flag resetting

🤖 Generated with [Claude Code](https://claude.com/claude-code)