### PR TITLE
Onboarding: Account Heads guard, metered product price, customer short_name, full config hints

### DIFF
--- a/controllers/onboarding-controller.js
+++ b/controllers/onboarding-controller.js
@@ -201,22 +201,25 @@ module.exports = {
 
     adminConfigHints: async (req, res, next) => {
         try {
+            // All setting names that exist anywhere — not just ones with a row on the
+            // reference locations, so nothing is silently invisible on the review screen.
+            const allNames = await db.sequelize.query(
+                `SELECT DISTINCT setting_name FROM m_location_config ORDER BY setting_name`,
+                { type: QueryTypes.SELECT }
+            );
             const rows = await db.sequelize.query(
                 `SELECT location_code, setting_name, setting_value
                  FROM m_location_config
-                 WHERE location_code IN (:locs)
-                 ORDER BY setting_name, location_code`,
-                { replacements: { locs: CONFIG_HINT_LOCATIONS }, type: QueryTypes.SELECT }
+                 WHERE location_code IN (:locs)`,
+                { replacements: { locs: [...CONFIG_HINT_LOCATIONS, '*'] }, type: QueryTypes.SELECT }
             );
-            // Pivot: setting_name → { MUE: val, SFS: val, AACBE: val }
+            // Pivot: setting_name → { '*': val, MUE: val, SFS: val, AACBE: val }
             const map = {};
             for (const row of rows) {
                 if (!map[row.setting_name]) map[row.setting_name] = {};
                 map[row.setting_name][row.location_code] = row.setting_value;
             }
-            const hints = Object.entries(map)
-                .sort(([a], [b]) => a.localeCompare(b))
-                .map(([name, vals]) => ({ name, ...vals }));
+            const hints = allNames.map(({ setting_name: name }) => ({ name, ...(map[name] || {}) }));
             res.json(hints);
         } catch (e) {
             next(e);

--- a/controllers/onboarding-migrate-controller.js
+++ b/controllers/onboarding-migrate-controller.js
@@ -158,9 +158,9 @@ module.exports = {
                 if (exists) return 'skipped';
                 const rgb = PRODUCT_RGB[(p.short_name || '').toUpperCase()] || '200,200,200';
                 await insertRow(
-                    `INSERT INTO m_product (product_name, location_code, qty, unit, is_tank_product, rgb_color, hsn_code, cgst_percent, sgst_percent, created_by, updated_by)
-                     VALUES (:name, :loc, 1, 'Litres', 1, :rgb, :hsn, :cgst, :sgst, 'onboarding', 'onboarding')`,
-                    { name: up(p.product_name), loc, rgb, hsn: up(p.hsn_code) || null, cgst: p.cgst_percent ?? null, sgst: p.sgst_percent ?? null }
+                    `INSERT INTO m_product (product_name, location_code, qty, unit, price, is_tank_product, rgb_color, hsn_code, cgst_percent, sgst_percent, created_by, updated_by)
+                     VALUES (:name, :loc, 1, 'Litres', :price, 1, :rgb, :hsn, :cgst, :sgst, 'onboarding', 'onboarding')`,
+                    { name: up(p.product_name), loc, price: p.selling_price || null, rgb, hsn: up(p.hsn_code) || null, cgst: p.cgst_percent ?? null, sgst: p.sgst_percent ?? null }
                 );
             }));
 
@@ -282,25 +282,57 @@ module.exports = {
                     );
                     if (rb) remitBankId = rb.bank_id;
                 }
+                // No separate short-name field is collected on the onboarding sheet —
+                // default it from the customer name so m_credit_list.short_name isn't left blank.
+                const shortName = up(c.customer_name).substring(0, 20);
                 await insertRow(
-                    `INSERT INTO m_credit_list (Company_Name, location_code, card_flag, Opening_Balance, gst, address, type, remittance_bank_id, effective_start_date, effective_end_date, creation_date, created_by, updated_by)
-                     VALUES (:name, :loc, 'N', 0, :gst, :address, :type, :remitBankId, CURDATE(), '9999-12-31', NOW(), 'onboarding', 'onboarding')`,
-                    { name: up(c.customer_name), loc, gst: up(c.gstin) || null, address: up(c.address) || null, type: c.customer_type || null, remitBankId }
+                    `INSERT INTO m_credit_list (Company_Name, location_code, card_flag, Opening_Balance, gst, address, type, short_name, remittance_bank_id, effective_start_date, effective_end_date, creation_date, created_by, updated_by)
+                     VALUES (:name, :loc, 'N', 0, :gst, :address, :type, :shortName, :remitBankId, CURDATE(), '9999-12-31', NOW(), 'onboarding', 'onboarding')`,
+                    { name: up(c.customer_name), loc, gst: up(c.gstin) || null, address: up(c.address) || null, type: c.customer_type || null, shortName, remitBankId }
                 );
             }));
 
             // ── Step 10: Account Heads (copy from template) ───────────────────────
+            // Inserts only heads missing by name — location creation (Step 1) already
+            // seeds 15 cashflow heads via trg_location_seed_data, so an all-or-nothing
+            // "does this location have any heads at all" guard would always skip here.
             {
-                const [countRow] = await db.sequelize.query(
-                    'SELECT COUNT(*) AS cnt FROM m_account_heads WHERE location_code = :loc',
-                    { replacements: { loc }, type: QueryTypes.SELECT }
-                );
-                if (countRow.cnt > 0) {
-                    results.push({ section: 'Account Heads', inserted: 0, skipped: countRow.cnt, errors: ['Already exist — skipped'] });
-                } else {
-                    try {
-                        // 5a: Copy all common heads (exclude any oil-company-specific heads)
-                        // JOIN to gl_ledger_groups so gl_group_id is resolved by name for the new location
+                try {
+                    const [beforeCountRow] = await db.sequelize.query(
+                        'SELECT COUNT(*) AS cnt FROM m_account_heads WHERE location_code = :loc',
+                        { replacements: { loc }, type: QueryTypes.SELECT }
+                    );
+
+                    // 10a: Copy common heads missing by name (exclude any oil-company-specific heads)
+                    // JOIN to gl_ledger_groups so gl_group_id is resolved by name for the new location
+                    await db.sequelize.query(
+                        `INSERT INTO m_account_heads
+                            (location_code, account_head_name, account_head_type, allowed_entry_type,
+                             notes_required_flag, active_flag, effective_start_date, effective_end_date,
+                             gl_group_id, created_by, updated_by, creation_date, updation_date)
+                         SELECT :loc, ah.account_head_name, ah.account_head_type, ah.allowed_entry_type,
+                            ah.notes_required_flag, ah.active_flag, ah.effective_start_date, ah.effective_end_date,
+                            new_grp.group_id, 'system', 'system', NOW(), NOW()
+                         FROM m_account_heads ah
+                         LEFT JOIN gl_ledger_groups tmpl_grp ON tmpl_grp.group_id       = ah.gl_group_id
+                         LEFT JOIN gl_ledger_groups new_grp   ON new_grp.location_code  = :loc
+                                                              AND new_grp.group_name     = tmpl_grp.group_name
+                         WHERE ah.location_code = :tmpl
+                           AND ah.account_head_name NOT IN (
+                               'IOCL LICENSE FEE RECOVERY', 'IOCL CHARGES',
+                               'BPCL LICENSE FEE RECOVERY', 'BPCL CHARGES'
+                           )
+                           AND NOT EXISTS (
+                               SELECT 1 FROM m_account_heads existing
+                               WHERE existing.location_code = :loc
+                                 AND existing.account_head_name = ah.account_head_name
+                           )`,
+                        { replacements: { loc, tmpl }, type: QueryTypes.INSERT }
+                    );
+
+                    // 10b: Add the oil-company-specific heads matching this location's brand, if missing
+                    const ocHeads = OC_HEADS_BY_BRAND[ro.ro_brand];
+                    if (ocHeads) {
                         await db.sequelize.query(
                             `INSERT INTO m_account_heads
                                 (location_code, account_head_name, account_head_type, allowed_entry_type,
@@ -310,46 +342,28 @@ module.exports = {
                                 ah.notes_required_flag, ah.active_flag, ah.effective_start_date, ah.effective_end_date,
                                 new_grp.group_id, 'system', 'system', NOW(), NOW()
                              FROM m_account_heads ah
-                             LEFT JOIN gl_ledger_groups tmpl_grp ON tmpl_grp.group_id       = ah.gl_group_id
-                             LEFT JOIN gl_ledger_groups new_grp   ON new_grp.location_code  = :loc
-                                                                  AND new_grp.group_name     = tmpl_grp.group_name
+                             LEFT JOIN gl_ledger_groups tmpl_grp ON tmpl_grp.group_id      = ah.gl_group_id
+                             LEFT JOIN gl_ledger_groups new_grp   ON new_grp.location_code = :loc
+                                                                  AND new_grp.group_name    = tmpl_grp.group_name
                              WHERE ah.location_code = :tmpl
-                               AND ah.account_head_name NOT IN (
-                                   'IOCL LICENSE FEE RECOVERY', 'IOCL CHARGES',
-                                   'BPCL LICENSE FEE RECOVERY', 'BPCL CHARGES'
+                               AND ah.account_head_name IN (:head1, :head2)
+                               AND NOT EXISTS (
+                                   SELECT 1 FROM m_account_heads existing
+                                   WHERE existing.location_code = :loc
+                                     AND existing.account_head_name = ah.account_head_name
                                )`,
-                            { replacements: { loc, tmpl }, type: QueryTypes.INSERT }
+                            { replacements: { loc, tmpl, head1: ocHeads[0], head2: ocHeads[1] }, type: QueryTypes.INSERT }
                         );
-
-                        // 5b: Add the oil-company-specific heads matching this location's brand
-                        const ocHeads = OC_HEADS_BY_BRAND[ro.ro_brand];
-                        if (ocHeads) {
-                            await db.sequelize.query(
-                                `INSERT INTO m_account_heads
-                                    (location_code, account_head_name, account_head_type, allowed_entry_type,
-                                     notes_required_flag, active_flag, effective_start_date, effective_end_date,
-                                     gl_group_id, created_by, updated_by, creation_date, updation_date)
-                                 SELECT :loc, ah.account_head_name, ah.account_head_type, ah.allowed_entry_type,
-                                    ah.notes_required_flag, ah.active_flag, ah.effective_start_date, ah.effective_end_date,
-                                    new_grp.group_id, 'system', 'system', NOW(), NOW()
-                                 FROM m_account_heads ah
-                                 LEFT JOIN gl_ledger_groups tmpl_grp ON tmpl_grp.group_id      = ah.gl_group_id
-                                 LEFT JOIN gl_ledger_groups new_grp   ON new_grp.location_code = :loc
-                                                                      AND new_grp.group_name    = tmpl_grp.group_name
-                                 WHERE ah.location_code = :tmpl
-                                   AND ah.account_head_name IN (:head1, :head2)`,
-                                { replacements: { loc, tmpl, head1: ocHeads[0], head2: ocHeads[1] }, type: QueryTypes.INSERT }
-                            );
-                        }
-
-                        const [newCountRow] = await db.sequelize.query(
-                            'SELECT COUNT(*) AS cnt FROM m_account_heads WHERE location_code = :loc',
-                            { replacements: { loc }, type: QueryTypes.SELECT }
-                        );
-                        results.push({ section: 'Account Heads', inserted: newCountRow.cnt, skipped: 0, errors: [] });
-                    } catch (e) {
-                        results.push({ section: 'Account Heads', inserted: 0, skipped: 0, errors: [e.message] });
                     }
+
+                    const [afterCountRow] = await db.sequelize.query(
+                        'SELECT COUNT(*) AS cnt FROM m_account_heads WHERE location_code = :loc',
+                        { replacements: { loc }, type: QueryTypes.SELECT }
+                    );
+                    const insertedCount = afterCountRow.cnt - beforeCountRow.cnt;
+                    results.push({ section: 'Account Heads', inserted: insertedCount, skipped: beforeCountRow.cnt, errors: [] });
+                } catch (e) {
+                    results.push({ section: 'Account Heads', inserted: 0, skipped: 0, errors: [e.message] });
                 }
             }
 

--- a/dao/onboarding-dao.js
+++ b/dao/onboarding-dao.js
@@ -4,7 +4,7 @@ const { QueryTypes } = require('sequelize');
 
 const SECTION_MAP = {
     'employees':        { table: 't_onboarding_employees',        fields: ['employee_name', 'designation'] },
-    'metered-products': { table: 't_onboarding_metered_products', fields: ['product_name', 'short_name', 'hsn_code', 'cgst_percent', 'sgst_percent'] },
+    'metered-products': { table: 't_onboarding_metered_products', fields: ['product_name', 'short_name', 'hsn_code', 'cgst_percent', 'sgst_percent', 'selling_price'] },
     'tanks':            { table: 't_onboarding_tanks',            fields: ['tank_name', 'tank_capacity', 'tank_short_name', 'product_short_name'] },
     'nozzles':          { table: 't_onboarding_nozzles',          fields: ['nozzle_name', 'nozzle_product', 'du_make', 'tank_connected', 'next_stamping_date'] },
     'lubes':            { table: 't_onboarding_lubes',            fields: ['product_name', 'unit', 'selling_price', 'hsn_code', 'cgst_percent', 'sgst_percent'] },

--- a/db/migrations/onboarding-metered-product-price.sql
+++ b/db/migrations/onboarding-metered-product-price.sql
@@ -1,0 +1,5 @@
+-- Add Selling Price to onboarding metered products, same as t_onboarding_lubes already has.
+-- Without it, m_product.price is NULL for MS/HSD/etc. after migrate, but that field is a
+-- required, pre-filled input on the live shift-closing form (views/mixins/new-closing-mixins.pug).
+ALTER TABLE t_onboarding_metered_products
+    ADD COLUMN selling_price DECIMAL(10, 2) NULL AFTER sgst_percent;

--- a/public/javascripts/onboarding-form.js
+++ b/public/javascripts/onboarding-form.js
@@ -199,6 +199,7 @@ function buildNewRow(section, id) {
         'metered-products': `<tr ${a}>
             <td data-label="Product Name"><input class="form-control form-control-sm" type="text" data-field="product_name" placeholder="As per Invoice e.g. EBMS"></td>
             <td data-label="Short Name"><input class="form-control form-control-sm" type="text" data-field="short_name" placeholder="e.g. MS / HSD"></td>
+            <td data-label="Selling Price"><input class="form-control form-control-sm" type="number" step="0.01" data-field="selling_price" placeholder="0.00"></td>
             <td data-label="HSN Code"><input class="form-control form-control-sm" type="text" data-field="hsn_code" placeholder="e.g. 27101290" maxlength="20"></td>
             <td data-label="CGST %"><input class="form-control form-control-sm" type="number" step="0.01" min="0" max="50" data-field="cgst_percent" placeholder="e.g. 9"></td>
             <td data-label="SGST %"><input class="form-control form-control-sm" type="number" step="0.01" min="0" max="50" data-field="sgst_percent" placeholder="e.g. 9"></td>

--- a/views/onboarding/admin-detail.pug
+++ b/views/onboarding/admin-detail.pug
@@ -416,15 +416,16 @@ block content
                     })
                     .then(function(hints) {
                         var el = document.getElementById('configHintTable');
-                        if (!hints.length) { el.innerHTML = '<p class="text-muted small mb-0">No location configs found for MUE / SFS / AACBE.</p>'; return; }
+                        if (!hints.length) { el.innerHTML = '<p class="text-muted small mb-0">No location config settings found.</p>'; return; }
                         // Pre-fill new-location column from brand template (IOCL→MUE, BPCL→SFS)
                         var tmplCol = OB_RO_BRAND === 'IOCL' ? 'MUE' : (OB_RO_BRAND === 'BPCL' ? 'SFS' : null);
                         var h = '<div class="table-responsive mt-1"><table class="table table-sm table-bordered mb-0" style="font-size:12px" id="configHintsTable">';
-                        h += '<thead class="thead-light"><tr><th>Setting</th><th>MUE<br><small class="font-weight-normal text-muted">IOCL</small></th><th>SFS<br><small class="font-weight-normal text-muted">BPCL</small></th><th>AACBE</th><th style="min-width:110px">New Location</th></tr></thead><tbody>';
+                        h += '<thead class="thead-light"><tr><th>Setting</th><th>Default</th><th>MUE<br><small class="font-weight-normal text-muted">IOCL</small></th><th>SFS<br><small class="font-weight-normal text-muted">BPCL</small></th><th>AACBE</th><th style="min-width:110px">New Location</th></tr></thead><tbody>';
                         hints.forEach(function(row) {
                             var prefill = tmplCol ? (row[tmplCol] || '') : '';
                             h += '<tr>';
                             h += '<td>' + row.name + '</td>';
+                            h += '<td>' + (row['*'] || '<span class="text-muted">—</span>') + '</td>';
                             h += '<td>' + (row.MUE || '<span class="text-muted">—</span>') + '</td>';
                             h += '<td>' + (row.SFS || '<span class="text-muted">—</span>') + '</td>';
                             h += '<td>' + (row.AACBE || '<span class="text-muted">—</span>') + '</td>';

--- a/views/onboarding/form.pug
+++ b/views/onboarding/form.pug
@@ -179,6 +179,7 @@ html(lang="en")
                                     tr
                                         th Product Name (as per Invoice)
                                         th Short Name
+                                        th Selling Price (₹)
                                         th HSN Code
                                         th CGST %
                                         th SGST %
@@ -188,6 +189,7 @@ html(lang="en")
                                         tr(data-section="metered-products" data-row-id=row.id)
                                             td(data-label="Product Name"): input.form-control.form-control-sm(type="text" data-field="product_name" value=(row.product_name||'') placeholder="e.g. EBMS, HSD")
                                             td(data-label="Short Name"): input.form-control.form-control-sm(type="text" data-field="short_name" value=(row.short_name||'') placeholder="e.g. MS / HSD")
+                                            td(data-label="Selling Price"): input.form-control.form-control-sm(type="number" step="0.01" data-field="selling_price" value=(row.selling_price||'') placeholder="0.00")
                                             td(data-label="HSN Code"): input.form-control.form-control-sm(type="text" data-field="hsn_code" value=(row.hsn_code||'') placeholder="e.g. 27101290" maxlength="20")
                                             td(data-label="CGST %"): input.form-control.form-control-sm(type="number" step="0.01" min="0" max="50" data-field="cgst_percent" value=(row.cgst_percent!=null?row.cgst_percent:'') placeholder="e.g. 9")
                                             td(data-label="SGST %"): input.form-control.form-control-sm(type="number" step="0.01" min="0" max="50" data-field="sgst_percent" value=(row.sgst_percent!=null?row.sgst_percent:'') placeholder="e.g. 9")


### PR DESCRIPTION
## Summary
- Step 10 (Account Heads) guard now inserts only missing heads by name, instead of an all-or-nothing count check that always skips now that location creation pre-seeds 15 cashflow heads.
- Metered Products tab gets a Selling Price field, written into `m_product.price` on migrate (was NULL, but it's a required pre-filled field on the live shift-closing form).
- Customers get a default `short_name` (from `customer_name`, truncated to 20 chars) since the onboarding sheet never collected one.
- Config Hints panel now shows every `m_location_config` setting name (was hiding ~46 of 71) plus the `*` global default.

## Why
Found during live onboarding testing for Balaa Fuels (BAF) on prod.

## Test plan
- [ ] Run `db/migrations/onboarding-metered-product-price.sql` on dev DB after merge
- [ ] Run `npm run minify` + PM2 restart on beta (onboarding-form.js changed)
- [ ] Verify Metered Products tab shows Selling Price, Config Hints shows full list with Default column, a fresh migrate run gives new customers a short_name and full account heads