### PR TITLE
Move credit sale add/edit to a modal instead of cramped inline table rows

### DIFF
--- a/public/javascripts/app-scripts.js
+++ b/public/javascripts/app-scripts.js
@@ -2851,13 +2851,11 @@ function showAddedDigitalSalesRow(prefix) {
     }
 }
 
-// Create a wrapper function that calls showAddedRow and then initializes vehicle select2
+// Wrapper that calls the generic showAddedRow for the credit sales table.
+// Vehicle select2 initialization now happens lazily inside the Add/Edit modal
+// (see credit-entry-modal.js) since the row stays off-screen until it's opened there.
 function showAddedCreditRow() {
-    // First call the existing showAddedRow function
     showAddedRow('credit', calculateCreditTotal);
-    
-    // Then initialize Select2 for any new vehicle dropdowns
-    initializeNewVehicleSelects();
     applyCreditBillDateConstraints();
 }
 
@@ -2867,29 +2865,6 @@ if (document.readyState === 'loading') {
     });
 } else {
     applyCreditBillDateConstraints();
-}
-
-// Function to initialize Select2 for newly added rows
-function initializeNewVehicleSelects() {
-    const prefix = 'credit-';
-    const userRowsCnt = document.getElementById(prefix + 'table').rows.length;
-    
-    for (let i = 0; i < userRowsCnt; i++) {
-        const vehicleSelectId = prefix + 'vehicle-' + i;
-        const vehicleSelect = document.getElementById(vehicleSelectId);
-        
-        if (vehicleSelect && !$(vehicleSelect).hasClass('select2-hidden-accessible')) {
-            $(vehicleSelect).select2({
-                placeholder: 'Search vehicle number...',
-                allowClear: true,
-                width: '100%',
-                minimumInputLength: 0,
-                theme: 'default'
-            });
-            
-            // REMOVED: Vehicle-first auto-population event handler
-        }
-    }
 }
 
 // Optional: Validate that selected vehicle belongs to selected credit party

--- a/public/javascripts/credit-entry-modal.js
+++ b/public/javascripts/credit-entry-modal.js
@@ -1,0 +1,238 @@
+// Credit sales tab: Add/Edit via a shared modal instead of cramped inline table editing.
+//
+// The credit table (see +addCredits in new-closing-mixins.pug) renders two rows per
+// line: a compact, read-only summary row that's always visible, and a hidden detail
+// row holding the real, submitted form fields (same ids/names as before, unchanged).
+// Opening a row for add/edit moves its actual field elements into the shared
+// #creditEntryModal; closing the modal moves them back. Nothing about how the fields
+// are collected/saved (saveCreditSales, calculateTotal, hideRow, etc.) changes.
+
+var creditModalState = { rowNo: null, isNew: false, savedThisSession: false, deleteRequested: false, moved: {} };
+
+var CREDIT_MODAL_SIMPLE_FIELDS = ['bill-date', 'product', 'billno', 'creditparty', 'odometer', 'price', 'discount', 'qty', 'amt', 'notes'];
+
+function creditFieldEl(rowNo, field) {
+    return document.getElementById('credit-' + field + '-' + rowNo);
+}
+
+function moveCreditFieldToSlot(rowNo, field, slotId) {
+    var el = creditFieldEl(rowNo, field);
+    var slot = document.getElementById(slotId);
+    if (el && slot) {
+        creditModalState.moved[field] = { el: el, parent: el.parentNode, next: el.nextSibling };
+        slot.appendChild(el);
+    }
+}
+
+function moveCreditVehicleWrapToSlot(rowNo) {
+    var wrap = document.getElementById('credit-vehicle-wrap-' + rowNo);
+    var slot = document.getElementById('creditModalSlot-vehiclewrap');
+    if (wrap && slot) {
+        creditModalState.moved.vehiclewrap = { el: wrap, parent: wrap.parentNode, next: wrap.nextSibling };
+        slot.appendChild(wrap);
+    }
+}
+
+function moveCreditOffMeterToSlot(rowNo) {
+    var el = document.getElementById('credit-off-meter-' + rowNo);
+    var slot = document.getElementById('creditModalSlot-off-meter');
+    if (el && slot) {
+        creditModalState.moved['off-meter'] = { el: el, parent: el.parentNode, next: el.nextSibling };
+        slot.appendChild(el);
+    }
+}
+
+function restoreCreditModalFields() {
+    Object.keys(creditModalState.moved).forEach(function (field) {
+        var info = creditModalState.moved[field];
+        if (!info) return;
+        if (info.next && info.next.parentNode === info.parent) {
+            info.parent.insertBefore(info.el, info.next);
+        } else {
+            info.parent.appendChild(info.el);
+        }
+    });
+    creditModalState.moved = {};
+}
+
+// Vehicle select2 is initialized lazily here (rather than eagerly on page load) because
+// the detail row stays off-screen (display:none) until it's opened in this modal, and
+// select2 mis-measures its width when initialized on a hidden element.
+function initVehicleSelect2ForModal(rowNo) {
+    var select = document.getElementById('credit-vehicle-' + rowNo);
+    if (!select || typeof $ === 'undefined') return;
+    var $select = $(select);
+    if ($select.hasClass('select2-hidden-accessible')) {
+        $select.select2('destroy');
+    }
+    $select.select2({
+        placeholder: 'Search vehicle number...',
+        allowClear: true,
+        width: '100%',
+        minimumInputLength: 0,
+        theme: 'default',
+        dropdownParent: $('#creditEntryModal')
+    });
+}
+
+function findNextAvailableCreditRow() {
+    var table = document.getElementById('credit-table');
+    if (!table) return null;
+    var rowsCnt = table.rows.length;
+    for (var i = 0; i < rowsCnt; i++) {
+        var tr = document.getElementById('credit-table-row-' + i);
+        if (tr && tr.className === 'd-md-none') return i;
+    }
+    return null;
+}
+
+// "Add credits" button: reuses the existing showAddedCreditRow() to find/enable the
+// next free row and keep its side effects (default product price, total, etc.), then
+// immediately opens that row in the modal.
+function handleAddCreditRowClick() {
+    var rowNo = findNextAvailableCreditRow();
+    showAddedCreditRow();
+    if (rowNo === null) return; // showAddedCreditRow already alerted "max reached"
+    openCreditRowModal(rowNo, true);
+}
+
+function openCreditRowModal(rowNo, isNew) {
+    creditModalState.rowNo = rowNo;
+    creditModalState.isNew = !!isNew;
+    creditModalState.savedThisSession = false;
+    creditModalState.deleteRequested = false;
+
+    var titleEl = document.getElementById('creditEntryModalTitleText');
+    if (titleEl) titleEl.textContent = isNew ? 'Add Credit Sale' : 'Edit Credit Sale';
+    var deleteBtn = document.getElementById('creditModalDeleteBtn');
+    if (deleteBtn) deleteBtn.style.display = isNew ? 'none' : '';
+
+    $('#creditEntryModal').modal('show');
+
+    CREDIT_MODAL_SIMPLE_FIELDS.forEach(function (field) {
+        moveCreditFieldToSlot(rowNo, field, 'creditModalSlot-' + field);
+    });
+    moveCreditVehicleWrapToSlot(rowNo);
+    moveCreditOffMeterToSlot(rowNo);
+    initVehicleSelect2ForModal(rowNo);
+}
+
+function saveCreditRowModal() {
+    var rowNo = creditModalState.rowNo;
+    if (rowNo === null || rowNo === undefined) return;
+
+    var amtEl = creditFieldEl(rowNo, 'amt');
+    var creditPartyEl = creditFieldEl(rowNo, 'creditparty');
+    var amt = amtEl && amtEl.value ? currenciesAsFloat(amtEl.value) : 0;
+
+    if (amt > 0 && creditPartyEl && !creditPartyEl.value) {
+        alert('Please select a Company before saving this credit sale.');
+        return;
+    }
+
+    if (creditModalState.isNew && amt <= 0) {
+        // Nothing meaningful entered - closing without data discards the row.
+        $('#creditEntryModal').modal('hide');
+        return;
+    }
+
+    creditModalState.savedThisSession = true;
+    var detailTr = document.getElementById('credit-table-row-' + rowNo);
+    if (detailTr) detailTr.className = '';
+    $('#creditEntryModal').modal('hide');
+}
+
+function deleteCreditRowModal() {
+    var rowNo = creditModalState.rowNo;
+    if (rowNo === null || rowNo === undefined) return;
+    if (!confirm('Delete this credit sale entry?')) return;
+    creditModalState.deleteRequested = true;
+    $('#creditEntryModal').modal('hide');
+}
+
+// Delete button on the compact summary row (row isn't open in the modal).
+function deleteCreditRow(rowNo) {
+    if (!confirm('Delete this credit sale entry?')) return;
+    performCreditRowDelete(rowNo);
+}
+
+function performCreditRowDelete(rowNo) {
+    hideRow('credit-table-row-' + rowNo, 'remove-credit-sale', function () {
+        calculateCreditTotal();
+        refreshCreditSummaryRow(rowNo);
+    });
+}
+
+$(document).on('hidden.bs.modal', '#creditEntryModal', function () {
+    var rowNo = creditModalState.rowNo;
+    if (rowNo === null || rowNo === undefined) return;
+
+    restoreCreditModalFields();
+
+    if (creditModalState.deleteRequested) {
+        performCreditRowDelete(rowNo);
+    } else if (creditModalState.isNew && !creditModalState.savedThisSession) {
+        // Closed (X / Close / Esc) without saving a newly added row - discard it.
+        performCreditRowDelete(rowNo);
+    } else {
+        refreshCreditSummaryRow(rowNo);
+        calculateCreditTotal();
+    }
+
+    creditModalState.rowNo = null;
+    creditModalState.isNew = false;
+    creditModalState.savedThisSession = false;
+    creditModalState.deleteRequested = false;
+});
+
+function refreshCreditSummaryRow(rowNo) {
+    var detailTr = document.getElementById('credit-table-row-' + rowNo);
+    var summaryTr = document.getElementById('credit-summary-row-' + rowNo);
+    if (!detailTr || !summaryTr) return;
+
+    var isUsed = detailTr.className !== 'd-md-none';
+    summaryTr.classList.toggle('d-md-none', !isUsed);
+
+    if (!isUsed) {
+        ['date', 'product', 'billno', 'company', 'vehicle', 'amt'].forEach(function (field) {
+            setCreditSummaryText('credit-summary-' + field + '-' + rowNo, '');
+        });
+        return;
+    }
+
+    var dateEl = creditFieldEl(rowNo, 'bill-date');
+    setCreditSummaryText('credit-summary-date-' + rowNo, dateEl ? dateEl.value : '');
+    setCreditSummaryText('credit-summary-product-' + rowNo, selectedCreditOptionText(creditFieldEl(rowNo, 'product')));
+    var billNoEl = creditFieldEl(rowNo, 'billno');
+    setCreditSummaryText('credit-summary-billno-' + rowNo, billNoEl ? billNoEl.value : '');
+    setCreditSummaryText('credit-summary-company-' + rowNo, selectedCreditOptionText(creditFieldEl(rowNo, 'creditparty')));
+    setCreditSummaryText('credit-summary-vehicle-' + rowNo, selectedCreditOptionText(document.getElementById('credit-vehicle-' + rowNo)));
+    var amtEl = creditFieldEl(rowNo, 'amt');
+    var amtVal = amtEl && amtEl.value ? currenciesAsFloat(amtEl.value) : 0;
+    setCreditSummaryText('credit-summary-amt-' + rowNo, formatCurrencies(amtVal || 0, toFixedValue));
+}
+
+function setCreditSummaryText(id, text) {
+    var el = document.getElementById(id);
+    if (el) el.textContent = text || '';
+}
+
+function selectedCreditOptionText(select) {
+    if (!select || select.selectedIndex < 0) return '';
+    var opt = select.options[select.selectedIndex];
+    return opt ? opt.text : '';
+}
+
+function initCreditSummaryRows() {
+    var rows = document.querySelectorAll('[id^="credit-table-row-"]');
+    rows.forEach(function (tr) {
+        var rowNo = tr.id.replace('credit-table-row-', '');
+        refreshCreditSummaryRow(rowNo);
+    });
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initCreditSummaryRows);
+} else {
+    initCreditSummaryRows();
+}

--- a/views/edit-draft-closing.pug
+++ b/views/edit-draft-closing.pug
@@ -373,20 +373,29 @@ block content
                             white-space: nowrap; /* keeps headers on one line */
                         }
 
-                        /* Column width tuning */
-                        #credit-table .col-product   { width: 12%; }
-                        #credit-table .col-bill      { width: 7%; }
-                        #credit-table .col-company   { width: 14%; }
-                        #credit-table .col-vehicle   { width: 10%; }
-                        #credit-table .col-odo       { width: 8%; }
-                        #credit-table .col-date      { width: 9%; }
-                        #credit-table .col-price     { width: 7%; }
-                        #credit-table .col-discount  { width: 6%; }  /* small field */
-                        #credit-table .col-qty       { width: 6%; }
-                        #credit-table .col-sale      { width: 10%; } /* extra space for sale */
-                        #credit-table .col-notes     { width: 10%; }
-                        #credit-table .col-off-meter { width: 5%; text-align: center; }
-                        #credit-table .col-delete    { width: 3%; text-align: center; }
+                        /* Column width tuning for the compact summary list */
+                        #credit-table .col-date      { width: 12%; }
+                        #credit-table .col-product   { width: 14%; }
+                        #credit-table .col-bill      { width: 10%; }
+                        #credit-table .col-company   { width: 22%; }
+                        #credit-table .col-vehicle   { width: 18%; }
+                        #credit-table .col-sale      { width: 12%; }
+                        #credit-table .col-actions   { width: 12%; text-align: center; }
+
+                        #credit-table tbody tr.credit-summary-row td {
+                            vertical-align: middle;
+                        }
+                        #credit-table .credit-summary-cell span:empty::before {
+                            content: '\2014'; /* em dash placeholder */
+                            color: #999;
+                        }
+                        #credit-table .credit-summary-actions {
+                            text-align: center;
+                            white-space: nowrap;
+                        }
+                        #credit-table .credit-summary-actions .btn {
+                            line-height: 1;
+                        }
                     div
                         div.col-16
                             div.table-responsive
@@ -399,32 +408,24 @@ block content
                                                 th.col-bill(scope="col") Bill #
                                                 th.col-company(scope="col") Company
                                                 th.col-vehicle(scope="col") Vehicle Number
-                                                th.col-odo(scope="col") Odometer
-                                                th.col-price(scope="col") Price
-                                                th.col-discount(scope="col") Price Discount
-                                                th.col-qty(scope="col") Quantity
                                                 th.col-sale(scope="col") Sale
-                                                th.col-notes(scope="col") Notes
-                                                if allowOffMeterSale
-                                                    th.col-off-meter(scope="col") Off Meter
-                                                if(!freezedRecord)
-                                                    th.col-delete(scope="col")
+                                                th.col-actions(scope="col") Actions
                                             - var rowCnt = 0
                                             while rowCnt < maxCreditsRowCnt
                                                 +addCredits(rowCnt, t_credits[rowCnt++])
 
                                             tr
                                                 td(colspan=5)
-                                                td Total
-                                                td
-                                                    input.form-control#credit-total(type='text' name='credit-total' readonly value='0')
+                                                td.text-right
+                                                    strong Total:&nbsp;
+                                                    input.form-control.d-inline-block(style='width:120px' type='text' name='credit-total' id='credit-total' readonly value='0')
                                                 td
 
                     div.row
                         div.col &nbsp;
                     div.row
                         div.col(align="center")
-                            button.btn.btn-info(type="button", onClick="showAddedCreditRow()") Add credits
+                            button.btn.btn-info(type="button", onClick="handleAddCreditRowClick()") Add credits
 
                     div.row
                         div.col &nbsp;
@@ -757,6 +758,8 @@ block content
         window.pumpsData = !{JSON.stringify(pumps)};
         window.productValuesData = !{JSON.stringify(productValues)}; 
         window.allowSecondaryPump = !{allowSecondaryPump};
+    // Credit sale Add/Edit modal (shared by the compact credit sales list)
+    +creditEntryModal(allowOffMeterSale)
     // Quick Add Vehicle Modal
     .modal.fade#quickAddVehicleModal(tabindex='-1' role='dialog' aria-labelledby='quickAddVehicleModalLabel' aria-hidden='true')
         .modal-dialog(role='document')
@@ -777,4 +780,5 @@ block content
                     button.btn.btn-secondary(type='button' data-dismiss='modal') Cancel
                     button.btn.btn-success#quickAddVehicleSaveBtn(type='button' onclick='quickSaveVehicle()') Add Vehicle
     script(src=`/javascripts/shift-products.js?v=${CACHE_BUST}`)
+    script(src=`/javascripts/credit-entry-modal.js?v=${CACHE_BUST}`)
 

--- a/views/mixins/new-closing-mixins.pug
+++ b/views/mixins/new-closing-mixins.pug
@@ -261,9 +261,15 @@ mixin optionsForProductRates(cashOrCreditSalePrefix)
 
 
 //- Add new page: Dom elements to show credit details
+//- Renders two rows per credit line:
+//-  1. A compact, read-only summary row that's always what the user sees in the list.
+//-  2. A hidden detail row holding the real, submitted form fields. Its fields are
+//-     moved into the shared #creditEntryModal (see creditEntryModal mixin below)
+//-     whenever the row is opened for add/edit, and moved back on close.
 mixin addCredits(creditRowNo, rowData)
     - var prefix = 'credit-';
     - var trId = prefix + 'table-row-'+creditRowNo;
+    - var summaryTrId = prefix + 'summary-row-' + creditRowNo;
     - var trClass = 'd-md-none';
     - var price = 0;
     - var creditType = undefined, creditName = undefined;
@@ -275,7 +281,29 @@ mixin addCredits(creditRowNo, rowData)
         - rowData = {price:price, priceDiscount:0, billNo:0, qty:0, amount:0, creditType: config.creditTypes[0], companyName: creditName, vehicleId: null, odometerReading: null, offMeterSale: 0, creditBillDate: (typeof closingData !== 'undefined' ? closingData.closingDate : currentDate)};
     if(rowData.tCreditId && parseInt(rowData.tCreditId) > 0)
         - trClass = ''
-    tr(class=trClass id=trId)
+    - var summaryClass = trClass === 'd-md-none' ? 'd-md-none' : ''
+
+    tr.credit-summary-row(class=summaryClass id=summaryTrId data-credit-row=creditRowNo)
+        td.credit-summary-cell
+            span(id=prefix + 'summary-date-' + creditRowNo)
+        td.credit-summary-cell
+            span(id=prefix + 'summary-product-' + creditRowNo)
+        td.credit-summary-cell
+            span(id=prefix + 'summary-billno-' + creditRowNo)
+        td.credit-summary-cell
+            span(id=prefix + 'summary-company-' + creditRowNo)
+        td.credit-summary-cell
+            span(id=prefix + 'summary-vehicle-' + creditRowNo)
+        td.credit-summary-cell.text-right
+            span(id=prefix + 'summary-amt-' + creditRowNo)
+        td.credit-summary-actions.text-center
+            if !freezedRecord
+                button.btn.btn-sm.btn-link.text-primary.p-1(type='button' title='Edit' aria-label='Edit credit sale' onclick='openCreditRowModal(' + creditRowNo + ', false)')
+                    i.bi.bi-pencil-square
+                button.btn.btn-sm.btn-link.text-danger.p-1(type='button' title='Delete' aria-label='Delete credit sale' onclick='deleteCreditRow(' + creditRowNo + ')')
+                    i.bi.bi-trash
+
+    tr(class=trClass id=trId style='display:none')
         input(type='hidden' id=prefix + creditRowNo + '_hiddenId' value=rowData.tCreditId)
         td
             - var defaultCreditDate = rowData.creditBillDate || (typeof closingData !== 'undefined' ? closingData.closingDate : currentDate)
@@ -305,7 +333,7 @@ mixin addCredits(creditRowNo, rowData)
                 each party in allCreditParties
                     option(value=`${party.creditorId}` selected= rowData.creditListId === party.creditorId)= party.creditorName
         td
-            .d-flex.align-items-center(style='gap:4px')
+            .d-flex.align-items-center(id=prefix + 'vehicle-wrap-' + creditRowNo style='gap:4px')
                 .flex-grow-1
                     select.form-control.select2-vehicle(name=prefix + 'vehicle-' + creditRowNo id=prefix + 'vehicle-' + creditRowNo data-row=creditRowNo)
                         option(value='') Select Vehicle
@@ -329,12 +357,86 @@ mixin addCredits(creditRowNo, rowData)
         td
             textarea.form-control(name=prefix + 'notes-' + creditRowNo id=prefix + 'notes-' + creditRowNo style="height:36px")= rowData.notes
         if allowOffMeterSale
-            td.text-center
+            td
                 - var offMeterStyle = rowData.isLubeProduct ? '' : 'display:none'
                 input(type='checkbox' name=prefix + 'off-meter-' + creditRowNo id=prefix + 'off-meter-' + creditRowNo checked=(rowData.offMeterSale == 1) style=offMeterStyle)
-        td
-            button.close(type="button" aria-label="Close" onclick='hideRow(\'' + trId + '\', "remove-credit-sale", calculateCreditTotal)')
-                span(aria-hidden="true") &times;
+
+//- Shared Add/Edit modal for a single credit sale line. The actual field elements from
+//- the detail row (see addCredits above) are relocated into the slot divs below by
+//- credit-entry-modal.js while the row is being edited, and relocated back on close.
+mixin creditEntryModal(allowOffMeterSale)
+    style.
+        .modal-backdrop + .modal-backdrop { z-index: 1052; }
+        #creditEntryModal .form-group label {
+            font-size: 0.8rem;
+            font-weight: 600;
+            color: #555;
+            text-transform: uppercase;
+            letter-spacing: .02em;
+            margin-bottom: 4px;
+        }
+        #creditEntryModal .select2-container { width: 100% !important; }
+    #creditEntryModal.modal.fade(tabindex='-1' role='dialog' aria-labelledby='creditEntryModalLabel' aria-hidden='true')
+        .modal-dialog.modal-lg(role='document')
+            .modal-content
+                .modal-header
+                    h5.modal-title#creditEntryModalLabel
+                        i.bi.bi-receipt.mr-2
+                        span#creditEntryModalTitleText Credit Sale
+                    button.close(type='button' data-dismiss='modal' aria-label='Close')
+                        span(aria-hidden='true') &times;
+                .modal-body
+                    .row
+                        .col-md-4.form-group
+                            label Bill Date
+                            div#creditModalSlot-bill-date
+                        .col-md-4.form-group
+                            label Product
+                            div#creditModalSlot-product
+                        .col-md-4.form-group
+                            label Bill #
+                            div#creditModalSlot-billno
+                    .row
+                        .col-md-6.form-group
+                            label Company
+                            div#creditModalSlot-creditparty
+                        .col-md-6.form-group
+                            label Vehicle Number
+                            div#creditModalSlot-vehiclewrap
+                    .row
+                        .col-md-3.form-group
+                            label Odometer
+                            div#creditModalSlot-odometer
+                        .col-md-3.form-group
+                            label Price
+                            div#creditModalSlot-price
+                        .col-md-3.form-group
+                            label Price Discount
+                            div#creditModalSlot-discount
+                        .col-md-3.form-group
+                            label Quantity
+                            div#creditModalSlot-qty
+                    .row
+                        .col-md-4.form-group
+                            label Sale Amount
+                            div#creditModalSlot-amt
+                        if allowOffMeterSale
+                            .col-md-3.form-group#creditModalOffMeterGroup
+                                label Off Meter
+                                div#creditModalSlot-off-meter
+                            .col-md-5.form-group
+                                label Notes
+                                div#creditModalSlot-notes
+                        else
+                            .col-md-8.form-group
+                                label Notes
+                                div#creditModalSlot-notes
+                .modal-footer
+                    button.btn.btn-outline-danger.mr-auto#creditModalDeleteBtn(type='button' onclick='deleteCreditRowModal()')
+                        i.bi.bi-trash.mr-1
+                        | Delete
+                    button.btn.btn-secondary(type='button' data-dismiss='modal') Close
+                    button.btn.btn-primary(type='button' onclick='saveCreditRowModal()') Save
 
 
 //- Add new page: Dom elements to show new custom expenses on 'add'

--- a/views/new-closing.pug
+++ b/views/new-closing.pug
@@ -322,54 +322,29 @@ block content
                             white-space: nowrap; /* keeps headers on one line */
                         }
 
-                        /* Column width tuning */
-                        #credit-table .col-product   { width: 10%; }
-                        #credit-table .col-bill      { width: 7%; }
-                        #credit-table .col-company   { width: 16%; }  /* More room for credit party */
-                        #credit-table .col-vehicle   { width: 13%; }  /* More room for vehicle dropdown */
-                        #credit-table .col-odo       { width: 7%; }
-                        #credit-table .col-date      { width: 9%; }
-                        #credit-table .col-price     { width: 7%; }
-                        #credit-table .col-discount  { width: 5%; }
-                        #credit-table .col-qty       { width: 6%; }
-                        #credit-table .col-sale      { width: 8%; }
-                        #credit-table .col-notes     { width: 9%; }
-                        #credit-table .col-off-meter { width: 5%; text-align: center; }
-                        #credit-table th:last-child  { width: 2%; text-align: center; } /* X delete column */
+                        /* Column width tuning for the compact summary list */
+                        #credit-table .col-date      { width: 12%; }
+                        #credit-table .col-product   { width: 14%; }
+                        #credit-table .col-bill      { width: 10%; }
+                        #credit-table .col-company   { width: 22%; }
+                        #credit-table .col-vehicle   { width: 18%; }
+                        #credit-table .col-sale      { width: 12%; }
+                        #credit-table .col-actions   { width: 12%; text-align: center; }
 
-                        #credit-table .col-delete {
+                        #credit-table tbody tr.credit-summary-row td {
+                            vertical-align: middle;
+                        }
+                        #credit-table .credit-summary-cell span:empty::before {
+                            content: '\2014'; /* em dash placeholder */
+                            color: #999;
+                        }
+                        #credit-table .credit-summary-actions {
                             text-align: center;
+                            white-space: nowrap;
                         }
-                        #credit-table .col-delete .close {
-                            font-size: 1.1rem;
-                            color: #dc3545; /* Bootstrap danger red */
-                            opacity: 0.7;
-                            transition: opacity 0.2s;
+                        #credit-table .credit-summary-actions .btn {
+                            line-height: 1;
                         }
-                        #credit-table .col-delete .close:hover {
-                            opacity: 1;
-                        }
-
-                        /* --- Fix Select2 width for vehicle dropdown --- */
-                            #credit-table .select2-container--default .select2-selection--single {
-                                display: inline-block;
-                                width: auto !important;       /* auto-fit to text */
-                                min-width: 120px;
-                                max-width: 240px;             /* don’t overflow layout */
-                                height: 36px;
-                                vertical-align: middle;
-                            }
-
-                            #credit-table .select2-container--default .select2-selection__rendered {
-                                overflow: visible !important;
-                                white-space: nowrap;
-                                text-overflow: clip;
-                                padding-right: 24px;          /* spacing for arrow */
-                            }
-
-                            #credit-table .select2-container--default .select2-selection__arrow {
-                                right: 6px;
-                            }
                     div
                         div.col-16
                             div.table-responsive
@@ -382,31 +357,23 @@ block content
                                                 th.col-bill(scope="col") Bill #
                                                 th.col-company(scope="col") Company
                                                 th.col-vehicle(scope="col") Vehicle Number
-                                                th.col-odo(scope="col") Odometer
-                                                th.col-price(scope="col") Price
-                                                th.col-discount(scope="col") Price Discount
-                                                th.col-qty(scope="col") Quantity
                                                 th.col-sale(scope="col") Sale
-                                                th.col-notes(scope="col") Notes
-                                                if allowOffMeterSale
-                                                    th.col-off-meter(scope="col") Off Meter
-                                                th.col-delete(scope="col")
-                                                th(scope="col")
+                                                th.col-actions(scope="col") Actions
                                             - var rowCnt = 0
                                             while rowCnt < maxCreditsRowCnt
                                                 +addCredits(rowCnt++)
 
                                             tr
                                                 td(colspan=5)
-                                                td Total
-                                                td
-                                                    input.form-control#credit-total(type='text' name='credit-total' readonly value='0')
+                                                td.text-right
+                                                    strong Total:&nbsp;
+                                                    input.form-control.d-inline-block(style='width:120px' type='text' name='credit-total' id='credit-total' readonly value='0')
                                                 td
                     div.row
                         div.col &nbsp;
                     div.row
                         div.col(align="center")
-                            button.btn.btn-info(type="button", onClick="showAddedCreditRow('credit')") Add credits
+                            button.btn.btn-info(type="button", onClick="handleAddCreditRowClick()") Add credits
 
                     div.row
                         div.col &nbsp;
@@ -716,34 +683,8 @@ block content
         window.pumpsData = !{JSON.stringify(pumps)};    
         window.productValuesData = !{JSON.stringify(productValues)};
         window.allowSecondaryPump = !{allowSecondaryPump};
-                // Initialize Select2 for vehicle dropdowns
-            function initVehicleSelect2() {
-                $('.select2-vehicle').each(function() {
-                    if ($(this).data('select2')) {
-                        $(this).select2('destroy');
-                    }
-                    $(this).select2({
-                        width: 'style',           // uses CSS width
-                        dropdownAutoWidth: true,  // dropdown expands to content
-                        minimumResultsForSearch: 5,
-                        placeholder: 'Select Vehicle'
-                    });
-                });
-            }
-
-            // Initialize when DOM ready
-            $(document).ready(function() {
-                initVehicleSelect2();
-            });
-
-            // Re-init when "Add credits" adds new rows dynamically
-            const _origShowAddedCreditRow = window.showAddedCreditRow;
-            window.showAddedCreditRow = function(prefix) {
-                if (typeof _origShowAddedCreditRow === 'function') {
-                    _origShowAddedCreditRow(prefix);
-                }
-                initVehicleSelect2(); // ensure new row gets Select2 applied
-            };
+    // Credit sale Add/Edit modal (shared by the compact credit sales list)
+    +creditEntryModal(allowOffMeterSale)
     // Quick Add Vehicle Modal
     .modal.fade#quickAddVehicleModal(tabindex='-1' role='dialog' aria-labelledby='quickAddVehicleModalLabel' aria-hidden='true')
         .modal-dialog(role='document')
@@ -764,3 +705,4 @@ block content
                     button.btn.btn-secondary(type='button' data-dismiss='modal') Cancel
                     button.btn.btn-success#quickAddVehicleSaveBtn(type='button' onclick='quickSaveVehicle()') Add Vehicle
     script(src=`/javascripts/shift-products.js?v=${CACHE_BUST}`)
+    script(src=`/javascripts/credit-entry-modal.js?v=${CACHE_BUST}`)


### PR DESCRIPTION
## Summary
- The Credit Sales tab in shift closing (both the "new closing" and "edit draft closing" flows) rendered a dense 12+ column table with every field editable inline, requiring horizontal scrolling and feeling cramped.
- The table now shows a compact 6-column read-only summary (Bill Date, Product, Bill #, Company, Vehicle, Sale) with Edit/Delete actions per row.
- Adding a new credit line or editing an existing one now opens a shared modal with all fields (bill date, product, bill #, company, vehicle, odometer, price, discount, quantity, sale, notes, off-meter) laid out in a roomy grid.

## Implementation notes
- The real form fields keep their original ids/names and live in a hidden row per line; the modal doesn't duplicate values — it relocates the actual input elements into itself while a line is being edited and moves them back on close.
- This means existing save/serialize logic (`saveCreditSales`, `calculateTotal`, `hideRow`, vehicle loading, off-meter show/hide, quick-add-vehicle) is unchanged.
- Vehicle select2 is now initialized lazily inside the modal (previously initialized eagerly on page load), since the row now stays hidden until opened.

## Test plan
- [x] Both templates compile and render correctly via Pug (including with pre-existing draft credit data)
- [x] New JS passes a syntax check
- [ ] Manual smoke test on deployed beta: add a credit line, edit an existing one, quick-add a vehicle from within the modal, delete a line


---
_Generated by [Claude Code](https://claude.ai/code/session_01NfXsUjPYmaqt84V7xoTyBb)_