### PR TITLE
Onboarding: collapse product/short name, remove Tank Short Name, naming pre-flight warning

### DIFF
--- a/controllers/onboarding-controller.js
+++ b/controllers/onboarding-controller.js
@@ -71,7 +71,13 @@ module.exports = {
             if (!OnboardingDao.SECTION_MAP[section]) return res.status(400).json({ error: 'Invalid section' });
             const onboarding = await OnboardingDao.findByToken(token);
             if (!onboarding) return res.status(404).json({ error: 'Not found' });
-            await OnboardingDao.updateRow(onboarding.id, section, parseInt(rowId, 10), req.body);
+            const data = { ...req.body };
+            // Tank Short Name isn't shown on the form anymore (it confused users into
+            // re-typing the product code there) — auto-derive it from Tank Name instead.
+            if (section === 'tanks' && 'tank_name' in data) {
+                data.tank_short_name = (data.tank_name || '').trim().toUpperCase().replace(/\s+/g, '');
+            }
+            await OnboardingDao.updateRow(onboarding.id, section, parseInt(rowId, 10), data);
             res.json({ ok: true });
         } catch (e) {
             next(e);

--- a/controllers/onboarding-migrate-controller.js
+++ b/controllers/onboarding-migrate-controller.js
@@ -149,18 +149,21 @@ module.exports = {
             }));
 
             // ── Step 3: Metered Products (with RGB color) ────────────────────────
+            // short_name is the sole name field (no separate "as per Invoice" name) —
+            // it's what Tanks/Nozzles reference, so it must also be what lands in
+            // m_product.product_name or tank/pump linkage silently breaks after migrate.
             results.push(await runSection('Metered Products', data.metered_products, async (p) => {
-                if (!p.product_name) return 'skipped';
+                if (!p.short_name) return 'skipped';
                 const exists = await selectOne(
                     'SELECT product_id FROM m_product WHERE product_name = :name AND location_code = :loc AND is_tank_product = 1',
-                    { name: up(p.product_name), loc }
+                    { name: up(p.short_name), loc }
                 );
                 if (exists) return 'skipped';
                 const rgb = PRODUCT_RGB[(p.short_name || '').toUpperCase()] || '200,200,200';
                 await insertRow(
                     `INSERT INTO m_product (product_name, location_code, qty, unit, price, is_tank_product, rgb_color, hsn_code, cgst_percent, sgst_percent, created_by, updated_by)
                      VALUES (:name, :loc, 1, 'Litres', :price, 1, :rgb, :hsn, :cgst, :sgst, 'onboarding', 'onboarding')`,
-                    { name: up(p.product_name), loc, price: p.selling_price || null, rgb, hsn: up(p.hsn_code) || null, cgst: p.cgst_percent ?? null, sgst: p.sgst_percent ?? null }
+                    { name: up(p.short_name), loc, price: p.selling_price || null, rgb, hsn: up(p.hsn_code) || null, cgst: p.cgst_percent ?? null, sgst: p.sgst_percent ?? null }
                 );
             }));
 

--- a/dao/onboarding-dao.js
+++ b/dao/onboarding-dao.js
@@ -4,7 +4,7 @@ const { QueryTypes } = require('sequelize');
 
 const SECTION_MAP = {
     'employees':        { table: 't_onboarding_employees',        fields: ['employee_name', 'designation'] },
-    'metered-products': { table: 't_onboarding_metered_products', fields: ['product_name', 'short_name', 'hsn_code', 'cgst_percent', 'sgst_percent', 'selling_price'] },
+    'metered-products': { table: 't_onboarding_metered_products', fields: ['short_name', 'hsn_code', 'cgst_percent', 'sgst_percent', 'selling_price'] },
     'tanks':            { table: 't_onboarding_tanks',            fields: ['tank_name', 'tank_capacity', 'tank_short_name', 'product_short_name'] },
     'nozzles':          { table: 't_onboarding_nozzles',          fields: ['nozzle_name', 'nozzle_product', 'du_make', 'tank_connected', 'next_stamping_date'] },
     'lubes':            { table: 't_onboarding_lubes',            fields: ['product_name', 'unit', 'selling_price', 'hsn_code', 'cgst_percent', 'sgst_percent'] },

--- a/public/javascripts/onboarding-form.js
+++ b/public/javascripts/onboarding-form.js
@@ -197,8 +197,7 @@ function buildNewRow(section, id) {
             <td class="text-center align-middle">${del}</td></tr>`,
 
         'metered-products': `<tr ${a}>
-            <td data-label="Product Name"><input class="form-control form-control-sm" type="text" data-field="product_name" placeholder="As per Invoice e.g. EBMS"></td>
-            <td data-label="Short Name"><input class="form-control form-control-sm" type="text" data-field="short_name" placeholder="e.g. MS / HSD"></td>
+            <td data-label="Product Name"><input class="form-control form-control-sm" type="text" data-field="short_name" placeholder="e.g. MS / HSD / XP95"></td>
             <td data-label="Selling Price"><input class="form-control form-control-sm" type="number" step="0.01" data-field="selling_price" placeholder="0.00"></td>
             <td data-label="HSN Code"><input class="form-control form-control-sm" type="text" data-field="hsn_code" placeholder="e.g. 27101290" maxlength="20"></td>
             <td data-label="CGST %"><input class="form-control form-control-sm" type="number" step="0.01" min="0" max="50" data-field="cgst_percent" placeholder="e.g. 9"></td>
@@ -208,7 +207,6 @@ function buildNewRow(section, id) {
         'tanks': `<tr ${a}>
             <td data-label="Tank Name"><input class="form-control form-control-sm" type="text" data-field="tank_name" data-no-space="true" placeholder="No spaces e.g. TANK1"></td>
             <td data-label="Capacity (L)"><input class="form-control form-control-sm" type="number" data-field="tank_capacity" placeholder="15000"></td>
-            <td data-label="Short Name"><input class="form-control form-control-sm" type="text" data-field="tank_short_name" placeholder="e.g. MS1"></td>
             <td data-label="Product"><select class="form-control form-control-sm" data-field="product_short_name">${productOpts()}</select></td>
             <td class="text-center align-middle">${del}</td></tr>`,
 

--- a/views/onboarding/admin-detail.pug
+++ b/views/onboarding/admin-detail.pug
@@ -99,11 +99,9 @@ block content
                         thead.thead-light
                             tr
                                 th Product Name
-                                th Short Name
                         tbody
                             each p in formData.metered_products
                                 tr
-                                    td= p.product_name || '—'
                                     td= p.short_name || '—'
                 else
                     p.text-muted.mb-0 No entries
@@ -115,14 +113,12 @@ block content
                             tr
                                 th Tank Name
                                 th Capacity (L)
-                                th Short Name
                                 th Product
                         tbody
                             each t in formData.tanks
                                 tr
                                     td= t.tank_name || '—'
                                     td= t.tank_capacity || '—'
-                                    td= t.tank_short_name || '—'
                                     td= t.product_short_name || '—'
                 else
                     p.text-muted.mb-0 No entries
@@ -261,8 +257,8 @@ block content
                                 each p in formData.metered_products
                                     tr(data-tax-section="metered-products" data-tax-id=p.id)
                                         td.small.text-muted Metered
-                                        td.small= p.product_name || '—'
                                         td.small= p.short_name || '—'
+                                        td.small —
                                         td: input.form-control.form-control-sm(type="text" list="hsnDatalist" class="tax-hsn" value=(p.hsn_code||'') placeholder="e.g. 27101290")
                                         td: input.form-control.form-control-sm(type="number" step="0.01" min="0" max="50" class="tax-cgst" value=(p.cgst_percent!=null?p.cgst_percent:'') placeholder="e.g. 9")
                                         td: input.form-control.form-control-sm(type="number" step="0.01" min="0" max="50" class="tax-sgst" value=(p.sgst_percent!=null?p.sgst_percent:'') placeholder="e.g. 9")
@@ -342,12 +338,13 @@ block content
             var issues = [], warnings = [];
 
             // Build lookup sets (case-insensitive)
+            var STANDARD_SHORT_NAMES = ['MS', 'HSD', 'XP95', 'XMS'];
             var productSN = new Set();
             (fd.metered_products || []).forEach(function(p) {
                 var sn = (p.short_name || '').trim().toUpperCase();
-                if (sn) productSN.add(sn);
-                if (!p.product_name || !p.product_name.trim()) issues.push('Metered product row with empty name');
-                else if (!sn) warnings.push('Product "' + p.product_name + '" has no Short Name — name will be used as product_code in tanks/nozzles');
+                if (!sn) { issues.push('Metered product row with empty name'); return; }
+                productSN.add(sn);
+                if (STANDARD_SHORT_NAMES.indexOf(sn) === -1) warnings.push('Product "' + sn + '" — expected MS / HSD / XP95 (or XMS). Non-standard names still work but won\'t get the app\'s built-in rate-entry/display handling — verify this is intentional before migrating.');
             });
 
             var tankNames = new Set();

--- a/views/onboarding/form.pug
+++ b/views/onboarding/form.pug
@@ -171,14 +171,13 @@ html(lang="en")
                         .d-flex.justify-content-between.align-items-center.mb-2.section-row
                             div
                                 h6.mb-0 Metered Products
-                                p.section-hint.mb-0 Products sold through Dispensing Units. Short Name is used across Tanks and Nozzles tabs. HSN &amp; GST% will be verified by PetroMath admin before import.
+                                p.section-hint.mb-0 Products sold through Dispensing Units. Use the short canonical name (MS, HSD, XP95) — this is used across Tanks and Nozzles tabs and becomes the product's name in PetroMath. HSN &amp; GST% will be verified by PetroMath admin before import.
                             button.btn.btn-primary.btn-sm(type="button" data-add-section="metered-products") + Add Row
                         .table-responsive
                             table.table.table-sm.table-bordered.ob-table
                                 thead
                                     tr
-                                        th Product Name (as per Invoice)
-                                        th Short Name
+                                        th Product Name
                                         th Selling Price (₹)
                                         th HSN Code
                                         th CGST %
@@ -187,8 +186,7 @@ html(lang="en")
                                 tbody#tbody-metered-products
                                     each row in formData.metered_products
                                         tr(data-section="metered-products" data-row-id=row.id)
-                                            td(data-label="Product Name"): input.form-control.form-control-sm(type="text" data-field="product_name" value=(row.product_name||'') placeholder="e.g. EBMS, HSD")
-                                            td(data-label="Short Name"): input.form-control.form-control-sm(type="text" data-field="short_name" value=(row.short_name||'') placeholder="e.g. MS / HSD")
+                                            td(data-label="Product Name"): input.form-control.form-control-sm(type="text" data-field="short_name" value=(row.short_name||'') placeholder="e.g. MS / HSD / XP95")
                                             td(data-label="Selling Price"): input.form-control.form-control-sm(type="number" step="0.01" data-field="selling_price" value=(row.selling_price||'') placeholder="0.00")
                                             td(data-label="HSN Code"): input.form-control.form-control-sm(type="text" data-field="hsn_code" value=(row.hsn_code||'') placeholder="e.g. 27101290" maxlength="20")
                                             td(data-label="CGST %"): input.form-control.form-control-sm(type="number" step="0.01" min="0" max="50" data-field="cgst_percent" value=(row.cgst_percent!=null?row.cgst_percent:'') placeholder="e.g. 9")
@@ -210,7 +208,6 @@ html(lang="en")
                                     tr
                                         th Tank Name
                                         th Capacity (L)
-                                        th Short Name
                                         th Product
                                         th(width="50")
                                 tbody#tbody-tanks
@@ -218,7 +215,6 @@ html(lang="en")
                                         tr(data-section="tanks" data-row-id=row.id)
                                             td(data-label="Tank Name"): input.form-control.form-control-sm(type="text" data-field="tank_name" data-no-space="true" value=(row.tank_name||'') placeholder="No spaces e.g. TANK1")
                                             td(data-label="Capacity (L)"): input.form-control.form-control-sm(type="number" data-field="tank_capacity" value=(row.tank_capacity||'') placeholder="15000")
-                                            td(data-label="Short Name"): input.form-control.form-control-sm(type="text" data-field="tank_short_name" value=(row.tank_short_name||'') placeholder="e.g. MS1")
                                             td(data-label="Product")
                                                 select.form-control.form-control-sm(data-field="product_short_name")
                                                     option(value="" selected=!row.product_short_name) -- Select --


### PR DESCRIPTION
## Summary
- Metered Products: dropped the separate "Product Name (as per Invoice)" field; `short_name` is now the sole name field and is what migrate writes into `m_product.product_name`. Fixes the recurring EBMS/HSD-BSVI mismatch (GAC2, BAF, BAF2 all hit this).
- Tanks tab: removed the "Short Name" input (never read by migrate, confused users into duplicating the product code there). Now auto-derived server-side from Tank Name.
- Pre-flight check: warns if a metered product's name isn't MS/HSD/XP95/XMS, before migration instead of after.

## Why
Found during live onboarding testing (BAF, BAF2) on prod/beta.

## Test plan
- [ ] Verify Metered Products tab shows one "Product Name" field, no separate invoice-name field
- [ ] Verify Tanks tab no longer shows Short Name column
- [ ] Run a fresh migrate and confirm m_product.product_name matches the tank/pump product_code exactly
- [ ] Verify pre-flight warning fires for a non-standard product short name