### PR TITLE
Add Collections tab to shift closing for direct credit-receipt entry

### DIFF
--- a/app.js
+++ b/app.js
@@ -356,6 +356,37 @@ const bypassLoginInDev = async (req, res, next) => {
 // Apply the bypass middleware
 app.use(bypassLoginInDev);
 
+// SuperUser idle timeout — SuperUser sessions carry access to confidential/billing data
+// and are sometimes used on other locations' shared PCs, so they get auto-logged-out
+// after a period of inactivity even if the user forgets to sign out manually. Applies
+// while previewing too (req.session.previewOriginal), since the underlying identity is
+// still a SuperUser even though req.user.Role is temporarily the previewed role.
+const SUPERUSER_IDLE_TIMEOUT_MS = 15 * 60 * 1000;
+const enforceSuperUserIdleTimeout = (req, res, next) => {
+    if (!req.user || !req.session) return next();
+    // Skip in the local SKIP_LOGIN dev bypass, which isn't a real passport session
+    // and would otherwise force a broken req.logout() after 15 idle minutes locally.
+    if (process.env.NODE_ENV === 'development' && process.env.SKIP_LOGIN === 'true') return next();
+
+    const isSuperUserSession = req.user.Role === 'SuperUser' || !!req.session.previewOriginal;
+    if (!isSuperUserSession) return next();
+
+    const now = Date.now();
+    if (req.session.lastActivity && (now - req.session.lastActivity > SUPERUSER_IDLE_TIMEOUT_MS)) {
+        const username = req.user.User_Name;
+        return req.logout(function (err) {
+            if (err) console.error('Error during idle-timeout logout:', err);
+            console.log(`[IDLE TIMEOUT] ${username} auto-logged-out after 15 min inactivity`);
+            req.flash('warning', 'You were signed out after 15 minutes of inactivity.');
+            res.redirect('/login');
+        });
+    }
+
+    req.session.lastActivity = now;
+    next();
+};
+app.use(enforceSuperUserIdleTimeout);
+
 
 const addUserLocationInfo = async (req, res, next) => {
     if (req.user && req.user.Person_id) {
@@ -482,6 +513,7 @@ app.use('/campaign', campaignPublicRoutes);
 app.use('/gst', gstRoutes);
 app.use('/transaction-upload', transactionUploadRoutes);
 app.use('/dsm-entry', require('./routes/dsm-entry-routes'));
+app.use('/admin/bill-ocr-formats', require('./routes/bill-ocr-format-routes'));
 app.use('/day-bill', dayBillRoutes);
 app.use('/platform-billing', platformBillingRoutes);
 app.use('/distributors', distributorRoutes);
@@ -1212,6 +1244,14 @@ app.delete('/remove-digital-sale', isLoginEnsured, function (req, res, next) {
     HomeController.deleteTxnDigitalSale(req, res, next);  // response returned inside controller
 });
 
+app.post('/new-credit-receipts', isLoginEnsured, function (req, res, next) {
+    HomeController.saveCreditReceiptsData(req, res, next);  // response returned inside controller
+});
+
+app.delete('/remove-credit-receipt', isLoginEnsured, function (req, res, next) {
+    HomeController.deleteTxnCreditReceipt(req, res, next);  // response returned inside controller
+});
+
 app.post('/new-expenses', isLoginEnsured, function (req, res, next) {
     HomeController.saveExpensesData(req, res, next);
 });
@@ -1821,7 +1861,8 @@ app.get('/preview-as', isLoginEnsured, isSuperUserOrPreviewing, async function (
             roles: roles,
             locations: locations,
             isPreviewing: !!req.session.previewOriginal,
-            previewMeta: req.session.previewMeta || null
+            previewMeta: req.session.previewMeta || null,
+            messages: req.flash()
         });
     } catch (error) {
         console.error("Error loading preview-as page:", error);

--- a/config/app-config.js
+++ b/config/app-config.js
@@ -32,6 +32,7 @@ const PRODUCTS = PRODUCT_2T.concat(PRODUCT_PUMPS);
 // config related to sales
 const MAX_CREDITS_ROW_CNT = 300;
 const MAX_DIGITAL_ROW_CNT = 20;
+const MAX_CREDIT_RECEIPTS_ROW_CNT = 20;
 const MAX_CASH_SALES_ROW_CNT = 25;
 const MAX_EXPENSES_ROW_CNT = 25;
 const MAX_CASHFLOWS_ROW_CNT = 30;
@@ -212,6 +213,7 @@ GST_RETURN_STATUS: ['DRAFT', 'READY', 'FILED', 'FAILED', 'CANCELLED'],
   APP_CONFIGS: {
       maxCreditsRowCnt: MAX_CREDITS_ROW_CNT,
       maxDigitalSalesRowCnt:MAX_DIGITAL_ROW_CNT,
+      maxCreditReceiptsRowCnt: MAX_CREDIT_RECEIPTS_ROW_CNT,
       maxCashSalesRowCnt: MAX_CASH_SALES_ROW_CNT,
       maxExpensesRowCnt: MAX_EXPENSES_ROW_CNT,
       maxCashFlowRowsCnt: MAX_CASHFLOWS_ROW_CNT,

--- a/controllers/account-heads-controller.js
+++ b/controllers/account-heads-controller.js
@@ -2,10 +2,18 @@
 const AccountHeadsDao    = require("../dao/account-heads-dao");
 const LedgerRulesDao     = require("../dao/ledger-rules-dao");
 const BankDao            = require("../dao/bank-dao");
+const CreditsDao         = require("../dao/credits-dao");
+const SupplierDao        = require("../dao/supplier-dao");
 const rolePermissionsDao = require("../dao/role-permissions-dao");
 const { getLedgersByGroup } = require('../routes/gl-routes');
+const { getLocationConfigValue } = require('../utils/location-config');
 const db = require('../db/db-connection');
 const { QueryTypes } = require('sequelize');
+
+// Credit Party rules default to CREDIT-only, Supplier rules to DEBIT-only —
+// each location can loosen its own via these location config settings.
+const CREDIT_ENTRY_TYPE_OVERRIDE_SETTING   = 'LEDGER_RULES_CREDIT_PARTY_ENTRY_TYPE_OVERRIDE';
+const SUPPLIER_ENTRY_TYPE_OVERRIDE_SETTING = 'LEDGER_RULES_SUPPLIER_ENTRY_TYPE_OVERRIDE';
 
 async function getAllGlGroups(locationCode) {
     return db.sequelize.query(`
@@ -24,15 +32,20 @@ module.exports = {
             const role         = req.user.Role;
             const activeTab    = req.query.tab || 'heads';
 
-            const [accountHeads, allRules, banks, glGroups,
-                   canEdit, canAdd, canDisable] = await Promise.all([
+            const [accountHeads, allRules, banks, glGroups, creditParties, suppliers,
+                   canEdit, canAdd, canDisable,
+                   creditEntryTypeOverride, supplierEntryTypeOverride] = await Promise.all([
                 AccountHeadsDao.getAccountHeads(locationCode),
                 LedgerRulesDao.getAllRules(locationCode),
                 BankDao.findAll(locationCode),
                 getAllGlGroups(locationCode),
+                CreditsDao.findAll(locationCode),
+                SupplierDao.findSuppliers(locationCode),
                 rolePermissionsDao.hasPermission(role, locationCode, 'EDIT_ACCOUNT_HEADS'),
                 rolePermissionsDao.hasPermission(role, locationCode, 'ADD_ACCOUNT_HEADS'),
                 rolePermissionsDao.hasPermission(role, locationCode, 'DISABLE_ACCOUNT_HEADS'),
+                getLocationConfigValue(locationCode, CREDIT_ENTRY_TYPE_OVERRIDE_SETTING, 'N'),
+                getLocationConfigValue(locationCode, SUPPLIER_ENTRY_TYPE_OVERRIDE_SETTING, 'N'),
             ]);
 
             res.render("account-heads", {
@@ -42,9 +55,13 @@ module.exports = {
                 allRules,
                 banks,
                 glGroups,
+                creditParties,
+                suppliers,
                 canEdit,
                 canAdd,
                 canDisable,
+                creditEntryTypeOverride:   creditEntryTypeOverride   === 'Y',
+                supplierEntryTypeOverride: supplierEntryTypeOverride === 'Y',
                 activeTab
             });
         } catch (err) {
@@ -192,6 +209,56 @@ module.exports = {
             const msg = err.original?.code === 'ER_DUP_ENTRY'
                 ? "A rule for this Bank + Account Head combination already exists"
                 : (err.original?.sqlMessage || err.message || "Error updating ledger rule");
+            req.flash("error", msg);
+            res.redirect("/account-heads?tab=rules");
+        }
+    },
+
+    // ── Credit Party / Supplier — manual extra Bank+Party mapping ──────────
+    // Auto-created rules (one per bank, via DB trigger) cover a party the
+    // moment it's created. This lets an admin add one more mapping — e.g. a
+    // customer or supplier that also needs to post against a second bank
+    // account. Entry type defaults to CREDIT (party) / DEBIT (supplier) and
+    // is only overridable when the location config setting allows it.
+
+    createPartyRule: async (req, res, next) => {
+        try {
+            const locationCode = req.user.location_code;
+            const sourceType   = req.body.source_type === 'SUPPLIER' ? 'Supplier' : 'Credit';
+            const defaultEntryType = sourceType === 'Credit' ? 'CREDIT' : 'DEBIT';
+
+            const overrideSetting = sourceType === 'Credit'
+                ? CREDIT_ENTRY_TYPE_OVERRIDE_SETTING
+                : SUPPLIER_ENTRY_TYPE_OVERRIDE_SETTING;
+            const overrideEnabled = (await getLocationConfigValue(locationCode, overrideSetting, 'N')) === 'Y';
+
+            const allowedEntryType = overrideEnabled && ['DEBIT', 'CREDIT', 'BOTH'].includes(req.body.allowed_entry_type)
+                ? req.body.allowed_entry_type
+                : defaultEntryType;
+
+            const data = {
+                location_code:        locationCode,
+                bank_id:              req.body.bank_id,
+                source_type:          sourceType,
+                external_id:          req.body.party_id,
+                ledger_name:          req.body.ledger_name,
+                allowed_entry_type:   allowedEntryType,
+                notes_required_flag:  req.body.notes_required_flag || 'N',
+                max_amount:           req.body.max_amount           || null,
+                effective_start_date: req.body.effective_start_date || null,
+                effective_end_date:   req.body.effective_end_date   || null,
+                allow_split_flag:     req.body.allow_split_flag     === 'Y' ? 'Y' : 'N',
+                created_by:           req.user.username || req.user.Person_id
+            };
+
+            await LedgerRulesDao.createPartyRule(data);
+            req.flash("success", `${sourceType} ledger rule created successfully`);
+            res.redirect("/account-heads?tab=rules");
+        } catch (err) {
+            console.error("Error creating party ledger rule:", err);
+            const msg = err.original?.code === 'ER_DUP_ENTRY'
+                ? "A rule for this Bank + Party combination already exists"
+                : (err.original?.sqlMessage || err.message || "Error creating ledger rule");
             req.flash("error", msg);
             res.redirect("/account-heads?tab=rules");
         }

--- a/controllers/closing-delete-controller.js
+++ b/controllers/closing-delete-controller.js
@@ -87,6 +87,9 @@ module.exports = {
     txnDeleteDigitalSalePromise: (digitalSalesId) => {
     return txnDeleteDigitalSalePromise(digitalSalesId);
     },
+    txnDeleteCreditReceiptPromise: (receiptId) => {
+    return txnDeleteCreditReceiptPromise(receiptId);
+    },
 }
 
 // Add new flow: Delete one reading data
@@ -201,6 +204,23 @@ const txnDeleteDigitalSalePromise = (digitalSalesId) => {
                 }
             }).catch((err) => {
             console.error("Error while deleting digital sale " + err.toString());
+            resolve({error: err.toString()});
+        });
+    });
+}
+
+// Add new flow: Delete one credit receipt (Collections tab) data
+const txnDeleteCreditReceiptPromise = (receiptId) => {
+    return new Promise((resolve, reject) => {
+        TxnWriteDao.deleteCreditReceiptById(receiptId)
+            .then(status => {
+                if (status > 0) {
+                    resolve({message: 'Data deletion success.'});
+                } else {
+                    resolve({error: 'Data deletion failed.'});
+                }
+            }).catch((err) => {
+            console.error("Error while deleting credit receipt " + err.toString());
             resolve({error: err.toString()});
         });
     });

--- a/controllers/closing-edit-controller.js
+++ b/controllers/closing-edit-controller.js
@@ -116,6 +116,12 @@ module.exports = {
                 'N'
             );
 
+            const allowCreditReceiptsInClosing = await locationConfig.getLocationConfigValue(
+                locationCode,
+                'ALLOW_CREDIT_RECEIPTS_IN_CLOSING',
+                'N' // default - disabled
+            );
+
         if(closingId) {
             Promise.allSettled([homeController.personDataPromise(locationCode),
                 txnClosingPromise(closingId),
@@ -137,7 +143,8 @@ module.exports = {
                 txnController.txnDigitalSalesPromise(closingId),
                 txnController.shiftProductsPromise(closingId),
                 BowserDao.getActiveBowsersByLocation(locationCode),
-                BowserDao.getIntercompanyByClosingId(closingId)])
+                BowserDao.getIntercompanyByClosingId(closingId),
+                txnController.txnCreditReceiptsPromise(closingId)])
                 .then((values) => {
                     res.render('edit-draft-closing', {
                         user: req.user,
@@ -151,6 +158,7 @@ module.exports = {
                         show2TSalesTab: show2TSalesTab === 'Y',
                         allowQuickAddVehicle: allowQuickAddVehicle === 'Y',
                         allowOffMeterSale: allowOffMeterSale === 'Y',
+                        allowCreditReceiptsInClosing: allowCreditReceiptsInClosing === 'Y',
                         cashiers: values[0].value.cashiers,
                         closingData: values[1].value,
                         productValues: values[2].value.products,
@@ -171,7 +179,8 @@ module.exports = {
                         digitalSalesData: values[17].value,
                         shiftProducts: values[18].value || [],
                         bowserValues: values[19].value || [],
-                        t_intercompany: values[20].value || []
+                        t_intercompany: values[20].value || [],
+                        creditReceiptsData: values[21].value || []
                     });
                 }).catch((err) => {
                 console.warn("Error while getting data using promises " + err.toString());

--- a/controllers/closing-save-controller.js
+++ b/controllers/closing-save-controller.js
@@ -37,6 +37,9 @@ module.exports = {
     txnWriteDigitalSalesPromise: (saleDataArr) => {
     return txnWriteDigitalSalesPromise(saleDataArr);
     },
+    txnWriteCreditReceiptsPromise: (receiptsArr) => {
+    return txnWriteCreditReceiptsPromise(receiptsArr);
+    },
 }
 
 
@@ -179,6 +182,19 @@ const txnWriteDigitalSalesPromise = (digitalSalesArr) => {
                 resolve(data);
             }).catch((err) => {
             console.error("Error while saving digital sales " + err.toString());
+            resolve({error: err.toString()});
+        });
+    });
+}
+
+// Add new flow: Add credit receipts (Collections tab) data
+const txnWriteCreditReceiptsPromise = (receiptsArr) => {
+    return new Promise((resolve, reject) => {
+        TxnWriteDao.saveCreditReceipts(receiptsArr)
+            .then(data => {
+                resolve(data);
+            }).catch((err) => {
+            console.error("Error while saving credit receipts " + err.toString());
             resolve({error: err.toString()});
         });
     });

--- a/controllers/credit-receipt-controller.js
+++ b/controllers/credit-receipt-controller.js
@@ -148,7 +148,8 @@ module.exports = {
                         inactiveCreditIds.add(creditlist.creditlist_id);
                     }                   
     
-                    isEditOrDeleteAllowed = receipt.dataValues.cashflow_date === null && receipt.dataValues.pending_cashflow_id === null;
+                    isEditOrDeleteAllowed = receipt.dataValues.cashflow_date === null && receipt.dataValues.pending_cashflow_id === null
+                        && receipt.dataValues.closing_id === null;
     
                     
 
@@ -164,7 +165,7 @@ module.exports = {
                         amount: receipt.amount,
                         notes: receipt.notes,
                         receipt_date: receipt.receipt_date_fmt,
-                        showEditOrDelete: receipt.dataValues.cashflow_date === null && receipt.dataValues.pending_cashflow_id === null,
+                        showEditOrDelete: isEditOrDeleteAllowed,
                         creditType: type
                     });
                 } else {
@@ -292,6 +293,9 @@ module.exports = {
                 }
                 if (receipt.cashflow_date !== null || receipt.pending_cashflow_id !== null) {
                     return res.status(400).send({ error: 'Receipt is part of a cashflow and cannot be deleted.' });
+                }
+                if (receipt.closing_id !== null) {
+                    return res.status(400).send({ error: 'Receipt was entered from a shift closing and can only be edited/deleted there.' });
                 }
                 return CreditReceiptsDao.delete(req.query.id);
             })

--- a/controllers/home-controller.js
+++ b/controllers/home-controller.js
@@ -82,6 +82,12 @@ module.exports = {
     'N'
     );
 
+    const allowCreditReceiptsInClosing = await locationConfig.getLocationConfigValue(
+    locationCode,
+    'ALLOW_CREDIT_RECEIPTS_IN_CLOSING',
+    'N' // default - disabled
+    );
+
         getDraftsCount(locationCode).then(data => {
             if(data < config.APP_CONFIGS.maxAllowedDrafts) {
                 Promise.allSettled([personDataPromise(locationCode),
@@ -120,7 +126,8 @@ module.exports = {
                             digitalSalesFutureDays: digitalSalesFutureDays,
                             show2TSalesTab: show2TSalesTab === 'Y',
                             allowQuickAddVehicle: allowQuickAddVehicle === 'Y',
-                            allowOffMeterSale: allowOffMeterSale === 'Y'
+                            allowOffMeterSale: allowOffMeterSale === 'Y',
+                            allowCreditReceiptsInClosing: allowCreditReceiptsInClosing === 'Y'
                   //          digitalCompanyValues: values[8].value,
                         });
                     }).catch((err) => {
@@ -265,6 +272,19 @@ module.exports = {
     }
 },
 
+    saveCreditReceiptsData: (req, res, next) => {
+    const receiptsData = req.body;
+    if (receiptsData) {
+        saveController.txnWriteCreditReceiptsPromise(receiptsData).then((result) => {
+            if (!result.error) {
+                res.status(200).send({message: 'Saved credit receipts data successfully.', rowsData: result});
+            } else {
+                res.status(500).send({error: result.error});
+            }
+        });
+    }
+},
+
 
 
     saveExpensesData: (req, res, next) => {
@@ -361,6 +381,23 @@ deleteTxnDigitalSale: ((req, res, next) => {
     const saleId = req.query.id;
     if (saleId) {
         deleteController.txnDeleteDigitalSalePromise(saleId).then((result) => {
+            if (!result.error) {
+                res.status(200).send({
+                    message: result.message
+                });
+            } else {
+                res.status(500).send({error: result.error});
+            }
+        });
+    } else {
+        res.status(302).send();
+    }
+}),
+
+deleteTxnCreditReceipt: ((req, res, next) => {
+    const receiptId = req.query.id;
+    if (receiptId) {
+        deleteController.txnDeleteCreditReceiptPromise(receiptId).then((result) => {
             if (!result.error) {
                 res.status(200).send({
                     message: result.message

--- a/controllers/txn-common-controller.js
+++ b/controllers/txn-common-controller.js
@@ -28,6 +28,9 @@ module.exports = {
     txnDigitalSalesPromise: (closingId) => {
     return txnDigitalSalesPromise(closingId);
     },
+    txnCreditReceiptsPromise: (closingId) => {
+    return txnCreditReceiptsPromise(closingId);
+    },
     txnDenominationPromise: (closingId) => {
         return txnDenominationPromise(closingId);
     },
@@ -297,6 +300,32 @@ const txnDigitalSalesPromise = (closingId) => {
                         });
                     });
                     resolve(digitalSalesData);
+                } else {
+                    resolve([]);
+                }
+            });
+    });
+}
+
+// Show closing records flow: Getting txn credit receipts (Collections tab) data based on closing id
+const txnCreditReceiptsPromise = (closingId) => {
+    return new Promise((resolve, reject) => {
+        return TxnReadDao.getReceiptsByClosingId(closingId)
+            .then(data => {
+                if (data && data.length > 0) {
+                    let creditReceiptsData = [];
+                    data.forEach((receipt) => {
+                        creditReceiptsData.push({
+                            receiptId: receipt.treceipt_id,
+                            receiptType: receipt.receipt_type,
+                            creditPartyId: receipt.creditlist_id,
+                            digitalVendorId: receipt.digital_creditlist_id,
+                            amount: receipt.amount,
+                            receiptDate: receipt.receipt_date,
+                            notes: receipt.notes
+                        });
+                    });
+                    resolve(creditReceiptsData);
                 } else {
                     resolve([]);
                 }

--- a/dao/credit-receipts-dao.js
+++ b/dao/credit-receipts-dao.js
@@ -23,6 +23,7 @@ module.exports = {
                 'location_code',
                 'cashflow_date',
                 'pending_cashflow_id',
+                'closing_id',
             ],
           where: { [Op.and]: [
                   { location_code: locationCode },
@@ -82,7 +83,7 @@ module.exports = {
     },
     findById: (receiptId) => {
         return CashReceipts.findOne({
-            attributes: ['treceipt_id', 'cashflow_date', 'pending_cashflow_id'],
+            attributes: ['treceipt_id', 'cashflow_date', 'pending_cashflow_id', 'closing_id'],
             where: { treceipt_id: receiptId },
         });
     },

--- a/dao/ledger-rules-dao.js
+++ b/dao/ledger-rules-dao.js
@@ -135,6 +135,33 @@ module.exports = {
         });
     },
 
+    // ── Credit Party / Supplier rule creation ────────────────────────────────
+    // Lets an admin manually add an extra Bank+Party mapping (e.g. a customer
+    // or supplier that needs to appear against a second bank account) on top
+    // of whatever the after_creditlist_insert_ledger_rule / after_supplier_
+    // insert_ledger_rule triggers already seeded. Same unique key as Static
+    // rules — (location_code, bank_id, source_type, external_id) — so this is
+    // a plain INSERT relying on ER_DUP_ENTRY for duplicate detection.
+    createPartyRule: async (data) => {
+        const query = `
+            INSERT INTO m_ledger_rules (
+                location_code, bank_id, source_type, external_id,
+                ledger_name, allowed_entry_type, notes_required_flag,
+                max_amount, effective_start_date, effective_end_date,
+                allow_split_flag, created_by
+            ) VALUES (
+                :location_code, :bank_id, :source_type, :external_id,
+                :ledger_name, :allowed_entry_type, :notes_required_flag,
+                :max_amount, :effective_start_date, :effective_end_date,
+                :allow_split_flag, :created_by
+            )
+        `;
+        return await db.sequelize.query(query, {
+            replacements: data,
+            type: QueryTypes.INSERT
+        });
+    },
+
     // ── Allow Split flag — editable on all rule types ───────────────────────
 
     updateSplitFlag: async ({ rule_id, allow_split_flag, updated_by }) => {

--- a/dao/txn-read-dao.js
+++ b/dao/txn-read-dao.js
@@ -14,6 +14,7 @@ const Expenses = db.expense;
 const TxnAttendance = db.txn_attendance;
 const TxnDeadlineViews = db.txn_deadline_views;
 const TxnDigitalSales = db.txn_digital_sales;
+const CashReceipts = db.credit_receipts;
 const Sequelize = require("sequelize");
 const { Op } = require("sequelize");
 const config = require("../config/app-config");
@@ -514,6 +515,11 @@ getMostRecentClosingDate: async (locationCode) => {
     },
     getDigitalSalesByClosingId: (closingId) => {
     return TxnDigitalSales.findAll({
+        where: {'closing_id': closingId}
+    });
+    },
+    getReceiptsByClosingId: (closingId) => {
+    return CashReceipts.findAll({
         where: {'closing_id': closingId}
     });
     }

--- a/dao/txn-write-dao.js
+++ b/dao/txn-write-dao.js
@@ -9,6 +9,8 @@ const TxnExpenses = db.txn_expense;
 const TxnDenoms = db.txn_denom;
 const TxnAttendance = db.txn_attendance;
 const TxnDigitalSales = db.txn_digital_sales;
+const CashReceipts = db.credit_receipts;
+const locationConfigDao = require('./location-config-dao');
 
 module.exports = {
     saveClosingData: (data) => {
@@ -124,6 +126,29 @@ saveReadings: (data) => {
     deleteDigitalSaleById: (digitalSalesId) => {
     const salesTxn = TxnDigitalSales.destroy({ where: { digital_sales_id: digitalSalesId } });
     return salesTxn;
+    },
+    saveCreditReceipts: async (data) => {
+    const newRows = data.filter(r => !r.treceipt_id);
+    const locationCode = newRows.length > 0 ? newRows[0].location_code : undefined;
+
+    if (locationCode) {
+        const cashflowEnabledRaw = await locationConfigDao.getSetting(locationCode, 'CASHFLOW_ENABLED');
+        const cashflowEnabled = String(cashflowEnabledRaw).toLowerCase() === 'true';
+        if (!cashflowEnabled) {
+            newRows.forEach(r => { r.cashflow_date = new Date(); });
+        }
+    }
+
+    const receiptsTxn = CashReceipts.bulkCreate(data, {
+        returning: true,
+        updateOnDuplicate: ["receipt_type", "creditlist_id", "digital_creditlist_id",
+            "amount", "receipt_date", "notes", "updated_by", "updation_date"]
+    });
+    return receiptsTxn;
+    },
+    deleteCreditReceiptById: (receiptId) => {
+    const receiptTxn = CashReceipts.destroy({ where: { treceipt_id: receiptId } });
+    return receiptTxn;
     },
     saveExpenses: async (data) => {
     const newExpenses = data.filter(e => !e.texpense_id);  // ✅ Will be empty array for UPDATE calls

--- a/db/credit-receipts.js
+++ b/db/credit-receipts.js
@@ -12,6 +12,10 @@ module.exports = function (sequelize, DataTypes) {
       receipt_no: DataTypes.INTEGER,
       creditlist_id: DataTypes.INTEGER,
       digital_creditlist_id: DataTypes.INTEGER,
+      closing_id: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+      },
       receipt_type: DataTypes.STRING,
       amount: DataTypes.DECIMAL,
       notes: DataTypes.STRING,

--- a/db/migrations/add-closing-id-to-receipts.sql
+++ b/db/migrations/add-closing-id-to-receipts.sql
@@ -1,0 +1,51 @@
+-- ============================================================
+-- Credit Receipts in Shift Closing: schema groundwork
+--
+-- Adds closing_id to t_receipts so a credit receipt (cash or
+-- digital) entered from the shift-closing "Collections" tab can
+-- be tied to the shift that recorded it. Nullable: rows created
+-- via the standalone /creditreceipts admin page are unaffected
+-- and keep closing_id = NULL.
+--
+-- Also creates t_receipts_deleted, the recycle-bin counterpart
+-- used by delete_closing/restore_closing (see
+-- add-receipts-to-delete-closing.sql and
+-- add-receipts-to-restore-closing.sql), mirroring the shape of
+-- t_credits_deleted / t_digital_sales_deleted.
+--
+-- Safe to re-run: uses IF NOT EXISTS guards throughout.
+-- ============================================================
+
+ALTER TABLE t_receipts
+    ADD COLUMN IF NOT EXISTS closing_id INT NULL
+        COMMENT 'FK to t_closing.closing_id; NULL for receipts entered outside a shift (admin Credit Receipts page).',
+    ADD INDEX IF NOT EXISTS idx_receipts_closing_id (closing_id);
+
+CREATE TABLE IF NOT EXISTS t_receipts_deleted (
+    treceipt_id             INT           NOT NULL,
+    receipt_no              INT           NULL,
+    creditlist_id           INT           NULL,
+    digital_creditlist_id   INT           NULL,
+    receipt_type            VARCHAR(45)   NULL,
+    amount                  DECIMAL(20,3) NULL,
+    notes                   VARCHAR(500)  NULL,
+    location_code           VARCHAR(50)   NULL,
+    closing_id              INT           NULL,
+    created_by              VARCHAR(45)   NULL,
+    updated_by              VARCHAR(45)   NULL,
+    creation_date           DATETIME      NULL,
+    updation_date           DATETIME      NULL,
+    receipt_date            DATETIME      NULL,
+    cashflow_date           DATETIME      NULL,
+    pending_cashflow_id     INT           NULL,
+    recon_match_id          BIGINT        NULL,
+    manual_recon_flag       TINYINT       NULL DEFAULT 0,
+    manual_recon_by         VARCHAR(50)   NULL,
+    manual_recon_date       DATETIME      NULL,
+    source_txn_id           INT           NULL,
+    source_split_id         INT           NULL,
+    deleted_by               VARCHAR(45)   NULL,
+    deleted_at                DATETIME      NULL,
+    PRIMARY KEY (treceipt_id),
+    KEY idx_receipts_deleted_closing_id (closing_id)
+);

--- a/db/migrations/add-receipts-to-delete-closing.sql
+++ b/db/migrations/add-receipts-to-delete-closing.sql
@@ -1,0 +1,280 @@
+-- ============================================================
+-- delete_closing: also archive/remove t_receipts rows
+--
+-- t_receipts gained a closing_id column (see
+-- add-closing-id-to-receipts.sql) once credit receipts could be
+-- entered from the shift-closing "Collections" tab. Without this
+-- change, deleting a draft closing would orphan its receipt rows
+-- instead of moving them to the recycle bin like every other
+-- child table.
+--
+-- Full re-declaration of delete_closing (based on
+-- fix-delete-closing-add-user-param.sql) with t_receipts handling
+-- added alongside the existing tables. Safe to re-run: uses
+-- DROP PROCEDURE IF EXISTS.
+-- ============================================================
+
+DELIMITER //
+
+DROP PROCEDURE IF EXISTS delete_closing //
+
+CREATE PROCEDURE delete_closing (
+    IN p_closing_id  INT,
+    IN p_deleted_by  VARCHAR(45)
+)
+BEGIN
+    DECLARE v_has_credit_bills INT DEFAULT 0;
+    DECLARE v_has_cash_bills   INT DEFAULT 0;
+    DECLARE v_total_bills      INT DEFAULT 0;
+    DECLARE v_error_message    VARCHAR(500);
+    DECLARE v_has_child_data   INT DEFAULT 0;
+    DECLARE v_deleted_by       VARCHAR(45);
+    DECLARE v_deletion_reason  TEXT DEFAULT NULL;
+
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    SET v_deleted_by = IFNULL(p_deleted_by, 'system');
+
+    START TRANSACTION;
+
+    -- Check if there are any credits with bills for this closing
+    SELECT COUNT(*) INTO v_has_credit_bills
+    FROM t_credits tc
+    INNER JOIN t_bills tb ON tc.bill_id = tb.bill_id
+    WHERE tc.closing_id = p_closing_id
+      AND tc.bill_id IS NOT NULL
+      AND tb.bill_status != 'CANCELLED';
+
+    -- Check if there are any cash sales with bills for this closing
+    SELECT COUNT(*) INTO v_has_cash_bills
+    FROM t_cashsales tcs
+    INNER JOIN t_bills tb ON tcs.bill_id = tb.bill_id
+    WHERE tcs.closing_id = p_closing_id
+      AND tcs.bill_id IS NOT NULL
+      AND tb.bill_status != 'CANCELLED';
+
+    SET v_total_bills = v_has_credit_bills + v_has_cash_bills;
+
+    -- If bills exist, raise an error and prevent deletion
+    IF v_total_bills > 0 THEN
+        SET v_error_message = CONCAT('Cannot delete closing_id ', p_closing_id,
+                                     '. Found ', v_total_bills,
+                                     ' record(s) with active bills (',
+                                     v_has_credit_bills, ' credit, ',
+                                     v_has_cash_bills, ' cash). ',
+                                     'Please remove or cancel the bills first.');
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = v_error_message;
+    END IF;
+
+    -- ============================================================
+    -- SMART RECYCLE BIN: Check if shift has any child data
+    -- ============================================================
+    SELECT (
+        (SELECT COUNT(*) FROM t_reading      WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_cashsales    WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_credits      WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_expense      WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_digital_sales WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_attendance   WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_denomination WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_2toil        WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_receipts     WHERE closing_id = p_closing_id)
+    ) INTO v_has_child_data;
+
+    -- ============================================================
+    -- Only move to recycle bin if there's actual child data
+    -- ============================================================
+    IF v_has_child_data > 0 THEN
+
+        -- 1. Move closing record to deleted table
+        INSERT INTO t_closing_deleted (
+            closing_id, closer_id, cashier_id, location_code, cash, ex_short,
+            closing_status, notes, created_by, updated_by, updation_date,
+            creation_date, closing_date, close_reading_time, cashflow_id,
+            deleted_by, deleted_at, deletion_reason
+        )
+        SELECT
+            closing_id, closer_id, cashier_id, location_code, cash, ex_short,
+            closing_status, notes, created_by, updated_by, updation_date,
+            creation_date, closing_date, close_reading_time, cashflow_id,
+            v_deleted_by, NOW(), v_deletion_reason
+        FROM t_closing
+        WHERE closing_id = p_closing_id;
+
+        -- 2. Move pump readings
+        IF EXISTS (SELECT 1 FROM t_reading WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_reading_deleted (
+                reading_id, closing_id, opening_reading, closing_reading, pump_id,
+                price, testing, created_by, updated_by, updation_date, creation_date,
+                deleted_by, deleted_at
+            )
+            SELECT
+                reading_id, closing_id, opening_reading, closing_reading, pump_id,
+                price, testing, created_by, updated_by, updation_date, creation_date,
+                v_deleted_by, NOW()
+            FROM t_reading
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 3. Move cash sales
+        IF EXISTS (SELECT 1 FROM t_cashsales WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_cashsales_deleted (
+                cashsales_id, closing_id, Bill_no, product_id, price, price_discount,
+                qty, notes, amount, created_by, updated_by, updation_date,
+                creation_date, bill_id, vehicle_number, odometer_reading,
+                deleted_by, deleted_at
+            )
+            SELECT
+                cashsales_id, closing_id, Bill_no, product_id, price, price_discount,
+                qty, notes, amount, created_by, updated_by, updation_date,
+                creation_date, bill_id, vehicle_number, odometer_reading,
+                v_deleted_by, NOW()
+            FROM t_cashsales
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 4. Move credit sales
+        IF EXISTS (SELECT 1 FROM t_credits WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_credits_deleted (
+                tcredit_id, closing_id, bill_no, creditlist_id, product_id,
+                price, price_discount, qty, amount, notes, created_by, updated_by,
+                updation_date, creation_date, vehicle_number, indent_number,
+                settlement_date, recon_id, bill_id, odometer_reading,
+                deleted_by, deleted_at
+            )
+            SELECT
+                tcredit_id, closing_id, bill_no, creditlist_id, product_id,
+                price, price_discount, qty, amount, notes, created_by, updated_by,
+                updation_date, creation_date, vehicle_number, indent_number,
+                settlement_date, recon_id, bill_id, odometer_reading,
+                v_deleted_by, NOW()
+            FROM t_credits
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 5. Move expenses
+        IF EXISTS (SELECT 1 FROM t_expense WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_expense_deleted (
+                texpense_id, closing_id, expense_id, amount, creditlist_id, notes,
+                created_by, updated_by, updation_date, creation_date,
+                deleted_by, deleted_at
+            )
+            SELECT
+                texpense_id, closing_id, expense_id, amount, creditlist_id, notes,
+                created_by, updated_by, updation_date, creation_date,
+                v_deleted_by, NOW()
+            FROM t_expense
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 6. Move digital sales
+        IF EXISTS (SELECT 1 FROM t_digital_sales WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_digital_sales_deleted (
+                digital_sales_id, closing_id, vendor_id, amount, transaction_date,
+                notes, created_by, updated_by, creation_date, updation_date,
+                deleted_by, deleted_at
+            )
+            SELECT
+                digital_sales_id, closing_id, vendor_id, amount, transaction_date,
+                notes, created_by, updated_by, creation_date, updation_date,
+                v_deleted_by, NOW()
+            FROM t_digital_sales
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 7. Move attendance
+        IF EXISTS (SELECT 1 FROM t_attendance WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_attendance_deleted (
+                tattendance_id, person_id, closing_id, shift_type, in_time, out_time,
+                notes, created_by, updated_by, updation_date, creation_date,
+                in_date, out_date,
+                deleted_by, deleted_at
+            )
+            SELECT
+                tattendance_id, person_id, closing_id, shift_type, in_time, out_time,
+                notes, created_by, updated_by, updation_date, creation_date,
+                in_date, out_date,
+                v_deleted_by, NOW()
+            FROM t_attendance
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 8. Move denominations
+        IF EXISTS (SELECT 1 FROM t_denomination WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_denomination_deleted (
+                denom_id, denomination, denomcount, closing_id, created_by, updated_by,
+                updation_date, creation_date,
+                deleted_by, deleted_at
+            )
+            SELECT
+                denom_id, denomination, denomcount, closing_id, created_by, updated_by,
+                updation_date, creation_date,
+                v_deleted_by, NOW()
+            FROM t_denomination
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 9. Move 2T oil sales
+        IF EXISTS (SELECT 1 FROM t_2toil WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_2toil_deleted (
+                oil_id, product_id, closing_id, price, given_qty, returned_qty,
+                created_by, updated_by, updation_date, creation_date,
+                deleted_by, deleted_at
+            )
+            SELECT
+                oil_id, product_id, closing_id, price, given_qty, returned_qty,
+                created_by, updated_by, updation_date, creation_date,
+                v_deleted_by, NOW()
+            FROM t_2toil
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 10. Move credit receipts (Collections tab)
+        IF EXISTS (SELECT 1 FROM t_receipts WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_receipts_deleted (
+                treceipt_id, receipt_no, creditlist_id, digital_creditlist_id,
+                receipt_type, amount, notes, location_code, closing_id,
+                created_by, updated_by, creation_date, updation_date, receipt_date,
+                cashflow_date, pending_cashflow_id, recon_match_id,
+                manual_recon_flag, manual_recon_by, manual_recon_date,
+                source_txn_id, source_split_id,
+                deleted_by, deleted_at
+            )
+            SELECT
+                treceipt_id, receipt_no, creditlist_id, digital_creditlist_id,
+                receipt_type, amount, notes, location_code, closing_id,
+                created_by, updated_by, creation_date, updation_date, receipt_date,
+                cashflow_date, pending_cashflow_id, recon_match_id,
+                manual_recon_flag, manual_recon_by, manual_recon_date,
+                source_txn_id, source_split_id,
+                v_deleted_by, NOW()
+            FROM t_receipts
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+    END IF;
+    -- If v_has_child_data = 0, skip recycle bin (just an empty header — hard delete)
+
+    -- ============================================================
+    -- Delete from original tables (either way)
+    -- ============================================================
+    DELETE FROM t_2toil          WHERE closing_id = p_closing_id;
+    DELETE FROM t_credits        WHERE closing_id = p_closing_id;
+    DELETE FROM t_digital_sales  WHERE closing_id = p_closing_id;
+    DELETE FROM t_denomination   WHERE closing_id = p_closing_id;
+    DELETE FROM t_expense        WHERE closing_id = p_closing_id;
+    DELETE FROM t_cashsales      WHERE closing_id = p_closing_id;
+    DELETE FROM t_reading        WHERE closing_id = p_closing_id;
+    DELETE FROM t_attendance     WHERE closing_id = p_closing_id;
+    DELETE FROM t_receipts       WHERE closing_id = p_closing_id;
+    DELETE FROM t_closing        WHERE closing_id = p_closing_id;
+
+    COMMIT;
+
+END //
+
+DELIMITER ;

--- a/db/migrations/add-receipts-to-restore-closing.sql
+++ b/db/migrations/add-receipts-to-restore-closing.sql
@@ -1,0 +1,235 @@
+-- ============================================================
+-- restore_closing: also restore t_receipts rows
+--
+-- Counterpart to add-receipts-to-delete-closing.sql — moves
+-- archived credit-receipt rows (Collections tab) back from
+-- t_receipts_deleted to t_receipts when a deleted draft closing
+-- is restored.
+--
+-- Full re-declaration of restore_closing (based on
+-- restore-closing-procedure.sql) with t_receipts handling added
+-- alongside the existing tables. Safe to re-run: uses
+-- DROP PROCEDURE IF EXISTS.
+-- ============================================================
+
+DELIMITER //
+
+DROP PROCEDURE IF EXISTS restore_closing //
+
+CREATE PROCEDURE restore_closing (
+    IN p_deleted_record_id INT,
+    IN p_restored_by       VARCHAR(45)
+)
+BEGIN
+    DECLARE v_closing_id          INT;
+    DECLARE v_location_code       VARCHAR(50);
+    DECLARE v_closing_date        TIMESTAMP;
+    DECLARE v_already_exists      INT DEFAULT 0;
+    DECLARE v_cashflow_closed     INT DEFAULT 0;
+
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    -- Resolve closing_id, location and date from the audit record
+    SELECT closing_id, location_code, closing_date
+    INTO v_closing_id, v_location_code, v_closing_date
+    FROM t_closing_deleted
+    WHERE deleted_record_id = p_deleted_record_id;
+
+    IF v_closing_id IS NULL THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'Deleted record not found. It may have already been restored or does not exist.';
+    END IF;
+
+    -- Guard: prevent restoring if closing_id already exists in live table
+    SELECT COUNT(*) INTO v_already_exists
+    FROM t_closing
+    WHERE closing_id = v_closing_id;
+
+    IF v_already_exists > 0 THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'Cannot restore — a shift with this closing_id already exists in the live table.';
+    END IF;
+
+    -- Guard: for cashflow-enabled locations, block restore if cashflow for
+    -- that date is already CLOSED (data would be orphaned outside the cashflow).
+    SELECT COUNT(*) INTO v_cashflow_closed
+    FROM t_cashflow_closing
+    WHERE location_code   = v_location_code
+      AND cashflow_date   = DATE(v_closing_date)
+      AND closing_status  = 'CLOSED';
+
+    IF v_cashflow_closed > 0 THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'Cannot restore — the cashflow for this shift\'s date is already closed. Reopen the cashflow first.';
+    END IF;
+
+    -- ── 1. Restore closing header ──────────────────────────────
+    INSERT INTO t_closing (
+        closing_id, closer_id, cashier_id, location_code, cash, ex_short,
+        closing_status, notes, created_by, updated_by, updation_date,
+        creation_date, closing_date, close_reading_time, cashflow_id
+        -- credit_billing_stopped omitted: defaults to 0
+    )
+    SELECT
+        closing_id, closer_id, cashier_id, location_code, cash, ex_short,
+        closing_status, notes, created_by, p_restored_by, NOW(),
+        creation_date, closing_date, close_reading_time, cashflow_id
+    FROM t_closing_deleted
+    WHERE deleted_record_id = p_deleted_record_id;
+
+    -- ── 2. Restore pump readings ───────────────────────────────
+    IF EXISTS (SELECT 1 FROM t_reading_deleted WHERE closing_id = v_closing_id) THEN
+        INSERT INTO t_reading (
+            reading_id, closing_id, opening_reading, closing_reading, pump_id,
+            price, testing, created_by, updated_by, updation_date, creation_date
+        )
+        SELECT
+            reading_id, closing_id, opening_reading, closing_reading, pump_id,
+            price, testing, created_by, p_restored_by, NOW(), creation_date
+        FROM t_reading_deleted
+        WHERE closing_id = v_closing_id;
+    END IF;
+
+    -- ── 3. Restore cash sales ──────────────────────────────────
+    IF EXISTS (SELECT 1 FROM t_cashsales_deleted WHERE closing_id = v_closing_id) THEN
+        INSERT INTO t_cashsales (
+            cashsales_id, closing_id, Bill_no, product_id, price, price_discount,
+            qty, notes, amount, created_by, updated_by, updation_date,
+            creation_date, bill_id, vehicle_number, odometer_reading
+        )
+        SELECT
+            cashsales_id, closing_id, Bill_no, product_id, price, price_discount,
+            qty, notes, amount, created_by, p_restored_by, NOW(),
+            creation_date, bill_id, vehicle_number, odometer_reading
+        FROM t_cashsales_deleted
+        WHERE closing_id = v_closing_id;
+    END IF;
+
+    -- ── 4. Restore credit sales ────────────────────────────────
+    IF EXISTS (SELECT 1 FROM t_credits_deleted WHERE closing_id = v_closing_id) THEN
+        INSERT INTO t_credits (
+            tcredit_id, closing_id, bill_no, creditlist_id, product_id,
+            price, price_discount, qty, amount, notes, created_by, updated_by,
+            updation_date, creation_date, vehicle_number, indent_number,
+            settlement_date, recon_id, bill_id, odometer_reading
+        )
+        SELECT
+            tcredit_id, closing_id, bill_no, creditlist_id, product_id,
+            price, price_discount, qty, amount, notes, created_by, p_restored_by,
+            NOW(), creation_date, vehicle_number, indent_number,
+            settlement_date, recon_id, bill_id, odometer_reading
+        FROM t_credits_deleted
+        WHERE closing_id = v_closing_id;
+    END IF;
+
+    -- ── 5. Restore expenses ────────────────────────────────────
+    IF EXISTS (SELECT 1 FROM t_expense_deleted WHERE closing_id = v_closing_id) THEN
+        INSERT INTO t_expense (
+            texpense_id, closing_id, expense_id, amount, creditlist_id, notes,
+            created_by, updated_by, updation_date, creation_date
+        )
+        SELECT
+            texpense_id, closing_id, expense_id, amount, creditlist_id, notes,
+            created_by, p_restored_by, NOW(), creation_date
+        FROM t_expense_deleted
+        WHERE closing_id = v_closing_id;
+    END IF;
+
+    -- ── 6. Restore digital sales ───────────────────────────────
+    IF EXISTS (SELECT 1 FROM t_digital_sales_deleted WHERE closing_id = v_closing_id) THEN
+        INSERT INTO t_digital_sales (
+            digital_sales_id, closing_id, vendor_id, amount, transaction_date,
+            notes, created_by, updated_by, creation_date, updation_date
+        )
+        SELECT
+            digital_sales_id, closing_id, vendor_id, amount, transaction_date,
+            notes, created_by, p_restored_by, creation_date, NOW()
+        FROM t_digital_sales_deleted
+        WHERE closing_id = v_closing_id;
+    END IF;
+
+    -- ── 7. Restore attendance ──────────────────────────────────
+    IF EXISTS (SELECT 1 FROM t_attendance_deleted WHERE closing_id = v_closing_id) THEN
+        INSERT INTO t_attendance (
+            tattendance_id, person_id, closing_id, shift_type, in_time, out_time,
+            notes, created_by, updated_by, updation_date, creation_date,
+            in_date, out_date
+        )
+        SELECT
+            tattendance_id, person_id, closing_id, shift_type, in_time, out_time,
+            notes, created_by, p_restored_by, NOW(), creation_date,
+            in_date, out_date
+        FROM t_attendance_deleted
+        WHERE closing_id = v_closing_id;
+    END IF;
+
+    -- ── 8. Restore denominations ───────────────────────────────
+    IF EXISTS (SELECT 1 FROM t_denomination_deleted WHERE closing_id = v_closing_id) THEN
+        INSERT INTO t_denomination (
+            denom_id, denomination, denomcount, closing_id, created_by, updated_by,
+            updation_date, creation_date
+        )
+        SELECT
+            denom_id, denomination, denomcount, closing_id, created_by, p_restored_by,
+            NOW(), creation_date
+        FROM t_denomination_deleted
+        WHERE closing_id = v_closing_id;
+    END IF;
+
+    -- ── 9. Restore 2T oil sales ────────────────────────────────
+    IF EXISTS (SELECT 1 FROM t_2toil_deleted WHERE closing_id = v_closing_id) THEN
+        INSERT INTO t_2toil (
+            oil_id, product_id, closing_id, price, given_qty, returned_qty,
+            created_by, updated_by, updation_date, creation_date
+        )
+        SELECT
+            oil_id, product_id, closing_id, price, given_qty, returned_qty,
+            created_by, p_restored_by, NOW(), creation_date
+        FROM t_2toil_deleted
+        WHERE closing_id = v_closing_id;
+    END IF;
+
+    -- ── 10. Restore credit receipts (Collections tab) ──────────
+    IF EXISTS (SELECT 1 FROM t_receipts_deleted WHERE closing_id = v_closing_id) THEN
+        INSERT INTO t_receipts (
+            treceipt_id, receipt_no, creditlist_id, digital_creditlist_id,
+            receipt_type, amount, notes, location_code, closing_id,
+            created_by, updated_by, creation_date, updation_date, receipt_date,
+            cashflow_date, pending_cashflow_id, recon_match_id,
+            manual_recon_flag, manual_recon_by, manual_recon_date,
+            source_txn_id, source_split_id
+        )
+        SELECT
+            treceipt_id, receipt_no, creditlist_id, digital_creditlist_id,
+            receipt_type, amount, notes, location_code, closing_id,
+            created_by, p_restored_by, creation_date, NOW(), receipt_date,
+            cashflow_date, pending_cashflow_id, recon_match_id,
+            manual_recon_flag, manual_recon_by, manual_recon_date,
+            source_txn_id, source_split_id
+        FROM t_receipts_deleted
+        WHERE closing_id = v_closing_id;
+    END IF;
+
+    -- ── Cleanup recycle bin ────────────────────────────────────
+    DELETE FROM t_reading_deleted      WHERE closing_id = v_closing_id;
+    DELETE FROM t_cashsales_deleted    WHERE closing_id = v_closing_id;
+    DELETE FROM t_credits_deleted      WHERE closing_id = v_closing_id;
+    DELETE FROM t_expense_deleted      WHERE closing_id = v_closing_id;
+    DELETE FROM t_digital_sales_deleted WHERE closing_id = v_closing_id;
+    DELETE FROM t_attendance_deleted   WHERE closing_id = v_closing_id;
+    DELETE FROM t_denomination_deleted WHERE closing_id = v_closing_id;
+    DELETE FROM t_2toil_deleted        WHERE closing_id = v_closing_id;
+    DELETE FROM t_receipts_deleted     WHERE closing_id = v_closing_id;
+    DELETE FROM t_closing_deleted      WHERE deleted_record_id = p_deleted_record_id;
+
+    COMMIT;
+
+END //
+
+DELIMITER ;

--- a/public/javascripts/app-scripts.js
+++ b/public/javascripts/app-scripts.js
@@ -1476,6 +1476,118 @@ function formDigitalSales(digitalSalesId, digitalSalesTag, saleObjRowNum, user) 
     };
 }
 
+// Toggle the digital-vendor cell in a Collections row based on the selected receipt type
+function toggleReceiptVendorCell(selectEl, rowNo) {
+    const vendorCell = document.getElementById('credit-receipts-vendor-cell-' + rowNo);
+    if (!vendorCell) {
+        return;
+    }
+    if (selectEl.value === 'Digital') {
+        vendorCell.style.display = '';
+    } else {
+        vendorCell.style.display = 'none';
+        const vendorField = document.getElementById('credit-receipts-vendor-' + rowNo);
+        if (vendorField) {
+            vendorField.value = '';
+        }
+    }
+}
+
+// Collections tab - add credit receipts to DB via ajax
+function saveCreditReceipts() {
+    return new Promise((resolve, reject) => {
+        const receiptTag = 'credit-receipts-';
+        const receiptRow = receiptTag + 'table-row-';
+        const tabToActivate = 'expenses_tab';
+        const currentTabId = 'new_credit_receipts';
+        const receiptObj = document.getElementById(currentTabId).querySelectorAll('[id^=' + receiptRow + ']:not([type="hidden"])');
+        let newReceipts = [], updateReceipts = [], newHiddenFieldsArr = [];
+        const user = JSON.parse(document.getElementById("user").value);
+        let hasValidationError = false;
+
+        receiptObj.forEach((receiptRowObj) => {
+            if (!receiptRowObj.className.includes('d-md-none')) {
+                const receiptObjRowNum = receiptRowObj.id.replace(receiptRow, '');
+                const typeField = document.getElementById(receiptTag + 'type-' + receiptObjRowNum);
+                const creditPartyField = document.getElementById(receiptTag + 'creditparty-' + receiptObjRowNum);
+                const vendorField = document.getElementById(receiptTag + 'vendor-' + receiptObjRowNum);
+                const amountField = document.getElementById(receiptTag + 'amt-' + receiptObjRowNum);
+                const dateField = document.getElementById(receiptTag + 'receipt-date-' + receiptObjRowNum);
+                const hiddenField = document.getElementById(receiptTag + receiptObjRowNum + '_hiddenId');
+
+                const hasCreditParty = creditPartyField.value;
+                const hasAmount = parseFloat(amountField.value) > 0;
+                const hasDate = dateField.value;
+                const isExistingRecord = hiddenField.value && parseInt(hiddenField.value) > 0;
+
+                if (hasCreditParty || hasAmount || hasDate || isExistingRecord) {
+
+                    if (!hasCreditParty) {
+                        alert('Please select a Credit Party for all Collections entries');
+                        hasValidationError = true;
+                        return;
+                    }
+
+                    if (typeField.value === 'Digital' && !vendorField.value) {
+                        alert('Please select a Digital Vendor for digital Collections entries');
+                        hasValidationError = true;
+                        return;
+                    }
+
+                    if (!hasAmount) {
+                        alert('Please enter an amount greater than 0 for all Collections entries');
+                        hasValidationError = true;
+                        return;
+                    }
+
+                    if (!hasDate) {
+                        alert('Please provide a receipt date for all Collections entries');
+                        hasValidationError = true;
+                        return;
+                    }
+
+                    if (isExistingRecord) {
+                        updateReceipts.push(formCreditReceipts(hiddenField.value, receiptTag, receiptObjRowNum, user));
+                    } else {
+                        newHiddenFieldsArr.push(receiptTag + receiptObjRowNum);
+                        newReceipts.push(formCreditReceipts(undefined, receiptTag, receiptObjRowNum, user));
+                    }
+                }
+            }
+        });
+
+        if (hasValidationError) {
+            resolve(false);
+            return;
+        }
+        postAjaxNew('new-credit-receipts', newReceipts, updateReceipts, tabToActivate, currentTabId, newHiddenFieldsArr, 'treceipt_id')
+            .then((data) => {
+                resolve(data);
+            });
+
+        if (newReceipts.length === 0 && updateReceipts.length === 0) {
+            resolve(true);      // tab click handled in trackMenu()
+        }
+    });
+}
+
+function formCreditReceipts(receiptId, receiptTag, receiptObjRowNum, user) {
+    const typeValue = document.getElementById(receiptTag + 'type-' + receiptObjRowNum).value;
+    return {
+        'treceipt_id': receiptId,
+        'closing_id': document.getElementById('closing_hiddenId').value,
+        'location_code': user.location_code,
+        'receipt_type': typeValue,
+        'creditlist_id': document.getElementById(receiptTag + 'creditparty-' + receiptObjRowNum).value,
+        'digital_creditlist_id': typeValue === 'Digital' ? document.getElementById(receiptTag + 'vendor-' + receiptObjRowNum).value : null,
+        'amount': document.getElementById(receiptTag + 'amt-' + receiptObjRowNum).value,
+        'receipt_date': document.getElementById(receiptTag + 'receipt-date-' + receiptObjRowNum).value,
+        'notes': document.getElementById(receiptTag + 'notes-' + receiptObjRowNum).value,
+        'created_by': user.User_Name,
+        'updated_by': user.User_Name
+    };
+}
+
 
 
 function getCreditType(creditSaleTag, creditObjRowNum) {
@@ -2856,6 +2968,14 @@ function showAddedDigitalSalesRow(prefix) {
 // (see credit-entry-modal.js) since the row stays off-screen until it's opened there.
 function showAddedCreditRow() {
     showAddedRow('credit', calculateCreditTotal);
+    applyCreditBillDateConstraints();
+}
+
+// Wrapper that calls the generic showAddedRow for the Collections table, then
+// re-applies the shared shift-scoped date constraints (receipt-date shares the
+// credit-bill-date class with the Credit tab's bill-date field).
+function showAddedCreditReceiptsRow() {
+    showAddedRow('credit-receipts', calculateCreditReceiptsTotal);
     applyCreditBillDateConstraints();
 }
 

--- a/public/javascripts/app-scripts.js
+++ b/public/javascripts/app-scripts.js
@@ -2851,13 +2851,11 @@ function showAddedDigitalSalesRow(prefix) {
     }
 }
 
-// Create a wrapper function that calls showAddedRow and then initializes vehicle select2
+// Wrapper that calls the generic showAddedRow for the credit sales table.
+// Vehicle select2 initialization now happens lazily inside the Add/Edit modal
+// (see credit-entry-modal.js) since the row stays off-screen until it's opened there.
 function showAddedCreditRow() {
-    // First call the existing showAddedRow function
     showAddedRow('credit', calculateCreditTotal);
-    
-    // Then initialize Select2 for any new vehicle dropdowns
-    initializeNewVehicleSelects();
     applyCreditBillDateConstraints();
 }
 
@@ -2867,29 +2865,6 @@ if (document.readyState === 'loading') {
     });
 } else {
     applyCreditBillDateConstraints();
-}
-
-// Function to initialize Select2 for newly added rows
-function initializeNewVehicleSelects() {
-    const prefix = 'credit-';
-    const userRowsCnt = document.getElementById(prefix + 'table').rows.length;
-    
-    for (let i = 0; i < userRowsCnt; i++) {
-        const vehicleSelectId = prefix + 'vehicle-' + i;
-        const vehicleSelect = document.getElementById(vehicleSelectId);
-        
-        if (vehicleSelect && !$(vehicleSelect).hasClass('select2-hidden-accessible')) {
-            $(vehicleSelect).select2({
-                placeholder: 'Search vehicle number...',
-                allowClear: true,
-                width: '100%',
-                minimumInputLength: 0,
-                theme: 'default'
-            });
-            
-            // REMOVED: Vehicle-first auto-population event handler
-        }
-    }
 }
 
 // Optional: Validate that selected vehicle belongs to selected credit party

--- a/public/javascripts/credit-entry-modal.js
+++ b/public/javascripts/credit-entry-modal.js
@@ -1,0 +1,238 @@
+// Credit sales tab: Add/Edit via a shared modal instead of cramped inline table editing.
+//
+// The credit table (see +addCredits in new-closing-mixins.pug) renders two rows per
+// line: a compact, read-only summary row that's always visible, and a hidden detail
+// row holding the real, submitted form fields (same ids/names as before, unchanged).
+// Opening a row for add/edit moves its actual field elements into the shared
+// #creditEntryModal; closing the modal moves them back. Nothing about how the fields
+// are collected/saved (saveCreditSales, calculateTotal, hideRow, etc.) changes.
+
+var creditModalState = { rowNo: null, isNew: false, savedThisSession: false, deleteRequested: false, moved: {} };
+
+var CREDIT_MODAL_SIMPLE_FIELDS = ['bill-date', 'product', 'billno', 'creditparty', 'odometer', 'price', 'discount', 'qty', 'amt', 'notes'];
+
+function creditFieldEl(rowNo, field) {
+    return document.getElementById('credit-' + field + '-' + rowNo);
+}
+
+function moveCreditFieldToSlot(rowNo, field, slotId) {
+    var el = creditFieldEl(rowNo, field);
+    var slot = document.getElementById(slotId);
+    if (el && slot) {
+        creditModalState.moved[field] = { el: el, parent: el.parentNode, next: el.nextSibling };
+        slot.appendChild(el);
+    }
+}
+
+function moveCreditVehicleWrapToSlot(rowNo) {
+    var wrap = document.getElementById('credit-vehicle-wrap-' + rowNo);
+    var slot = document.getElementById('creditModalSlot-vehiclewrap');
+    if (wrap && slot) {
+        creditModalState.moved.vehiclewrap = { el: wrap, parent: wrap.parentNode, next: wrap.nextSibling };
+        slot.appendChild(wrap);
+    }
+}
+
+function moveCreditOffMeterToSlot(rowNo) {
+    var el = document.getElementById('credit-off-meter-' + rowNo);
+    var slot = document.getElementById('creditModalSlot-off-meter');
+    if (el && slot) {
+        creditModalState.moved['off-meter'] = { el: el, parent: el.parentNode, next: el.nextSibling };
+        slot.appendChild(el);
+    }
+}
+
+function restoreCreditModalFields() {
+    Object.keys(creditModalState.moved).forEach(function (field) {
+        var info = creditModalState.moved[field];
+        if (!info) return;
+        if (info.next && info.next.parentNode === info.parent) {
+            info.parent.insertBefore(info.el, info.next);
+        } else {
+            info.parent.appendChild(info.el);
+        }
+    });
+    creditModalState.moved = {};
+}
+
+// Vehicle select2 is initialized lazily here (rather than eagerly on page load) because
+// the detail row stays off-screen (display:none) until it's opened in this modal, and
+// select2 mis-measures its width when initialized on a hidden element.
+function initVehicleSelect2ForModal(rowNo) {
+    var select = document.getElementById('credit-vehicle-' + rowNo);
+    if (!select || typeof $ === 'undefined') return;
+    var $select = $(select);
+    if ($select.hasClass('select2-hidden-accessible')) {
+        $select.select2('destroy');
+    }
+    $select.select2({
+        placeholder: 'Search vehicle number...',
+        allowClear: true,
+        width: '100%',
+        minimumInputLength: 0,
+        theme: 'default',
+        dropdownParent: $('#creditEntryModal')
+    });
+}
+
+function findNextAvailableCreditRow() {
+    var table = document.getElementById('credit-table');
+    if (!table) return null;
+    var rowsCnt = table.rows.length;
+    for (var i = 0; i < rowsCnt; i++) {
+        var tr = document.getElementById('credit-table-row-' + i);
+        if (tr && tr.className === 'd-md-none') return i;
+    }
+    return null;
+}
+
+// "Add credits" button: reuses the existing showAddedCreditRow() to find/enable the
+// next free row and keep its side effects (default product price, total, etc.), then
+// immediately opens that row in the modal.
+function handleAddCreditRowClick() {
+    var rowNo = findNextAvailableCreditRow();
+    showAddedCreditRow();
+    if (rowNo === null) return; // showAddedCreditRow already alerted "max reached"
+    openCreditRowModal(rowNo, true);
+}
+
+function openCreditRowModal(rowNo, isNew) {
+    creditModalState.rowNo = rowNo;
+    creditModalState.isNew = !!isNew;
+    creditModalState.savedThisSession = false;
+    creditModalState.deleteRequested = false;
+
+    var titleEl = document.getElementById('creditEntryModalTitleText');
+    if (titleEl) titleEl.textContent = isNew ? 'Add Credit Sale' : 'Edit Credit Sale';
+    var deleteBtn = document.getElementById('creditModalDeleteBtn');
+    if (deleteBtn) deleteBtn.style.display = isNew ? 'none' : '';
+
+    $('#creditEntryModal').modal('show');
+
+    CREDIT_MODAL_SIMPLE_FIELDS.forEach(function (field) {
+        moveCreditFieldToSlot(rowNo, field, 'creditModalSlot-' + field);
+    });
+    moveCreditVehicleWrapToSlot(rowNo);
+    moveCreditOffMeterToSlot(rowNo);
+    initVehicleSelect2ForModal(rowNo);
+}
+
+function saveCreditRowModal() {
+    var rowNo = creditModalState.rowNo;
+    if (rowNo === null || rowNo === undefined) return;
+
+    var amtEl = creditFieldEl(rowNo, 'amt');
+    var creditPartyEl = creditFieldEl(rowNo, 'creditparty');
+    var amt = amtEl && amtEl.value ? currenciesAsFloat(amtEl.value) : 0;
+
+    if (amt > 0 && creditPartyEl && !creditPartyEl.value) {
+        alert('Please select a Company before saving this credit sale.');
+        return;
+    }
+
+    if (creditModalState.isNew && amt <= 0) {
+        // Nothing meaningful entered - closing without data discards the row.
+        $('#creditEntryModal').modal('hide');
+        return;
+    }
+
+    creditModalState.savedThisSession = true;
+    var detailTr = document.getElementById('credit-table-row-' + rowNo);
+    if (detailTr) detailTr.className = '';
+    $('#creditEntryModal').modal('hide');
+}
+
+function deleteCreditRowModal() {
+    var rowNo = creditModalState.rowNo;
+    if (rowNo === null || rowNo === undefined) return;
+    if (!confirm('Delete this credit sale entry?')) return;
+    creditModalState.deleteRequested = true;
+    $('#creditEntryModal').modal('hide');
+}
+
+// Delete button on the compact summary row (row isn't open in the modal).
+function deleteCreditRow(rowNo) {
+    if (!confirm('Delete this credit sale entry?')) return;
+    performCreditRowDelete(rowNo);
+}
+
+function performCreditRowDelete(rowNo) {
+    hideRow('credit-table-row-' + rowNo, 'remove-credit-sale', function () {
+        calculateCreditTotal();
+        refreshCreditSummaryRow(rowNo);
+    });
+}
+
+$(document).on('hidden.bs.modal', '#creditEntryModal', function () {
+    var rowNo = creditModalState.rowNo;
+    if (rowNo === null || rowNo === undefined) return;
+
+    restoreCreditModalFields();
+
+    if (creditModalState.deleteRequested) {
+        performCreditRowDelete(rowNo);
+    } else if (creditModalState.isNew && !creditModalState.savedThisSession) {
+        // Closed (X / Close / Esc) without saving a newly added row - discard it.
+        performCreditRowDelete(rowNo);
+    } else {
+        refreshCreditSummaryRow(rowNo);
+        calculateCreditTotal();
+    }
+
+    creditModalState.rowNo = null;
+    creditModalState.isNew = false;
+    creditModalState.savedThisSession = false;
+    creditModalState.deleteRequested = false;
+});
+
+function refreshCreditSummaryRow(rowNo) {
+    var detailTr = document.getElementById('credit-table-row-' + rowNo);
+    var summaryTr = document.getElementById('credit-summary-row-' + rowNo);
+    if (!detailTr || !summaryTr) return;
+
+    var isUsed = detailTr.className !== 'd-md-none';
+    summaryTr.classList.toggle('d-md-none', !isUsed);
+
+    if (!isUsed) {
+        ['date', 'product', 'billno', 'company', 'vehicle', 'amt'].forEach(function (field) {
+            setCreditSummaryText('credit-summary-' + field + '-' + rowNo, '');
+        });
+        return;
+    }
+
+    var dateEl = creditFieldEl(rowNo, 'bill-date');
+    setCreditSummaryText('credit-summary-date-' + rowNo, dateEl ? dateEl.value : '');
+    setCreditSummaryText('credit-summary-product-' + rowNo, selectedCreditOptionText(creditFieldEl(rowNo, 'product')));
+    var billNoEl = creditFieldEl(rowNo, 'billno');
+    setCreditSummaryText('credit-summary-billno-' + rowNo, billNoEl ? billNoEl.value : '');
+    setCreditSummaryText('credit-summary-company-' + rowNo, selectedCreditOptionText(creditFieldEl(rowNo, 'creditparty')));
+    setCreditSummaryText('credit-summary-vehicle-' + rowNo, selectedCreditOptionText(document.getElementById('credit-vehicle-' + rowNo)));
+    var amtEl = creditFieldEl(rowNo, 'amt');
+    var amtVal = amtEl && amtEl.value ? currenciesAsFloat(amtEl.value) : 0;
+    setCreditSummaryText('credit-summary-amt-' + rowNo, formatCurrencies(amtVal || 0, toFixedValue));
+}
+
+function setCreditSummaryText(id, text) {
+    var el = document.getElementById(id);
+    if (el) el.textContent = text || '';
+}
+
+function selectedCreditOptionText(select) {
+    if (!select || select.selectedIndex < 0) return '';
+    var opt = select.options[select.selectedIndex];
+    return opt ? opt.text : '';
+}
+
+function initCreditSummaryRows() {
+    var rows = document.querySelectorAll('[id^="credit-table-row-"]');
+    rows.forEach(function (tr) {
+        var rowNo = tr.id.replace('credit-table-row-', '');
+        refreshCreditSummaryRow(rowNo);
+    });
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initCreditSummaryRows);
+} else {
+    initCreditSummaryRows();
+}

--- a/public/javascripts/draft-edit-scripts.js
+++ b/public/javascripts/draft-edit-scripts.js
@@ -57,6 +57,10 @@ function calculateDigitalSalesTotal() {
     calculateTotal('digital-sales-');
 }
 
+function calculateCreditReceiptsTotal() {
+    calculateTotal('credit-receipts-');
+}
+
 function calculateExpenseTotal() {
     calculateTotal('exp-');
 }
@@ -77,6 +81,13 @@ function calculateDigitalSalesAndTrackMenu(obj) {
      setTimeout(() => {
         trackMenu(obj);
         calculateDigitalSalesTotal();
+    }, 100);
+}
+
+function calculateCreditReceiptsAndTrackMenu(obj) {
+     setTimeout(() => {
+        trackMenu(obj);
+        calculateCreditReceiptsTotal();
     }, 100);
 }
 
@@ -214,6 +225,7 @@ function getSaveFunction(clickedTab) {
             case 'cash_sales_tab':
             case 'credit_sales_tab':
             case 'digital_sales_tab':
+            case 'credit_receipts_tab':
             case 'closing_tab':
             case 'reading_tab':
             case 'sales_2t_tab':
@@ -245,7 +257,10 @@ function getSaveFunction(clickedTab) {
                 break;
             case 'digital_sales_tab':
                 saveFunctionName = 'saveDigitalSales';
-                break;    
+                break;
+            case 'credit_receipts_tab':
+                saveFunctionName = 'saveCreditReceipts';
+                break;
             case 'expenses_tab':
                 saveFunctionName = 'saveExpensesAndDenoms';
                 break;
@@ -302,6 +317,7 @@ function disableOtherTabs(tabName) {
             disableLink(document.getElementById('cash_sales_tab'));
             disableLink(document.getElementById('credit_sales_tab'));
             disableLink(document.getElementById('digital_sales_tab'));
+            disableLink(document.getElementById('credit_receipts_tab'));
             disableLink(document.getElementById('expenses_tab'));
             disableLink(document.getElementById('summary_tab'));
             disableLink(document.getElementById('attendance_tab'));
@@ -313,6 +329,7 @@ function disableOtherTabs(tabName) {
             disableLink(document.getElementById('cash_sales_tab'));
             disableLink(document.getElementById('credit_sales_tab'));
             disableLink(document.getElementById('digital_sales_tab'));
+            disableLink(document.getElementById('credit_receipts_tab'));
             disableLink(document.getElementById('summary_tab'));
             disableLink(document.getElementById('attendance_tab'));
             break;
@@ -331,6 +348,7 @@ function enableOtherTabs(tabName) {
             enableLink(document.getElementById('cash_sales_tab'));
             enableLink(document.getElementById('credit_sales_tab'));
             enableLink(document.getElementById('digital_sales_tab'));
+            enableLink(document.getElementById('credit_receipts_tab'));
             enableLink(document.getElementById('expenses_tab'));
             enableLink(document.getElementById('summary_tab'));
             enableLink(document.getElementById('attendance_tab'));
@@ -342,6 +360,7 @@ function enableOtherTabs(tabName) {
             enableLink(document.getElementById('cash_sales_tab'));
             enableLink(document.getElementById('credit_sales_tab'));
             enableLink(document.getElementById('digital_sales_tab'));
+            enableLink(document.getElementById('credit_receipts_tab'));
             enableLink(document.getElementById('summary_tab'));
             enableLink(document.getElementById('attendance_tab'));
             break;

--- a/routes/account-heads-routes.js
+++ b/routes/account-heads-routes.js
@@ -55,6 +55,14 @@ router.post(
     AccountHeadsController.updateRule
 );
 
+// Manual extra Bank+Party mapping for Credit Party / Supplier rules
+router.post(
+    "/rules/party",
+    isLoggedIn,
+    appSecurity.hasPermission("ADD_ACCOUNT_HEADS"),
+    AccountHeadsController.createPartyRule
+);
+
 router.post(
     "/rules/:id/delete",
     isLoggedIn,

--- a/views/account-heads.pug
+++ b/views/account-heads.pug
@@ -157,7 +157,7 @@ block content
             #tab-rules.tab-pane.fade(role="tabpanel")
                 p.text-muted.small.mb-3
                     i.bi.bi-info-circle.mr-1
-                    | Static rules are fully manageable here. Credit, Supplier and Bank rules are created automatically by the system — only the Entry Type can be overridden.
+                    | Static rules are fully manageable here. Credit, Supplier and Bank rules are created automatically by the system when the party is created — use "Add Rule" to map a Credit Party or Supplier to an additional bank account, and use the pencil icon to override an existing rule's Entry Type.
 
                 .row.mb-3
                     .col-12.col-md-4.col-lg-3
@@ -406,75 +406,141 @@ block content
         .modal-dialog.modal-lg(role="document")
             .modal-content
                 .modal-header
-                    h5.modal-title Add Static Ledger Rule
+                    h5.modal-title Add Ledger Rule
                     button.close(type="button", data-dismiss="modal", aria-label="Close")
                         span(aria-hidden="true") &times;
                 .modal-body
-                    p.text-muted.small Select what this rule applies to and the account head it should map to.
-                    form#addRuleForm(method='POST', action='/account-heads/rules')
-                        input(type="hidden", name="account_head_id", id="add_rule_head_id")
-                        input(type="hidden", name="ledger_name",     id="add_rule_ledger_name")
-                        input(type="hidden", name="applies_to_cashflow", id="add_rule_applies_cashflow", value="N")
-                        .form-group
-                            label Applies To *
-                            .form-check.form-check-inline
-                                input.form-check-input.add-rule-context(type="radio", name="context_type", id="add_rule_context_bank", value="BANK", checked)
-                                label.form-check-label(for="add_rule_context_bank") Bank
-                            .form-check.form-check-inline
-                                input.form-check-input.add-rule-context(type="radio", name="context_type", id="add_rule_context_cashflow", value="CASHFLOW")
-                                label.form-check-label(for="add_rule_context_cashflow") Cashflow
-                        .form-row
-                            .col-md-6#add_rule_bank_wrapper
-                                .form-group
-                                    label Bank *
-                                    select.form-control(name="bank_id", id="add_rule_bank_select", required)
-                                        option(value="") — Select Bank —
-                                        each bank in banks
-                                            option(value=bank.bank_id)
-                                                = bank.account_number ? `${bank.bank_name} (...${bank.account_number.slice(-4)})` : bank.bank_name
-                            .col-md-6
-                                .form-group
-                                    label Account Head (Ledger) *
-                                    select.form-control#add_rule_head_select(required)
-                                        option(value="") — Select Account Head —
-                                        each head in accountHeads
-                                            option(value=head.account_head_id, data-name=head.account_head_name)= head.account_head_name
-                        .form-row
-                            .col-md-3
-                                .form-group
-                                    label Entry Type *
-                                    select.form-control(name="allowed_entry_type", required)
-                                        option(value="BOTH") BOTH
-                                        option(value="DEBIT") DEBIT
-                                        option(value="CREDIT") CREDIT
-                            .col-md-3
-                                .form-group
-                                    label Notes Required
-                                    select.form-control(name="notes_required_flag")
-                                        option(value="N") No
-                                        option(value="Y") Yes
-                            .col-md-3
-                                .form-group
-                                    label Allow Split
-                                    select.form-control(name="allow_split_flag")
-                                        option(value="N") No
-                                        option(value="Y") Yes
-                            .col-md-3
-                                .form-group
-                                    label Max Amount
-                                    input.form-control(type="number", name="max_amount", step="0.01", placeholder="Blank = unlimited")
-                        .form-row
-                            .col-md-6
-                                .form-group
-                                    label Effective From
-                                    input.form-control(type="date", name="effective_start_date")
-                            .col-md-6
-                                .form-group
-                                    label Effective To
-                                    input.form-control(type="date", name="effective_end_date")
+                    .form-group
+                        label Rule Type *
+                        select.form-control#add_rule_type
+                            option(value="STATIC") Static (Bank / Cashflow)
+                            option(value="CREDIT") Credit Party
+                            option(value="SUPPLIER") Supplier
+
+                    #add_rule_static_section
+                        p.text-muted.small Select what this rule applies to and the account head it should map to.
+                        form#addRuleForm(method='POST', action='/account-heads/rules')
+                            input(type="hidden", name="account_head_id", id="add_rule_head_id")
+                            input(type="hidden", name="ledger_name",     id="add_rule_ledger_name")
+                            input(type="hidden", name="applies_to_cashflow", id="add_rule_applies_cashflow", value="N")
+                            .form-group
+                                label Applies To *
+                                .form-check.form-check-inline
+                                    input.form-check-input.add-rule-context(type="radio", name="context_type", id="add_rule_context_bank", value="BANK", checked)
+                                    label.form-check-label(for="add_rule_context_bank") Bank
+                                .form-check.form-check-inline
+                                    input.form-check-input.add-rule-context(type="radio", name="context_type", id="add_rule_context_cashflow", value="CASHFLOW")
+                                    label.form-check-label(for="add_rule_context_cashflow") Cashflow
+                            .form-row
+                                .col-md-6#add_rule_bank_wrapper
+                                    .form-group
+                                        label Bank *
+                                        select.form-control(name="bank_id", id="add_rule_bank_select", required)
+                                            option(value="") — Select Bank —
+                                            each bank in banks
+                                                option(value=bank.bank_id)
+                                                    = bank.account_number ? `${bank.bank_name} (...${bank.account_number.slice(-4)})` : bank.bank_name
+                                .col-md-6
+                                    .form-group
+                                        label Account Head (Ledger) *
+                                        select.form-control#add_rule_head_select(required)
+                                            option(value="") — Select Account Head —
+                                            each head in accountHeads
+                                                option(value=head.account_head_id, data-name=head.account_head_name)= head.account_head_name
+                            .form-row
+                                .col-md-3
+                                    .form-group
+                                        label Entry Type *
+                                        select.form-control(name="allowed_entry_type", required)
+                                            option(value="BOTH") BOTH
+                                            option(value="DEBIT") DEBIT
+                                            option(value="CREDIT") CREDIT
+                                .col-md-3
+                                    .form-group
+                                        label Notes Required
+                                        select.form-control(name="notes_required_flag")
+                                            option(value="N") No
+                                            option(value="Y") Yes
+                                .col-md-3
+                                    .form-group
+                                        label Allow Split
+                                        select.form-control(name="allow_split_flag")
+                                            option(value="N") No
+                                            option(value="Y") Yes
+                                .col-md-3
+                                    .form-group
+                                        label Max Amount
+                                        input.form-control(type="number", name="max_amount", step="0.01", placeholder="Blank = unlimited")
+                            .form-row
+                                .col-md-6
+                                    .form-group
+                                        label Effective From
+                                        input.form-control(type="date", name="effective_start_date")
+                                .col-md-6
+                                    .form-group
+                                        label Effective To
+                                        input.form-control(type="date", name="effective_end_date")
+
+                    #add_rule_party_section(style="display:none;")
+                        p.text-muted.small Map an existing Credit Party or Supplier to an additional bank account. The default Entry Type is fixed unless the location allows overriding it.
+                        form#addPartyRuleForm(method='POST', action='/account-heads/rules/party')
+                            input(type="hidden", name="source_type", id="add_party_source_type", value="CREDIT")
+                            input(type="hidden", name="party_id",    id="add_party_id")
+                            input(type="hidden", name="ledger_name", id="add_party_ledger_name")
+                            .form-row
+                                .col-md-6
+                                    .form-group
+                                        label Bank *
+                                        select.form-control(name="bank_id", id="add_party_bank_select", required)
+                                            option(value="") — Select Bank —
+                                            each bank in banks
+                                                option(value=bank.bank_id)
+                                                    = bank.account_number ? `${bank.bank_name} (...${bank.account_number.slice(-4)})` : bank.bank_name
+                                .col-md-6
+                                    .form-group
+                                        label#add_party_select_label Credit Party *
+                                        select.form-control#add_party_credit_select(required)
+                                            option(value="") — Select Credit Party —
+                                            each cp in creditParties
+                                                option(value=cp.creditlist_id, data-name=cp.Company_Name)= cp.Company_Name
+                                        select.form-control#add_party_supplier_select(style="display:none;")
+                                            option(value="") — Select Supplier —
+                                            each sup in suppliers
+                                                option(value=sup.supplier_id, data-name=sup.supplier_name)= sup.supplier_name
+                            .form-row
+                                .col-md-3
+                                    .form-group
+                                        label Entry Type
+                                        select.form-control#add_party_entry_type(name="allowed_entry_type", disabled)
+                                            option(value="CREDIT") CREDIT (fixed)
+                                .col-md-3
+                                    .form-group
+                                        label Notes Required
+                                        select.form-control(name="notes_required_flag")
+                                            option(value="N") No
+                                            option(value="Y") Yes
+                                .col-md-3
+                                    .form-group
+                                        label Allow Split
+                                        select.form-control(name="allow_split_flag")
+                                            option(value="N") No
+                                            option(value="Y") Yes
+                                .col-md-3
+                                    .form-group
+                                        label Max Amount
+                                        input.form-control(type="number", name="max_amount", step="0.01", placeholder="Blank = unlimited")
+                            .form-row
+                                .col-md-6
+                                    .form-group
+                                        label Effective From
+                                        input.form-control(type="date", name="effective_start_date")
+                                .col-md-6
+                                    .form-group
+                                        label Effective To
+                                        input.form-control(type="date", name="effective_end_date")
                 .modal-footer
                     button.btn.btn-secondary(type="button", data-dismiss="modal") Cancel
-                    button.btn.btn-success(type="submit", form="addRuleForm") Save
+                    button.btn.btn-success#addRuleSaveBtn(type="submit", form="addRuleForm") Save
 
     .modal.fade#editRuleModal(tabindex="-1", role="dialog", aria-hidden="true")
         .modal-dialog.modal-lg(role="document")
@@ -598,6 +664,10 @@ block content
         // ── Tab activation ────────────────────────────────────────────────
         const ACTIVE_TAB = '!{activeTab}';
 
+        // ── Credit/Supplier rule Entry Type override (per-location config) ──
+        const CREDIT_ENTRY_TYPE_OVERRIDE   = !{creditEntryTypeOverride};
+        const SUPPLIER_ENTRY_TYPE_OVERRIDE = !{supplierEntryTypeOverride};
+
         function syncAddBtn(tabId) {
             const addHeadBtn = document.getElementById('addHeadBtn');
             const addRuleBtn = document.getElementById('addRuleBtn');
@@ -708,6 +778,64 @@ block content
                 document.getElementById('add_rule_head_id').value     = '';
                 document.getElementById('add_rule_ledger_name').value = '';
                 setAddRuleContext(false);
+
+                document.getElementById('addPartyRuleForm').reset();
+                document.getElementById('add_party_id').value          = '';
+                document.getElementById('add_party_ledger_name').value = '';
+                document.getElementById('add_rule_type').value = 'STATIC';
+                setAddRuleType('STATIC');
+            });
+
+            // ── Add Rule: Static vs Credit Party vs Supplier ────────────────
+            function setAddRuleType(type) {
+                document.getElementById('add_rule_static_section').style.display = type === 'STATIC' ? '' : 'none';
+                document.getElementById('add_rule_party_section').style.display  = type === 'STATIC' ? 'none' : '';
+                document.getElementById('addRuleSaveBtn').setAttribute('form', type === 'STATIC' ? 'addRuleForm' : 'addPartyRuleForm');
+
+                document.getElementById('add_rule_bank_select').required = (type === 'STATIC');
+                document.getElementById('add_rule_head_select').required = (type === 'STATIC');
+
+                if (type === 'STATIC') return;
+
+                const isCredit = type === 'CREDIT';
+                document.getElementById('add_party_source_type').value = type;
+                document.getElementById('add_party_select_label').textContent = isCredit ? 'Credit Party *' : 'Supplier *';
+
+                const creditSelect   = document.getElementById('add_party_credit_select');
+                const supplierSelect = document.getElementById('add_party_supplier_select');
+                creditSelect.style.display   = isCredit ? '' : 'none';
+                supplierSelect.style.display = isCredit ? 'none' : '';
+                creditSelect.required   = isCredit;
+                supplierSelect.required = !isCredit;
+                document.getElementById('add_party_id').value          = '';
+                document.getElementById('add_party_ledger_name').value = '';
+
+                const override = isCredit ? CREDIT_ENTRY_TYPE_OVERRIDE : SUPPLIER_ENTRY_TYPE_OVERRIDE;
+                const fixed    = isCredit ? 'CREDIT' : 'DEBIT';
+                const entryTypeSelect = document.getElementById('add_party_entry_type');
+                if (override) {
+                    entryTypeSelect.disabled  = false;
+                    entryTypeSelect.innerHTML = '<option value="DEBIT">DEBIT</option><option value="CREDIT">CREDIT</option><option value="BOTH">BOTH</option>';
+                    entryTypeSelect.value     = fixed;
+                } else {
+                    entryTypeSelect.disabled  = true;
+                    entryTypeSelect.innerHTML = `<option value="${fixed}">${fixed} (fixed — enable override in Location Config to change)</option>`;
+                }
+            }
+
+            document.getElementById('add_rule_type').addEventListener('change', function () {
+                setAddRuleType(this.value);
+            });
+
+            document.getElementById('add_party_credit_select').addEventListener('change', function () {
+                const opt = this.options[this.selectedIndex];
+                document.getElementById('add_party_id').value          = opt.value;
+                document.getElementById('add_party_ledger_name').value = opt.dataset.name || '';
+            });
+            document.getElementById('add_party_supplier_select').addEventListener('change', function () {
+                const opt = this.options[this.selectedIndex];
+                document.getElementById('add_party_id').value          = opt.value;
+                document.getElementById('add_party_ledger_name').value = opt.dataset.name || '';
             });
 
             // ── Edit Account Head ─────────────────────────────────────────

--- a/views/edit-draft-closing.pug
+++ b/views/edit-draft-closing.pug
@@ -7,6 +7,7 @@ block content
     - var maxCashSalesRowCnt = config.maxCashSalesRowCnt;
     - var maxExpensesRowCnt = config.maxExpensesRowCnt;
     - var maxDigitalSalesRowCnt = config.maxDigitalSalesRowCnt;
+    - var maxCreditReceiptsRowCnt = config.maxCreditReceiptsRowCnt;
     - var currency = config.currency;
     - var denominationValues = config.denominationValues;
     - var denominationValuesJson = config.denominationValuesJson;
@@ -62,6 +63,9 @@ block content
                         a.nav-link#credit_sales_tab(data-toggle="tab" href="#new_credit_sales" onclick=`cashSaleOrCreditUpdateProductTypePrices(this, 'credit-')`) Credit Sales
                     li.nav-item.col-md
                         a.nav-link#digital_sales_tab(data-toggle="tab" href="#new_digital_sales" onclick=`calculateDigitalSalesAndTrackMenu(this)`) Digital Sales
+                    if allowCreditReceiptsInClosing
+                        li.nav-item.col-md
+                            a.nav-link#credit_receipts_tab(data-toggle="tab" href="#new_credit_receipts" onclick=`calculateCreditReceiptsAndTrackMenu(this)`) Collections
                     li.nav-item.col-md
                         a.nav-link#expenses_tab(data-toggle="tab" href="#new_expenses" onclick=`calculateExpensesAndDenoms(this)`) Expenses
                     if bowserValues && bowserValues.length > 0
@@ -88,6 +92,9 @@ block content
                         a.nav-link#credit_sales_tab(data-toggle="tab" href="#new_credit_sales" onclick=`cashSaleOrCreditUpdateProductTypePrices(this, 'credit-')`) Credit Sales
                     li.nav-item.col-md
                         a.nav-link#digital_sales_tab(data-toggle="tab" href="#new_digital_sales" onclick=`calculateDigitalSalesAndTrackMenu(this)`) Digital Sales
+                    if allowCreditReceiptsInClosing
+                        li.nav-item.col-md
+                            a.nav-link#credit_receipts_tab(data-toggle="tab" href="#new_credit_receipts") Collections
                     li.nav-item.col-md
                         a.nav-link#expenses_tab(data-toggle="tab" href="#new_expenses") Expenses
                     if bowserValues && bowserValues.length > 0
@@ -470,8 +477,49 @@ block content
                     div.row(align="center")
                         div.col
                             button.btn.btn-primary(type="button", onClick="trackMenuWithName('expenses_tab')") Next &raquo;
-                                
-                                
+
+                if allowCreditReceiptsInClosing
+                    // ----------------------- Credit receipts (Collections) details ----------------------------
+                    div.tab-pane.fade#new_credit_receipts(class= divDisableClass)
+                        div
+                            div.col-16
+                                div.table-responsive
+                                    table.table#credit-receipts-table
+                                        tbody.w-100
+                                            thead(class="thead-light")
+                                                tr
+                                                    th(scope="col") Type
+                                                    th(scope="col") Credit Party
+                                                    th(scope="col") Digital Vendor
+                                                    th(scope="col") Amount
+                                                    th(scope="col") Receipt Date
+                                                    th(scope="col") Notes
+                                                    if(!freezedRecord)
+                                                        th(scope="col")
+
+                                                - var rowCnt = 0
+                                                while rowCnt < maxCreditReceiptsRowCnt
+                                                    +addCreditReceipts(rowCnt, creditReceiptsData ? creditReceiptsData[rowCnt] : null)
+                                                    - rowCnt++
+                                            tr
+                                                td(colspan=3)
+                                                td Total
+                                                td
+                                                    input.form-control#credit-receipts-total(type='text' name='credit-receipts-total' readonly value='0')
+                                                td
+                                                td
+                        div.row
+                            div.col &nbsp;
+                        div.row
+                            div.col(align="center")
+                                button.btn.btn-info(type="button", onClick="showAddedCreditReceiptsRow()") Add Collection
+
+                        div.row
+                            div.col &nbsp;
+                        div.row(align="center")
+                            div.col
+                                button.btn.btn-primary(type="button", onClick="trackMenuWithName('expenses_tab')") Next &raquo;
+
                 // ----------------------- New expenses & denominations details ----------------------------
                 div.tab-pane.container.fade#new_expenses(class= divDisableClass)
                     div.row
@@ -695,6 +743,31 @@ block content
                                                                 b#val-intercompany-total 0.000
                                         else
                                             div.col-6
+                                    if allowCreditReceiptsInClosing
+                                        div.row
+                                            // Summary: Credit receipts (Collections)
+                                            div.col-6#v-credit-receipts
+                                                h6.sub-header Collections
+                                                div.table-responsive#vis-credit-receipts-table
+                                                    table.table.table-sm
+                                                        thead.thead-light
+                                                            tr
+                                                                th(scope="col") Type
+                                                                th(scope="col") Credit Party
+                                                                th(scope="col") Amount
+                                                                th(scope="col") Receipt Date
+                                                        - var rowCnt = 0
+                                                        - var maxCreditReceiptsRowCnt = config.maxCreditReceiptsRowCnt
+                                                        while rowCnt < maxCreditReceiptsRowCnt
+                                                            +summaryCreditReceiptsData(rowCnt++)
+                                                        tr
+                                                            td(colspan=2)
+                                                            td
+                                                                span
+                                                                    b Total
+                                                            td
+                                                                span
+                                                                    b#val-credit-receipts-total= 0
                                 div.row
                                     if show2TSalesTab
                                         // 2T loose details

--- a/views/edit-draft-closing.pug
+++ b/views/edit-draft-closing.pug
@@ -373,20 +373,29 @@ block content
                             white-space: nowrap; /* keeps headers on one line */
                         }
 
-                        /* Column width tuning */
-                        #credit-table .col-product   { width: 12%; }
-                        #credit-table .col-bill      { width: 7%; }
-                        #credit-table .col-company   { width: 14%; }
-                        #credit-table .col-vehicle   { width: 10%; }
-                        #credit-table .col-odo       { width: 8%; }
-                        #credit-table .col-date      { width: 9%; }
-                        #credit-table .col-price     { width: 7%; }
-                        #credit-table .col-discount  { width: 6%; }  /* small field */
-                        #credit-table .col-qty       { width: 6%; }
-                        #credit-table .col-sale      { width: 10%; } /* extra space for sale */
-                        #credit-table .col-notes     { width: 10%; }
-                        #credit-table .col-off-meter { width: 5%; text-align: center; }
-                        #credit-table .col-delete    { width: 3%; text-align: center; }
+                        /* Column width tuning for the compact summary list */
+                        #credit-table .col-date      { width: 12%; }
+                        #credit-table .col-product   { width: 14%; }
+                        #credit-table .col-bill      { width: 10%; }
+                        #credit-table .col-company   { width: 22%; }
+                        #credit-table .col-vehicle   { width: 18%; }
+                        #credit-table .col-sale      { width: 12%; }
+                        #credit-table .col-actions   { width: 12%; text-align: center; }
+
+                        #credit-table tbody tr.credit-summary-row td {
+                            vertical-align: middle;
+                        }
+                        #credit-table .credit-summary-cell span:empty::before {
+                            content: '\2014'; /* em dash placeholder */
+                            color: #999;
+                        }
+                        #credit-table .credit-summary-actions {
+                            text-align: center;
+                            white-space: nowrap;
+                        }
+                        #credit-table .credit-summary-actions .btn {
+                            line-height: 1;
+                        }
                     div
                         div.col-16
                             div.table-responsive
@@ -399,32 +408,24 @@ block content
                                                 th.col-bill(scope="col") Bill #
                                                 th.col-company(scope="col") Company
                                                 th.col-vehicle(scope="col") Vehicle Number
-                                                th.col-odo(scope="col") Odometer
-                                                th.col-price(scope="col") Price
-                                                th.col-discount(scope="col") Price Discount
-                                                th.col-qty(scope="col") Quantity
                                                 th.col-sale(scope="col") Sale
-                                                th.col-notes(scope="col") Notes
-                                                if allowOffMeterSale
-                                                    th.col-off-meter(scope="col") Off Meter
-                                                if(!freezedRecord)
-                                                    th.col-delete(scope="col")
+                                                th.col-actions(scope="col") Actions
                                             - var rowCnt = 0
                                             while rowCnt < maxCreditsRowCnt
                                                 +addCredits(rowCnt, t_credits[rowCnt++])
 
                                             tr
                                                 td(colspan=5)
-                                                td Total
-                                                td
-                                                    input.form-control#credit-total(type='text' name='credit-total' readonly value='0')
+                                                td.text-right
+                                                    strong Total:&nbsp;
+                                                    input.form-control.d-inline-block(style='width:120px' type='text' name='credit-total' id='credit-total' readonly value='0')
                                                 td
 
                     div.row
                         div.col &nbsp;
                     div.row
                         div.col(align="center")
-                            button.btn.btn-info(type="button", onClick="showAddedCreditRow()") Add credits
+                            button.btn.btn-info(type="button", onClick="handleAddCreditRowClick()") Add credits
 
                     div.row
                         div.col &nbsp;
@@ -757,6 +758,8 @@ block content
         window.pumpsData = !{JSON.stringify(pumps)};
         window.productValuesData = !{JSON.stringify(productValues)}; 
         window.allowSecondaryPump = !{allowSecondaryPump};
+    // Credit sale Add/Edit modal (shared by the compact credit sales list)
+    +creditEntryModal(allowOffMeterSale)
     // Quick Add Vehicle Modal
     .modal.fade#quickAddVehicleModal(tabindex='-1' role='dialog' aria-labelledby='quickAddVehicleModalLabel' aria-hidden='true')
         .modal-dialog(role='document')
@@ -777,4 +780,5 @@ block content
                     button.btn.btn-secondary(type='button' data-dismiss='modal') Cancel
                     button.btn.btn-success#quickAddVehicleSaveBtn(type='button' onclick='quickSaveVehicle()') Add Vehicle
     script(src=`/javascripts/shift-products.js?v=${CACHE_BUST}`)
+    script(src=`/javascripts/credit-entry-modal.js?v=${CACHE_BUST}`)
 

--- a/views/mixins/new-closing-mixins.pug
+++ b/views/mixins/new-closing-mixins.pug
@@ -261,9 +261,15 @@ mixin optionsForProductRates(cashOrCreditSalePrefix)
 
 
 //- Add new page: Dom elements to show credit details
+//- Renders two rows per credit line:
+//-  1. A compact, read-only summary row that's always what the user sees in the list.
+//-  2. A hidden detail row holding the real, submitted form fields. Its fields are
+//-     moved into the shared #creditEntryModal (see creditEntryModal mixin below)
+//-     whenever the row is opened for add/edit, and moved back on close.
 mixin addCredits(creditRowNo, rowData)
     - var prefix = 'credit-';
     - var trId = prefix + 'table-row-'+creditRowNo;
+    - var summaryTrId = prefix + 'summary-row-' + creditRowNo;
     - var trClass = 'd-md-none';
     - var price = 0;
     - var creditType = undefined, creditName = undefined;
@@ -275,7 +281,29 @@ mixin addCredits(creditRowNo, rowData)
         - rowData = {price:price, priceDiscount:0, billNo:0, qty:0, amount:0, creditType: config.creditTypes[0], companyName: creditName, vehicleId: null, odometerReading: null, offMeterSale: 0, creditBillDate: (typeof closingData !== 'undefined' ? closingData.closingDate : currentDate)};
     if(rowData.tCreditId && parseInt(rowData.tCreditId) > 0)
         - trClass = ''
-    tr(class=trClass id=trId)
+    - var summaryClass = trClass === 'd-md-none' ? 'd-md-none' : ''
+
+    tr.credit-summary-row(class=summaryClass id=summaryTrId data-credit-row=creditRowNo)
+        td.credit-summary-cell
+            span(id=prefix + 'summary-date-' + creditRowNo)
+        td.credit-summary-cell
+            span(id=prefix + 'summary-product-' + creditRowNo)
+        td.credit-summary-cell
+            span(id=prefix + 'summary-billno-' + creditRowNo)
+        td.credit-summary-cell
+            span(id=prefix + 'summary-company-' + creditRowNo)
+        td.credit-summary-cell
+            span(id=prefix + 'summary-vehicle-' + creditRowNo)
+        td.credit-summary-cell.text-right
+            span(id=prefix + 'summary-amt-' + creditRowNo)
+        td.credit-summary-actions.text-center
+            if !freezedRecord
+                button.btn.btn-sm.btn-link.text-primary.p-1(type='button' title='Edit' aria-label='Edit credit sale' onclick='openCreditRowModal(' + creditRowNo + ', false)')
+                    i.bi.bi-pencil-square
+                button.btn.btn-sm.btn-link.text-danger.p-1(type='button' title='Delete' aria-label='Delete credit sale' onclick='deleteCreditRow(' + creditRowNo + ')')
+                    i.bi.bi-trash
+
+    tr(class=trClass id=trId style='display:none')
         input(type='hidden' id=prefix + creditRowNo + '_hiddenId' value=rowData.tCreditId)
         td
             - var defaultCreditDate = rowData.creditBillDate || (typeof closingData !== 'undefined' ? closingData.closingDate : currentDate)
@@ -305,7 +333,7 @@ mixin addCredits(creditRowNo, rowData)
                 each party in allCreditParties
                     option(value=`${party.creditorId}` selected= rowData.creditListId === party.creditorId)= party.creditorName
         td
-            .d-flex.align-items-center(style='gap:4px')
+            .d-flex.align-items-center(id=prefix + 'vehicle-wrap-' + creditRowNo style='gap:4px')
                 .flex-grow-1
                     select.form-control.select2-vehicle(name=prefix + 'vehicle-' + creditRowNo id=prefix + 'vehicle-' + creditRowNo data-row=creditRowNo)
                         option(value='') Select Vehicle
@@ -329,12 +357,86 @@ mixin addCredits(creditRowNo, rowData)
         td
             textarea.form-control(name=prefix + 'notes-' + creditRowNo id=prefix + 'notes-' + creditRowNo style="height:36px")= rowData.notes
         if allowOffMeterSale
-            td.text-center
+            td
                 - var offMeterStyle = rowData.isLubeProduct ? '' : 'display:none'
                 input(type='checkbox' name=prefix + 'off-meter-' + creditRowNo id=prefix + 'off-meter-' + creditRowNo checked=(rowData.offMeterSale == 1) style=offMeterStyle)
-        td
-            button.close(type="button" aria-label="Close" onclick='hideRow(\'' + trId + '\', "remove-credit-sale", calculateCreditTotal)')
-                span(aria-hidden="true") &times;
+
+//- Shared Add/Edit modal for a single credit sale line. The actual field elements from
+//- the detail row (see addCredits above) are relocated into the slot divs below by
+//- credit-entry-modal.js while the row is being edited, and relocated back on close.
+mixin creditEntryModal(allowOffMeterSale)
+    style.
+        .modal-backdrop + .modal-backdrop { z-index: 1052; }
+        #creditEntryModal .form-group label {
+            font-size: 0.8rem;
+            font-weight: 600;
+            color: #555;
+            text-transform: uppercase;
+            letter-spacing: .02em;
+            margin-bottom: 4px;
+        }
+        #creditEntryModal .select2-container { width: 100% !important; }
+    #creditEntryModal.modal.fade(tabindex='-1' role='dialog' aria-labelledby='creditEntryModalLabel' aria-hidden='true')
+        .modal-dialog.modal-lg(role='document')
+            .modal-content
+                .modal-header
+                    h5.modal-title#creditEntryModalLabel
+                        i.bi.bi-receipt.mr-2
+                        span#creditEntryModalTitleText Credit Sale
+                    button.close(type='button' data-dismiss='modal' aria-label='Close')
+                        span(aria-hidden='true') &times;
+                .modal-body
+                    .row
+                        .col-md-4.form-group
+                            label Bill Date
+                            div#creditModalSlot-bill-date
+                        .col-md-4.form-group
+                            label Product
+                            div#creditModalSlot-product
+                        .col-md-4.form-group
+                            label Bill #
+                            div#creditModalSlot-billno
+                    .row
+                        .col-md-6.form-group
+                            label Company
+                            div#creditModalSlot-creditparty
+                        .col-md-6.form-group
+                            label Vehicle Number
+                            div#creditModalSlot-vehiclewrap
+                    .row
+                        .col-md-3.form-group
+                            label Odometer
+                            div#creditModalSlot-odometer
+                        .col-md-3.form-group
+                            label Price
+                            div#creditModalSlot-price
+                        .col-md-3.form-group
+                            label Price Discount
+                            div#creditModalSlot-discount
+                        .col-md-3.form-group
+                            label Quantity
+                            div#creditModalSlot-qty
+                    .row
+                        .col-md-4.form-group
+                            label Sale Amount
+                            div#creditModalSlot-amt
+                        if allowOffMeterSale
+                            .col-md-3.form-group#creditModalOffMeterGroup
+                                label Off Meter
+                                div#creditModalSlot-off-meter
+                            .col-md-5.form-group
+                                label Notes
+                                div#creditModalSlot-notes
+                        else
+                            .col-md-8.form-group
+                                label Notes
+                                div#creditModalSlot-notes
+                .modal-footer
+                    button.btn.btn-outline-danger.mr-auto#creditModalDeleteBtn(type='button' onclick='deleteCreditRowModal()')
+                        i.bi.bi-trash.mr-1
+                        | Delete
+                    button.btn.btn-secondary(type='button' data-dismiss='modal') Close
+                    button.btn.btn-primary(type='button' onclick='saveCreditRowModal()') Save
 
 
 //- Add new page: Dom elements to show new custom expenses on 'add'

--- a/views/mixins/new-closing-mixins.pug
+++ b/views/mixins/new-closing-mixins.pug
@@ -253,6 +253,58 @@ mixin addDigitalSales(digitalSalesRowNo, rowData)
                 button.close(type="button" aria-label="Close" onclick='hideRow(\'' + trId + '\',"remove-digital-sales", calculateDigitalSalesTotal)')
                     span(aria-hidden="true") &times;
 
+//- Collections tab: Dom elements to show a credit receipt (payment collected from a
+//- credit customer during the shift, Cash or Digital). Structurally mirrors
+//- addDigitalSales - plain row, no modal - since receipts don't need product/price fields.
+mixin addCreditReceipts(receiptRowNo, rowData)
+    - var prefix = 'credit-receipts-';
+    - var trId = prefix + 'table-row-'+receiptRowNo;
+    - var trClass = 'd-md-none';
+    if(!rowData)
+        - rowData = {amount:0, receiptDate: '', receiptType: 'Cash', creditPartyId: null, digitalVendorId: null, notes: ''};
+    if(rowData.receiptId && parseInt(rowData.receiptId) > 0)
+        - trClass = ''
+    - var vendorCellStyle = rowData.receiptType === 'Digital' ? '' : 'display:none'
+    tr(class=trClass id=trId)
+        input(type='hidden' id=prefix + receiptRowNo + '_hiddenId' value=rowData.receiptId)
+        td
+            select.form-control(name=prefix + 'type-' + receiptRowNo id=prefix + 'type-' + receiptRowNo required onchange='toggleReceiptVendorCell(this, ' + receiptRowNo + ')')
+                option(value='Cash' selected= rowData.receiptType === 'Cash') Cash
+                option(value='Digital' selected= rowData.receiptType === 'Digital') Digital
+        td
+            - var allReceiptCreditParties = [];
+            if creditCompanyValues
+                each val in creditCompanyValues
+                    if val.card_flag !== 'Y'
+                        - allReceiptCreditParties.push({creditorId: val.creditorId, creditorName: val.creditorName});
+            if suspenseValues
+                each val in suspenseValues
+                    if val.card_flag !== 'Y'
+                        - allReceiptCreditParties.push({creditorId: val.creditorId, creditorName: val.creditorName});
+            - allReceiptCreditParties.sort((a, b) => a.creditorName.localeCompare(b.creditorName));
+            select.form-control(name=prefix + 'creditparty-' + receiptRowNo id=prefix + 'creditparty-' + receiptRowNo required)
+                option(value='') Select Credit Party
+                each party in allReceiptCreditParties
+                    option(value=`${party.creditorId}` selected= rowData.creditPartyId === party.creditorId)= party.creditorName
+        td(id=prefix + 'vendor-cell-' + receiptRowNo style=vendorCellStyle)
+            select.form-control(name=prefix + 'vendor-' + receiptRowNo id=prefix + 'vendor-' + receiptRowNo)
+                option(value='') Select Digital Vendor
+                if creditCompanyValues
+                    each vendor in creditCompanyValues
+                        if vendor.card_flag === 'Y'
+                            option(value=`${vendor.creditorId}` selected= vendor.creditorId === rowData.digitalVendorId)= vendor.creditorName
+        td
+            input.form-control(type='number' name=prefix + 'amount-' + receiptRowNo id=prefix + 'amt-' + receiptRowNo min=0.01 step=0.01 required value=rowData.amount onchange='calculateCreditReceiptsTotal()' oninput='validity.valid||(value="")')
+        td
+            - var defaultReceiptDate = rowData.receiptDate || (typeof closingData !== 'undefined' ? closingData.closingDate : currentDate)
+            input.form-control.credit-bill-date(type='date' name=prefix + 'receipt-date-' + receiptRowNo id=prefix + 'receipt-date-' + receiptRowNo required value=defaultReceiptDate data-closing-date=(typeof closingData !== 'undefined' ? closingData.closingDate : currentDate))
+        td
+            textarea.form-control(name=prefix + 'notes-' + receiptRowNo id=prefix + 'notes-' + receiptRowNo style="height:36px")= rowData.notes
+        if(!freezedRecord)
+            td
+                button.close(type="button" aria-label="Close" onclick='hideRow(\'' + trId + '\',"remove-credit-receipt", calculateCreditReceiptsTotal)')
+                    span(aria-hidden="true") &times;
+
 //- Add new page: used by addCredits & addCashSales - a separate fn will populate product rates
 mixin optionsForProductRates(cashOrCreditSalePrefix)
     if productValues

--- a/views/mixins/summary-mixins.pug
+++ b/views/mixins/summary-mixins.pug
@@ -171,7 +171,21 @@ mixin summaryDigitalSalesData(digitalSaleRowNo)
             span(id='val-' + prefix + 'transaction-date-' + digitalSaleRowNo)
         td
             span(id='val-' + prefix + 'notes-' + digitalSaleRowNo)
-            
+
+//- Collections tab: Summary on credit receipts data
+mixin summaryCreditReceiptsData(receiptRowNo)
+    - var prefix = 'credit-receipts-';
+    - var trClass = 'd-md-none';
+    tr(class=trClass id='vis-' + prefix + 'table-row-' + receiptRowNo)
+        td
+            span(id='valText-' + prefix + 'type-' + receiptRowNo)
+        td
+            span(id='valText-' + prefix + 'creditparty-' + receiptRowNo)
+        td
+            span(id='val-' + prefix + 'amt-' + receiptRowNo)
+        td
+            span(id='val-' + prefix + 'receipt-date-' + receiptRowNo)
+
 //- Add new page: Summary on expenses data
 mixin showExpensesData(rowNo, val)
     - var trClass = 'd-md-none';

--- a/views/new-closing.pug
+++ b/views/new-closing.pug
@@ -8,6 +8,7 @@ block content
     - var maxCashSalesRowCnt = config.maxCashSalesRowCnt;
     - var maxExpensesRowCnt = config.maxExpensesRowCnt;
     - var maxDigitalSalesRowCnt = config.maxDigitalSalesRowCnt;
+    - var maxCreditReceiptsRowCnt = config.maxCreditReceiptsRowCnt;
     - var currency = config.currency;
     - var denominationValues = config.denominationValues;
     - var denominationValuesJson = config.denominationValuesJson;
@@ -31,8 +32,11 @@ block content
                     a.nav-link#cash_sales_tab(data-toggle="tab" href="#new_cash_sales" onclick=`cashSaleOrCreditUpdateProductTypePrices(this, 'cash-sale-')`) Lube Sales
                 li.nav-item.col-md
                     a.nav-link#credit_sales_tab(data-toggle="tab" href="#new_credit_sales" onclick=`cashSaleOrCreditUpdateProductTypePrices(this, 'credit-')`) Credit Sales
-                li.nav-item.col-md                    
+                li.nav-item.col-md
                     a.nav-link#digital_sales_tab(data-toggle="tab" href="#new_digital_sales" onclick=`calculateDigitalSalesAndTrackMenu(this)`) Digital Sales
+                if allowCreditReceiptsInClosing
+                    li.nav-item.col-md
+                        a.nav-link#credit_receipts_tab(data-toggle="tab" href="#new_credit_receipts" onclick=`calculateCreditReceiptsAndTrackMenu(this)`) Collections
                 li.nav-item.col-md
                     a.nav-link#expenses_tab(data-toggle="tab" href="#new_expenses" onclick=`trackMenu(this)`) Expenses
                 if bowserValues && bowserValues.length > 0
@@ -416,6 +420,46 @@ block content
                         div.col
                             button.btn.btn-primary(type="button", onClick="trackMenuWithName('expenses_tab')") Next &raquo;
 
+                if allowCreditReceiptsInClosing
+                    div.tab-pane.fade#new_credit_receipts
+                        div
+                            div.col-16
+                                div.table-responsive
+                                    table.table#credit-receipts-table
+                                        tbody.w-100
+                                            thead(class="thead-light")
+                                                tr
+                                                    th(scope="col") Type
+                                                    th(scope="col") Credit Party
+                                                    th(scope="col") Digital Vendor
+                                                    th(scope="col") Amount
+                                                    th(scope="col") Receipt Date
+                                                    th(scope="col") Notes
+                                                    th(scope="col")
+
+                                                - var rowCnt = 0
+                                                while rowCnt < maxCreditReceiptsRowCnt
+                                                    +addCreditReceipts(rowCnt++)
+                                            tr
+                                                td(colspan=3)
+                                                td Total
+                                                td
+                                                    input.form-control#credit-receipts-total(type='text' name='credit-receipts-total' readonly value='0')
+                                                td
+                                                td
+
+                        div.row
+                            div.col &nbsp;
+                        div.row
+                            div.col(align="center")
+                                button.btn.btn-info(type="button", onClick="showAddedCreditReceiptsRow()") Add Collection
+
+                        div.row
+                            div.col &nbsp;
+                        div.row(align="center")
+                            div.col
+                                button.btn.btn-primary(type="button", onClick="trackMenuWithName('expenses_tab')") Next &raquo;
+
                 // ----------------------- New expenses & denominations details ----------------------------
                 div.tab-pane.container.fade#new_expenses
                     div.row
@@ -623,6 +667,31 @@ block content
                                                             b#val-intercompany-total 0.000
                                     else
                                         div.col-6
+                                if allowCreditReceiptsInClosing
+                                    div.row
+                                        // Summary: Credit receipts (Collections)
+                                        div.col-6#v-credit-receipts
+                                            h6.sub-header Collections
+                                            div.table-responsive#vis-credit-receipts-table
+                                                table.table.table-sm
+                                                    thead.thead-light
+                                                        tr
+                                                            th(scope="col") Type
+                                                            th(scope="col") Credit Party
+                                                            th(scope="col") Amount
+                                                            th(scope="col") Receipt Date
+                                                    - var rowCnt = 0
+                                                    - var maxCreditReceiptsRowCnt = config.maxCreditReceiptsRowCnt
+                                                    while rowCnt < maxCreditReceiptsRowCnt
+                                                        +summaryCreditReceiptsData(rowCnt++)
+                                                    tr
+                                                        td(colspan=2)
+                                                        td
+                                                            span
+                                                                b Total
+                                                        td
+                                                            span
+                                                                b#val-credit-receipts-total= 0
                                 div.row
                                     if show2TSalesTab
                                         // 2T loose details

--- a/views/new-closing.pug
+++ b/views/new-closing.pug
@@ -322,54 +322,29 @@ block content
                             white-space: nowrap; /* keeps headers on one line */
                         }
 
-                        /* Column width tuning */
-                        #credit-table .col-product   { width: 10%; }
-                        #credit-table .col-bill      { width: 7%; }
-                        #credit-table .col-company   { width: 16%; }  /* More room for credit party */
-                        #credit-table .col-vehicle   { width: 13%; }  /* More room for vehicle dropdown */
-                        #credit-table .col-odo       { width: 7%; }
-                        #credit-table .col-date      { width: 9%; }
-                        #credit-table .col-price     { width: 7%; }
-                        #credit-table .col-discount  { width: 5%; }
-                        #credit-table .col-qty       { width: 6%; }
-                        #credit-table .col-sale      { width: 8%; }
-                        #credit-table .col-notes     { width: 9%; }
-                        #credit-table .col-off-meter { width: 5%; text-align: center; }
-                        #credit-table th:last-child  { width: 2%; text-align: center; } /* X delete column */
+                        /* Column width tuning for the compact summary list */
+                        #credit-table .col-date      { width: 12%; }
+                        #credit-table .col-product   { width: 14%; }
+                        #credit-table .col-bill      { width: 10%; }
+                        #credit-table .col-company   { width: 22%; }
+                        #credit-table .col-vehicle   { width: 18%; }
+                        #credit-table .col-sale      { width: 12%; }
+                        #credit-table .col-actions   { width: 12%; text-align: center; }
 
-                        #credit-table .col-delete {
+                        #credit-table tbody tr.credit-summary-row td {
+                            vertical-align: middle;
+                        }
+                        #credit-table .credit-summary-cell span:empty::before {
+                            content: '\2014'; /* em dash placeholder */
+                            color: #999;
+                        }
+                        #credit-table .credit-summary-actions {
                             text-align: center;
+                            white-space: nowrap;
                         }
-                        #credit-table .col-delete .close {
-                            font-size: 1.1rem;
-                            color: #dc3545; /* Bootstrap danger red */
-                            opacity: 0.7;
-                            transition: opacity 0.2s;
+                        #credit-table .credit-summary-actions .btn {
+                            line-height: 1;
                         }
-                        #credit-table .col-delete .close:hover {
-                            opacity: 1;
-                        }
-
-                        /* --- Fix Select2 width for vehicle dropdown --- */
-                            #credit-table .select2-container--default .select2-selection--single {
-                                display: inline-block;
-                                width: auto !important;       /* auto-fit to text */
-                                min-width: 120px;
-                                max-width: 240px;             /* don’t overflow layout */
-                                height: 36px;
-                                vertical-align: middle;
-                            }
-
-                            #credit-table .select2-container--default .select2-selection__rendered {
-                                overflow: visible !important;
-                                white-space: nowrap;
-                                text-overflow: clip;
-                                padding-right: 24px;          /* spacing for arrow */
-                            }
-
-                            #credit-table .select2-container--default .select2-selection__arrow {
-                                right: 6px;
-                            }
                     div
                         div.col-16
                             div.table-responsive
@@ -382,31 +357,23 @@ block content
                                                 th.col-bill(scope="col") Bill #
                                                 th.col-company(scope="col") Company
                                                 th.col-vehicle(scope="col") Vehicle Number
-                                                th.col-odo(scope="col") Odometer
-                                                th.col-price(scope="col") Price
-                                                th.col-discount(scope="col") Price Discount
-                                                th.col-qty(scope="col") Quantity
                                                 th.col-sale(scope="col") Sale
-                                                th.col-notes(scope="col") Notes
-                                                if allowOffMeterSale
-                                                    th.col-off-meter(scope="col") Off Meter
-                                                th.col-delete(scope="col")
-                                                th(scope="col")
+                                                th.col-actions(scope="col") Actions
                                             - var rowCnt = 0
                                             while rowCnt < maxCreditsRowCnt
                                                 +addCredits(rowCnt++)
 
                                             tr
                                                 td(colspan=5)
-                                                td Total
-                                                td
-                                                    input.form-control#credit-total(type='text' name='credit-total' readonly value='0')
+                                                td.text-right
+                                                    strong Total:&nbsp;
+                                                    input.form-control.d-inline-block(style='width:120px' type='text' name='credit-total' id='credit-total' readonly value='0')
                                                 td
                     div.row
                         div.col &nbsp;
                     div.row
                         div.col(align="center")
-                            button.btn.btn-info(type="button", onClick="showAddedCreditRow('credit')") Add credits
+                            button.btn.btn-info(type="button", onClick="handleAddCreditRowClick()") Add credits
 
                     div.row
                         div.col &nbsp;
@@ -716,34 +683,8 @@ block content
         window.pumpsData = !{JSON.stringify(pumps)};    
         window.productValuesData = !{JSON.stringify(productValues)};
         window.allowSecondaryPump = !{allowSecondaryPump};
-                // Initialize Select2 for vehicle dropdowns
-            function initVehicleSelect2() {
-                $('.select2-vehicle').each(function() {
-                    if ($(this).data('select2')) {
-                        $(this).select2('destroy');
-                    }
-                    $(this).select2({
-                        width: 'style',           // uses CSS width
-                        dropdownAutoWidth: true,  // dropdown expands to content
-                        minimumResultsForSearch: 5,
-                        placeholder: 'Select Vehicle'
-                    });
-                });
-            }
-
-            // Initialize when DOM ready
-            $(document).ready(function() {
-                initVehicleSelect2();
-            });
-
-            // Re-init when "Add credits" adds new rows dynamically
-            const _origShowAddedCreditRow = window.showAddedCreditRow;
-            window.showAddedCreditRow = function(prefix) {
-                if (typeof _origShowAddedCreditRow === 'function') {
-                    _origShowAddedCreditRow(prefix);
-                }
-                initVehicleSelect2(); // ensure new row gets Select2 applied
-            };
+    // Credit sale Add/Edit modal (shared by the compact credit sales list)
+    +creditEntryModal(allowOffMeterSale)
     // Quick Add Vehicle Modal
     .modal.fade#quickAddVehicleModal(tabindex='-1' role='dialog' aria-labelledby='quickAddVehicleModalLabel' aria-hidden='true')
         .modal-dialog(role='document')
@@ -764,3 +705,4 @@ block content
                     button.btn.btn-secondary(type='button' data-dismiss='modal') Cancel
                     button.btn.btn-success#quickAddVehicleSaveBtn(type='button' onclick='quickSaveVehicle()') Add Vehicle
     script(src=`/javascripts/shift-products.js?v=${CACHE_BUST}`)
+    script(src=`/javascripts/credit-entry-modal.js?v=${CACHE_BUST}`)


### PR DESCRIPTION
## Summary
- New "Collections" tab in shift closing (new-closing.pug / edit-draft-closing.pug) so cashiers can log a credit receipt (Cash or Digital) against a credit customer directly during their shift, instead of only via the standalone admin Credit Receipts page
- Gated behind `ALLOW_CREDIT_RECEIPTS_IN_CLOSING` location-config flag (default `N`) — built for Balaa Fuels, invisible everywhere else until enabled
- `t_receipts` gains a `closing_id` column; `delete_closing`/`restore_closing` procedures updated so deleting/restoring a draft shift correctly archives/restores receipts entered this way (SQL already run against dev by user)
- Admin Credit Receipts page now hides edit/delete for receipts owned by a shift (`closing_id IS NOT NULL`)

Note: the "Excess/Shortage" cash-reconciliation figure is computed by a DB-only stored function (`calculate_exshortage`) not tracked in this repo — wiring Cash-type receipts into that calculation is a separate follow-up once its current definition is available.

## Test plan
- [ ] Enable `ALLOW_CREDIT_RECEIPTS_IN_CLOSING=Y` for a test location
- [ ] New shift: Collections tab appears, add Cash + Digital rows, save, confirm persistence across tabs
- [ ] Reopen as draft: rows reload correctly, still editable
- [ ] Summary tab shows Collections total
- [ ] Delete draft shift: receipt rows archived to `t_receipts_deleted` and removed
- [ ] Restore deleted shift: receipt rows restored
- [ ] `/creditreceipts` admin page: shift-owned rows show read-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)