### PR TITLE
Add Collections tab to shift closing for direct credit-receipt entry

### DIFF
--- a/app.js
+++ b/app.js
@@ -356,6 +356,37 @@ const bypassLoginInDev = async (req, res, next) => {
 // Apply the bypass middleware
 app.use(bypassLoginInDev);
 
+// SuperUser idle timeout — SuperUser sessions carry access to confidential/billing data
+// and are sometimes used on other locations' shared PCs, so they get auto-logged-out
+// after a period of inactivity even if the user forgets to sign out manually. Applies
+// while previewing too (req.session.previewOriginal), since the underlying identity is
+// still a SuperUser even though req.user.Role is temporarily the previewed role.
+const SUPERUSER_IDLE_TIMEOUT_MS = 15 * 60 * 1000;
+const enforceSuperUserIdleTimeout = (req, res, next) => {
+    if (!req.user || !req.session) return next();
+    // Skip in the local SKIP_LOGIN dev bypass, which isn't a real passport session
+    // and would otherwise force a broken req.logout() after 15 idle minutes locally.
+    if (process.env.NODE_ENV === 'development' && process.env.SKIP_LOGIN === 'true') return next();
+
+    const isSuperUserSession = req.user.Role === 'SuperUser' || !!req.session.previewOriginal;
+    if (!isSuperUserSession) return next();
+
+    const now = Date.now();
+    if (req.session.lastActivity && (now - req.session.lastActivity > SUPERUSER_IDLE_TIMEOUT_MS)) {
+        const username = req.user.User_Name;
+        return req.logout(function (err) {
+            if (err) console.error('Error during idle-timeout logout:', err);
+            console.log(`[IDLE TIMEOUT] ${username} auto-logged-out after 15 min inactivity`);
+            req.flash('warning', 'You were signed out after 15 minutes of inactivity.');
+            res.redirect('/login');
+        });
+    }
+
+    req.session.lastActivity = now;
+    next();
+};
+app.use(enforceSuperUserIdleTimeout);
+
 
 const addUserLocationInfo = async (req, res, next) => {
     if (req.user && req.user.Person_id) {
@@ -482,6 +513,7 @@ app.use('/campaign', campaignPublicRoutes);
 app.use('/gst', gstRoutes);
 app.use('/transaction-upload', transactionUploadRoutes);
 app.use('/dsm-entry', require('./routes/dsm-entry-routes'));
+app.use('/admin/bill-ocr-formats', require('./routes/bill-ocr-format-routes'));
 app.use('/day-bill', dayBillRoutes);
 app.use('/platform-billing', platformBillingRoutes);
 app.use('/distributors', distributorRoutes);
@@ -1212,6 +1244,14 @@ app.delete('/remove-digital-sale', isLoginEnsured, function (req, res, next) {
     HomeController.deleteTxnDigitalSale(req, res, next);  // response returned inside controller
 });
 
+app.post('/new-credit-receipts', isLoginEnsured, function (req, res, next) {
+    HomeController.saveCreditReceiptsData(req, res, next);  // response returned inside controller
+});
+
+app.delete('/remove-credit-receipt', isLoginEnsured, function (req, res, next) {
+    HomeController.deleteTxnCreditReceipt(req, res, next);  // response returned inside controller
+});
+
 app.post('/new-expenses', isLoginEnsured, function (req, res, next) {
     HomeController.saveExpensesData(req, res, next);
 });
@@ -1821,7 +1861,8 @@ app.get('/preview-as', isLoginEnsured, isSuperUserOrPreviewing, async function (
             roles: roles,
             locations: locations,
             isPreviewing: !!req.session.previewOriginal,
-            previewMeta: req.session.previewMeta || null
+            previewMeta: req.session.previewMeta || null,
+            messages: req.flash()
         });
     } catch (error) {
         console.error("Error loading preview-as page:", error);

--- a/config/app-config.js
+++ b/config/app-config.js
@@ -32,6 +32,7 @@ const PRODUCTS = PRODUCT_2T.concat(PRODUCT_PUMPS);
 // config related to sales
 const MAX_CREDITS_ROW_CNT = 300;
 const MAX_DIGITAL_ROW_CNT = 20;
+const MAX_CREDIT_RECEIPTS_ROW_CNT = 20;
 const MAX_CASH_SALES_ROW_CNT = 25;
 const MAX_EXPENSES_ROW_CNT = 25;
 const MAX_CASHFLOWS_ROW_CNT = 30;
@@ -212,6 +213,7 @@ GST_RETURN_STATUS: ['DRAFT', 'READY', 'FILED', 'FAILED', 'CANCELLED'],
   APP_CONFIGS: {
       maxCreditsRowCnt: MAX_CREDITS_ROW_CNT,
       maxDigitalSalesRowCnt:MAX_DIGITAL_ROW_CNT,
+      maxCreditReceiptsRowCnt: MAX_CREDIT_RECEIPTS_ROW_CNT,
       maxCashSalesRowCnt: MAX_CASH_SALES_ROW_CNT,
       maxExpensesRowCnt: MAX_EXPENSES_ROW_CNT,
       maxCashFlowRowsCnt: MAX_CASHFLOWS_ROW_CNT,

--- a/controllers/closing-delete-controller.js
+++ b/controllers/closing-delete-controller.js
@@ -87,6 +87,9 @@ module.exports = {
     txnDeleteDigitalSalePromise: (digitalSalesId) => {
     return txnDeleteDigitalSalePromise(digitalSalesId);
     },
+    txnDeleteCreditReceiptPromise: (receiptId) => {
+    return txnDeleteCreditReceiptPromise(receiptId);
+    },
 }
 
 // Add new flow: Delete one reading data
@@ -201,6 +204,23 @@ const txnDeleteDigitalSalePromise = (digitalSalesId) => {
                 }
             }).catch((err) => {
             console.error("Error while deleting digital sale " + err.toString());
+            resolve({error: err.toString()});
+        });
+    });
+}
+
+// Add new flow: Delete one credit receipt (Collections tab) data
+const txnDeleteCreditReceiptPromise = (receiptId) => {
+    return new Promise((resolve, reject) => {
+        TxnWriteDao.deleteCreditReceiptById(receiptId)
+            .then(status => {
+                if (status > 0) {
+                    resolve({message: 'Data deletion success.'});
+                } else {
+                    resolve({error: 'Data deletion failed.'});
+                }
+            }).catch((err) => {
+            console.error("Error while deleting credit receipt " + err.toString());
             resolve({error: err.toString()});
         });
     });

--- a/controllers/closing-edit-controller.js
+++ b/controllers/closing-edit-controller.js
@@ -116,6 +116,12 @@ module.exports = {
                 'N'
             );
 
+            const allowCreditReceiptsInClosing = await locationConfig.getLocationConfigValue(
+                locationCode,
+                'ALLOW_CREDIT_RECEIPTS_IN_CLOSING',
+                'N' // default - disabled
+            );
+
         if(closingId) {
             Promise.allSettled([homeController.personDataPromise(locationCode),
                 txnClosingPromise(closingId),
@@ -137,7 +143,8 @@ module.exports = {
                 txnController.txnDigitalSalesPromise(closingId),
                 txnController.shiftProductsPromise(closingId),
                 BowserDao.getActiveBowsersByLocation(locationCode),
-                BowserDao.getIntercompanyByClosingId(closingId)])
+                BowserDao.getIntercompanyByClosingId(closingId),
+                txnController.txnCreditReceiptsPromise(closingId)])
                 .then((values) => {
                     res.render('edit-draft-closing', {
                         user: req.user,
@@ -151,6 +158,7 @@ module.exports = {
                         show2TSalesTab: show2TSalesTab === 'Y',
                         allowQuickAddVehicle: allowQuickAddVehicle === 'Y',
                         allowOffMeterSale: allowOffMeterSale === 'Y',
+                        allowCreditReceiptsInClosing: allowCreditReceiptsInClosing === 'Y',
                         cashiers: values[0].value.cashiers,
                         closingData: values[1].value,
                         productValues: values[2].value.products,
@@ -171,7 +179,8 @@ module.exports = {
                         digitalSalesData: values[17].value,
                         shiftProducts: values[18].value || [],
                         bowserValues: values[19].value || [],
-                        t_intercompany: values[20].value || []
+                        t_intercompany: values[20].value || [],
+                        creditReceiptsData: values[21].value || []
                     });
                 }).catch((err) => {
                 console.warn("Error while getting data using promises " + err.toString());

--- a/controllers/closing-save-controller.js
+++ b/controllers/closing-save-controller.js
@@ -37,6 +37,9 @@ module.exports = {
     txnWriteDigitalSalesPromise: (saleDataArr) => {
     return txnWriteDigitalSalesPromise(saleDataArr);
     },
+    txnWriteCreditReceiptsPromise: (receiptsArr) => {
+    return txnWriteCreditReceiptsPromise(receiptsArr);
+    },
 }
 
 
@@ -179,6 +182,19 @@ const txnWriteDigitalSalesPromise = (digitalSalesArr) => {
                 resolve(data);
             }).catch((err) => {
             console.error("Error while saving digital sales " + err.toString());
+            resolve({error: err.toString()});
+        });
+    });
+}
+
+// Add new flow: Add credit receipts (Collections tab) data
+const txnWriteCreditReceiptsPromise = (receiptsArr) => {
+    return new Promise((resolve, reject) => {
+        TxnWriteDao.saveCreditReceipts(receiptsArr)
+            .then(data => {
+                resolve(data);
+            }).catch((err) => {
+            console.error("Error while saving credit receipts " + err.toString());
             resolve({error: err.toString()});
         });
     });

--- a/controllers/credit-receipt-controller.js
+++ b/controllers/credit-receipt-controller.js
@@ -148,7 +148,8 @@ module.exports = {
                         inactiveCreditIds.add(creditlist.creditlist_id);
                     }                   
     
-                    isEditOrDeleteAllowed = receipt.dataValues.cashflow_date === null && receipt.dataValues.pending_cashflow_id === null;
+                    isEditOrDeleteAllowed = receipt.dataValues.cashflow_date === null && receipt.dataValues.pending_cashflow_id === null
+                        && receipt.dataValues.closing_id === null;
     
                     
 
@@ -164,7 +165,7 @@ module.exports = {
                         amount: receipt.amount,
                         notes: receipt.notes,
                         receipt_date: receipt.receipt_date_fmt,
-                        showEditOrDelete: receipt.dataValues.cashflow_date === null && receipt.dataValues.pending_cashflow_id === null,
+                        showEditOrDelete: isEditOrDeleteAllowed,
                         creditType: type
                     });
                 } else {
@@ -292,6 +293,9 @@ module.exports = {
                 }
                 if (receipt.cashflow_date !== null || receipt.pending_cashflow_id !== null) {
                     return res.status(400).send({ error: 'Receipt is part of a cashflow and cannot be deleted.' });
+                }
+                if (receipt.closing_id !== null) {
+                    return res.status(400).send({ error: 'Receipt was entered from a shift closing and can only be edited/deleted there.' });
                 }
                 return CreditReceiptsDao.delete(req.query.id);
             })

--- a/controllers/home-controller.js
+++ b/controllers/home-controller.js
@@ -82,6 +82,12 @@ module.exports = {
     'N'
     );
 
+    const allowCreditReceiptsInClosing = await locationConfig.getLocationConfigValue(
+    locationCode,
+    'ALLOW_CREDIT_RECEIPTS_IN_CLOSING',
+    'N' // default - disabled
+    );
+
         getDraftsCount(locationCode).then(data => {
             if(data < config.APP_CONFIGS.maxAllowedDrafts) {
                 Promise.allSettled([personDataPromise(locationCode),
@@ -120,7 +126,8 @@ module.exports = {
                             digitalSalesFutureDays: digitalSalesFutureDays,
                             show2TSalesTab: show2TSalesTab === 'Y',
                             allowQuickAddVehicle: allowQuickAddVehicle === 'Y',
-                            allowOffMeterSale: allowOffMeterSale === 'Y'
+                            allowOffMeterSale: allowOffMeterSale === 'Y',
+                            allowCreditReceiptsInClosing: allowCreditReceiptsInClosing === 'Y'
                   //          digitalCompanyValues: values[8].value,
                         });
                     }).catch((err) => {
@@ -265,6 +272,19 @@ module.exports = {
     }
 },
 
+    saveCreditReceiptsData: (req, res, next) => {
+    const receiptsData = req.body;
+    if (receiptsData) {
+        saveController.txnWriteCreditReceiptsPromise(receiptsData).then((result) => {
+            if (!result.error) {
+                res.status(200).send({message: 'Saved credit receipts data successfully.', rowsData: result});
+            } else {
+                res.status(500).send({error: result.error});
+            }
+        });
+    }
+},
+
 
 
     saveExpensesData: (req, res, next) => {
@@ -361,6 +381,23 @@ deleteTxnDigitalSale: ((req, res, next) => {
     const saleId = req.query.id;
     if (saleId) {
         deleteController.txnDeleteDigitalSalePromise(saleId).then((result) => {
+            if (!result.error) {
+                res.status(200).send({
+                    message: result.message
+                });
+            } else {
+                res.status(500).send({error: result.error});
+            }
+        });
+    } else {
+        res.status(302).send();
+    }
+}),
+
+deleteTxnCreditReceipt: ((req, res, next) => {
+    const receiptId = req.query.id;
+    if (receiptId) {
+        deleteController.txnDeleteCreditReceiptPromise(receiptId).then((result) => {
             if (!result.error) {
                 res.status(200).send({
                     message: result.message

--- a/controllers/txn-common-controller.js
+++ b/controllers/txn-common-controller.js
@@ -28,6 +28,9 @@ module.exports = {
     txnDigitalSalesPromise: (closingId) => {
     return txnDigitalSalesPromise(closingId);
     },
+    txnCreditReceiptsPromise: (closingId) => {
+    return txnCreditReceiptsPromise(closingId);
+    },
     txnDenominationPromise: (closingId) => {
         return txnDenominationPromise(closingId);
     },
@@ -297,6 +300,32 @@ const txnDigitalSalesPromise = (closingId) => {
                         });
                     });
                     resolve(digitalSalesData);
+                } else {
+                    resolve([]);
+                }
+            });
+    });
+}
+
+// Show closing records flow: Getting txn credit receipts (Collections tab) data based on closing id
+const txnCreditReceiptsPromise = (closingId) => {
+    return new Promise((resolve, reject) => {
+        return TxnReadDao.getReceiptsByClosingId(closingId)
+            .then(data => {
+                if (data && data.length > 0) {
+                    let creditReceiptsData = [];
+                    data.forEach((receipt) => {
+                        creditReceiptsData.push({
+                            receiptId: receipt.treceipt_id,
+                            receiptType: receipt.receipt_type,
+                            creditPartyId: receipt.creditlist_id,
+                            digitalVendorId: receipt.digital_creditlist_id,
+                            amount: receipt.amount,
+                            receiptDate: receipt.receipt_date,
+                            notes: receipt.notes
+                        });
+                    });
+                    resolve(creditReceiptsData);
                 } else {
                     resolve([]);
                 }

--- a/dao/credit-receipts-dao.js
+++ b/dao/credit-receipts-dao.js
@@ -23,6 +23,7 @@ module.exports = {
                 'location_code',
                 'cashflow_date',
                 'pending_cashflow_id',
+                'closing_id',
             ],
           where: { [Op.and]: [
                   { location_code: locationCode },
@@ -82,7 +83,7 @@ module.exports = {
     },
     findById: (receiptId) => {
         return CashReceipts.findOne({
-            attributes: ['treceipt_id', 'cashflow_date', 'pending_cashflow_id'],
+            attributes: ['treceipt_id', 'cashflow_date', 'pending_cashflow_id', 'closing_id'],
             where: { treceipt_id: receiptId },
         });
     },

--- a/dao/txn-read-dao.js
+++ b/dao/txn-read-dao.js
@@ -14,6 +14,7 @@ const Expenses = db.expense;
 const TxnAttendance = db.txn_attendance;
 const TxnDeadlineViews = db.txn_deadline_views;
 const TxnDigitalSales = db.txn_digital_sales;
+const CashReceipts = db.credit_receipts;
 const Sequelize = require("sequelize");
 const { Op } = require("sequelize");
 const config = require("../config/app-config");
@@ -514,6 +515,11 @@ getMostRecentClosingDate: async (locationCode) => {
     },
     getDigitalSalesByClosingId: (closingId) => {
     return TxnDigitalSales.findAll({
+        where: {'closing_id': closingId}
+    });
+    },
+    getReceiptsByClosingId: (closingId) => {
+    return CashReceipts.findAll({
         where: {'closing_id': closingId}
     });
     }

--- a/dao/txn-write-dao.js
+++ b/dao/txn-write-dao.js
@@ -9,6 +9,8 @@ const TxnExpenses = db.txn_expense;
 const TxnDenoms = db.txn_denom;
 const TxnAttendance = db.txn_attendance;
 const TxnDigitalSales = db.txn_digital_sales;
+const CashReceipts = db.credit_receipts;
+const locationConfigDao = require('./location-config-dao');
 
 module.exports = {
     saveClosingData: (data) => {
@@ -124,6 +126,29 @@ saveReadings: (data) => {
     deleteDigitalSaleById: (digitalSalesId) => {
     const salesTxn = TxnDigitalSales.destroy({ where: { digital_sales_id: digitalSalesId } });
     return salesTxn;
+    },
+    saveCreditReceipts: async (data) => {
+    const newRows = data.filter(r => !r.treceipt_id);
+    const locationCode = newRows.length > 0 ? newRows[0].location_code : undefined;
+
+    if (locationCode) {
+        const cashflowEnabledRaw = await locationConfigDao.getSetting(locationCode, 'CASHFLOW_ENABLED');
+        const cashflowEnabled = String(cashflowEnabledRaw).toLowerCase() === 'true';
+        if (!cashflowEnabled) {
+            newRows.forEach(r => { r.cashflow_date = new Date(); });
+        }
+    }
+
+    const receiptsTxn = CashReceipts.bulkCreate(data, {
+        returning: true,
+        updateOnDuplicate: ["receipt_type", "creditlist_id", "digital_creditlist_id",
+            "amount", "receipt_date", "notes", "updated_by", "updation_date"]
+    });
+    return receiptsTxn;
+    },
+    deleteCreditReceiptById: (receiptId) => {
+    const receiptTxn = CashReceipts.destroy({ where: { treceipt_id: receiptId } });
+    return receiptTxn;
     },
     saveExpenses: async (data) => {
     const newExpenses = data.filter(e => !e.texpense_id);  // ✅ Will be empty array for UPDATE calls

--- a/db/credit-receipts.js
+++ b/db/credit-receipts.js
@@ -12,6 +12,10 @@ module.exports = function (sequelize, DataTypes) {
       receipt_no: DataTypes.INTEGER,
       creditlist_id: DataTypes.INTEGER,
       digital_creditlist_id: DataTypes.INTEGER,
+      closing_id: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+      },
       receipt_type: DataTypes.STRING,
       amount: DataTypes.DECIMAL,
       notes: DataTypes.STRING,

--- a/db/migrations/add-closing-id-to-receipts.sql
+++ b/db/migrations/add-closing-id-to-receipts.sql
@@ -1,0 +1,51 @@
+-- ============================================================
+-- Credit Receipts in Shift Closing: schema groundwork
+--
+-- Adds closing_id to t_receipts so a credit receipt (cash or
+-- digital) entered from the shift-closing "Collections" tab can
+-- be tied to the shift that recorded it. Nullable: rows created
+-- via the standalone /creditreceipts admin page are unaffected
+-- and keep closing_id = NULL.
+--
+-- Also creates t_receipts_deleted, the recycle-bin counterpart
+-- used by delete_closing/restore_closing (see
+-- add-receipts-to-delete-closing.sql and
+-- add-receipts-to-restore-closing.sql), mirroring the shape of
+-- t_credits_deleted / t_digital_sales_deleted.
+--
+-- Safe to re-run: uses IF NOT EXISTS guards throughout.
+-- ============================================================
+
+ALTER TABLE t_receipts
+    ADD COLUMN IF NOT EXISTS closing_id INT NULL
+        COMMENT 'FK to t_closing.closing_id; NULL for receipts entered outside a shift (admin Credit Receipts page).',
+    ADD INDEX IF NOT EXISTS idx_receipts_closing_id (closing_id);
+
+CREATE TABLE IF NOT EXISTS t_receipts_deleted (
+    treceipt_id             INT           NOT NULL,
+    receipt_no              INT           NULL,
+    creditlist_id           INT           NULL,
+    digital_creditlist_id   INT           NULL,
+    receipt_type            VARCHAR(45)   NULL,
+    amount                  DECIMAL(20,3) NULL,
+    notes                   VARCHAR(500)  NULL,
+    location_code           VARCHAR(50)   NULL,
+    closing_id              INT           NULL,
+    created_by              VARCHAR(45)   NULL,
+    updated_by              VARCHAR(45)   NULL,
+    creation_date           DATETIME      NULL,
+    updation_date           DATETIME      NULL,
+    receipt_date            DATETIME      NULL,
+    cashflow_date           DATETIME      NULL,
+    pending_cashflow_id     INT           NULL,
+    recon_match_id          BIGINT        NULL,
+    manual_recon_flag       TINYINT       NULL DEFAULT 0,
+    manual_recon_by         VARCHAR(50)   NULL,
+    manual_recon_date       DATETIME      NULL,
+    source_txn_id           INT           NULL,
+    source_split_id         INT           NULL,
+    deleted_by               VARCHAR(45)   NULL,
+    deleted_at                DATETIME      NULL,
+    PRIMARY KEY (treceipt_id),
+    KEY idx_receipts_deleted_closing_id (closing_id)
+);

--- a/db/migrations/add-receipts-to-delete-closing.sql
+++ b/db/migrations/add-receipts-to-delete-closing.sql
@@ -1,0 +1,280 @@
+-- ============================================================
+-- delete_closing: also archive/remove t_receipts rows
+--
+-- t_receipts gained a closing_id column (see
+-- add-closing-id-to-receipts.sql) once credit receipts could be
+-- entered from the shift-closing "Collections" tab. Without this
+-- change, deleting a draft closing would orphan its receipt rows
+-- instead of moving them to the recycle bin like every other
+-- child table.
+--
+-- Full re-declaration of delete_closing (based on
+-- fix-delete-closing-add-user-param.sql) with t_receipts handling
+-- added alongside the existing tables. Safe to re-run: uses
+-- DROP PROCEDURE IF EXISTS.
+-- ============================================================
+
+DELIMITER //
+
+DROP PROCEDURE IF EXISTS delete_closing //
+
+CREATE PROCEDURE delete_closing (
+    IN p_closing_id  INT,
+    IN p_deleted_by  VARCHAR(45)
+)
+BEGIN
+    DECLARE v_has_credit_bills INT DEFAULT 0;
+    DECLARE v_has_cash_bills   INT DEFAULT 0;
+    DECLARE v_total_bills      INT DEFAULT 0;
+    DECLARE v_error_message    VARCHAR(500);
+    DECLARE v_has_child_data   INT DEFAULT 0;
+    DECLARE v_deleted_by       VARCHAR(45);
+    DECLARE v_deletion_reason  TEXT DEFAULT NULL;
+
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    SET v_deleted_by = IFNULL(p_deleted_by, 'system');
+
+    START TRANSACTION;
+
+    -- Check if there are any credits with bills for this closing
+    SELECT COUNT(*) INTO v_has_credit_bills
+    FROM t_credits tc
+    INNER JOIN t_bills tb ON tc.bill_id = tb.bill_id
+    WHERE tc.closing_id = p_closing_id
+      AND tc.bill_id IS NOT NULL
+      AND tb.bill_status != 'CANCELLED';
+
+    -- Check if there are any cash sales with bills for this closing
+    SELECT COUNT(*) INTO v_has_cash_bills
+    FROM t_cashsales tcs
+    INNER JOIN t_bills tb ON tcs.bill_id = tb.bill_id
+    WHERE tcs.closing_id = p_closing_id
+      AND tcs.bill_id IS NOT NULL
+      AND tb.bill_status != 'CANCELLED';
+
+    SET v_total_bills = v_has_credit_bills + v_has_cash_bills;
+
+    -- If bills exist, raise an error and prevent deletion
+    IF v_total_bills > 0 THEN
+        SET v_error_message = CONCAT('Cannot delete closing_id ', p_closing_id,
+                                     '. Found ', v_total_bills,
+                                     ' record(s) with active bills (',
+                                     v_has_credit_bills, ' credit, ',
+                                     v_has_cash_bills, ' cash). ',
+                                     'Please remove or cancel the bills first.');
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = v_error_message;
+    END IF;
+
+    -- ============================================================
+    -- SMART RECYCLE BIN: Check if shift has any child data
+    -- ============================================================
+    SELECT (
+        (SELECT COUNT(*) FROM t_reading      WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_cashsales    WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_credits      WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_expense      WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_digital_sales WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_attendance   WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_denomination WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_2toil        WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_receipts     WHERE closing_id = p_closing_id)
+    ) INTO v_has_child_data;
+
+    -- ============================================================
+    -- Only move to recycle bin if there's actual child data
+    -- ============================================================
+    IF v_has_child_data > 0 THEN
+
+        -- 1. Move closing record to deleted table
+        INSERT INTO t_closing_deleted (
+            closing_id, closer_id, cashier_id, location_code, cash, ex_short,
+            closing_status, notes, created_by, updated_by, updation_date,
+            creation_date, closing_date, close_reading_time, cashflow_id,
+            deleted_by, deleted_at, deletion_reason
+        )
+        SELECT
+            closing_id, closer_id, cashier_id, location_code, cash, ex_short,
+            closing_status, notes, created_by, updated_by, updation_date,
+            creation_date, closing_date, close_reading_time, cashflow_id,
+            v_deleted_by, NOW(), v_deletion_reason
+        FROM t_closing
+        WHERE closing_id = p_closing_id;
+
+        -- 2. Move pump readings
+        IF EXISTS (SELECT 1 FROM t_reading WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_reading_deleted (
+                reading_id, closing_id, opening_reading, closing_reading, pump_id,
+                price, testing, created_by, updated_by, updation_date, creation_date,
+                deleted_by, deleted_at
+            )
+            SELECT
+                reading_id, closing_id, opening_reading, closing_reading, pump_id,
+                price, testing, created_by, updated_by, updation_date, creation_date,
+                v_deleted_by, NOW()
+            FROM t_reading
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 3. Move cash sales
+        IF EXISTS (SELECT 1 FROM t_cashsales WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_cashsales_deleted (
+                cashsales_id, closing_id, Bill_no, product_id, price, price_discount,
+                qty, notes, amount, created_by, updated_by, updation_date,
+                creation_date, bill_id, vehicle_number, odometer_reading,
+                deleted_by, deleted_at
+            )
+            SELECT
+                cashsales_id, closing_id, Bill_no, product_id, price, price_discount,
+                qty, notes, amount, created_by, updated_by, updation_date,
+                creation_date, bill_id, vehicle_number, odometer_reading,
+                v_deleted_by, NOW()
+            FROM t_cashsales
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 4. Move credit sales
+        IF EXISTS (SELECT 1 FROM t_credits WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_credits_deleted (
+                tcredit_id, closing_id, bill_no, creditlist_id, product_id,
+                price, price_discount, qty, amount, notes, created_by, updated_by,
+                updation_date, creation_date, vehicle_number, indent_number,
+                settlement_date, recon_id, bill_id, odometer_reading,
+                deleted_by, deleted_at
+            )
+            SELECT
+                tcredit_id, closing_id, bill_no, creditlist_id, product_id,
+                price, price_discount, qty, amount, notes, created_by, updated_by,
+                updation_date, creation_date, vehicle_number, indent_number,
+                settlement_date, recon_id, bill_id, odometer_reading,
+                v_deleted_by, NOW()
+            FROM t_credits
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 5. Move expenses
+        IF EXISTS (SELECT 1 FROM t_expense WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_expense_deleted (
+                texpense_id, closing_id, expense_id, amount, creditlist_id, notes,
+                created_by, updated_by, updation_date, creation_date,
+                deleted_by, deleted_at
+            )
+            SELECT
+                texpense_id, closing_id, expense_id, amount, creditlist_id, notes,
+                created_by, updated_by, updation_date, creation_date,
+                v_deleted_by, NOW()
+            FROM t_expense
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 6. Move digital sales
+        IF EXISTS (SELECT 1 FROM t_digital_sales WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_digital_sales_deleted (
+                digital_sales_id, closing_id, vendor_id, amount, transaction_date,
+                notes, created_by, updated_by, creation_date, updation_date,
+                deleted_by, deleted_at
+            )
+            SELECT
+                digital_sales_id, closing_id, vendor_id, amount, transaction_date,
+                notes, created_by, updated_by, creation_date, updation_date,
+                v_deleted_by, NOW()
+            FROM t_digital_sales
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 7. Move attendance
+        IF EXISTS (SELECT 1 FROM t_attendance WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_attendance_deleted (
+                tattendance_id, person_id, closing_id, shift_type, in_time, out_time,
+                notes, created_by, updated_by, updation_date, creation_date,
+                in_date, out_date,
+                deleted_by, deleted_at
+            )
+            SELECT
+                tattendance_id, person_id, closing_id, shift_type, in_time, out_time,
+                notes, created_by, updated_by, updation_date, creation_date,
+                in_date, out_date,
+                v_deleted_by, NOW()
+            FROM t_attendance
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 8. Move denominations
+        IF EXISTS (SELECT 1 FROM t_denomination WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_denomination_deleted (
+                denom_id, denomination, denomcount, closing_id, created_by, updated_by,
+                updation_date, creation_date,
+                deleted_by, deleted_at
+            )
+            SELECT
+                denom_id, denomination, denomcount, closing_id, created_by, updated_by,
+                updation_date, creation_date,
+                v_deleted_by, NOW()
+            FROM t_denomination
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 9. Move 2T oil sales
+        IF EXISTS (SELECT 1 FROM t_2toil WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_2toil_deleted (
+                oil_id, product_id, closing_id, price, given_qty, returned_qty,
+                created_by, updated_by, updation_date, creation_date,
+                deleted_by, deleted_at
+            )
+            SELECT
+                oil_id, product_id, closing_id, price, given_qty, returned_qty,
+                created_by, updated_by, updation_date, creation_date,
+                v_deleted_by, NOW()
+            FROM t_2toil
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 10. Move credit receipts (Collections tab)
+        IF EXISTS (SELECT 1 FROM t_receipts WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_receipts_deleted (
+                treceipt_id, receipt_no, creditlist_id, digital_creditlist_id,
+                receipt_type, amount, notes, location_code, closing_id,
+                created_by, updated_by, creation_date, updation_date, receipt_date,
+                cashflow_date, pending_cashflow_id, recon_match_id,
+                manual_recon_flag, manual_recon_by, manual_recon_date,
+                source_txn_id, source_split_id,
+                deleted_by, deleted_at
+            )
+            SELECT
+                treceipt_id, receipt_no, creditlist_id, digital_creditlist_id,
+                receipt_type, amount, notes, location_code, closing_id,
+                created_by, updated_by, creation_date, updation_date, receipt_date,
+                cashflow_date, pending_cashflow_id, recon_match_id,
+                manual_recon_flag, manual_recon_by, manual_recon_date,
+                source_txn_id, source_split_id,
+                v_deleted_by, NOW()
+            FROM t_receipts
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+    END IF;
+    -- If v_has_child_data = 0, skip recycle bin (just an empty header — hard delete)
+
+    -- ============================================================
+    -- Delete from original tables (either way)
+    -- ============================================================
+    DELETE FROM t_2toil          WHERE closing_id = p_closing_id;
+    DELETE FROM t_credits        WHERE closing_id = p_closing_id;
+    DELETE FROM t_digital_sales  WHERE closing_id = p_closing_id;
+    DELETE FROM t_denomination   WHERE closing_id = p_closing_id;
+    DELETE FROM t_expense        WHERE closing_id = p_closing_id;
+    DELETE FROM t_cashsales      WHERE closing_id = p_closing_id;
+    DELETE FROM t_reading        WHERE closing_id = p_closing_id;
+    DELETE FROM t_attendance     WHERE closing_id = p_closing_id;
+    DELETE FROM t_receipts       WHERE closing_id = p_closing_id;
+    DELETE FROM t_closing        WHERE closing_id = p_closing_id;
+
+    COMMIT;
+
+END //
+
+DELIMITER ;

--- a/db/migrations/add-receipts-to-restore-closing.sql
+++ b/db/migrations/add-receipts-to-restore-closing.sql
@@ -1,0 +1,235 @@
+-- ============================================================
+-- restore_closing: also restore t_receipts rows
+--
+-- Counterpart to add-receipts-to-delete-closing.sql — moves
+-- archived credit-receipt rows (Collections tab) back from
+-- t_receipts_deleted to t_receipts when a deleted draft closing
+-- is restored.
+--
+-- Full re-declaration of restore_closing (based on
+-- restore-closing-procedure.sql) with t_receipts handling added
+-- alongside the existing tables. Safe to re-run: uses
+-- DROP PROCEDURE IF EXISTS.
+-- ============================================================
+
+DELIMITER //
+
+DROP PROCEDURE IF EXISTS restore_closing //
+
+CREATE PROCEDURE restore_closing (
+    IN p_deleted_record_id INT,
+    IN p_restored_by       VARCHAR(45)
+)
+BEGIN
+    DECLARE v_closing_id          INT;
+    DECLARE v_location_code       VARCHAR(50);
+    DECLARE v_closing_date        TIMESTAMP;
+    DECLARE v_already_exists      INT DEFAULT 0;
+    DECLARE v_cashflow_closed     INT DEFAULT 0;
+
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    -- Resolve closing_id, location and date from the audit record
+    SELECT closing_id, location_code, closing_date
+    INTO v_closing_id, v_location_code, v_closing_date
+    FROM t_closing_deleted
+    WHERE deleted_record_id = p_deleted_record_id;
+
+    IF v_closing_id IS NULL THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'Deleted record not found. It may have already been restored or does not exist.';
+    END IF;
+
+    -- Guard: prevent restoring if closing_id already exists in live table
+    SELECT COUNT(*) INTO v_already_exists
+    FROM t_closing
+    WHERE closing_id = v_closing_id;
+
+    IF v_already_exists > 0 THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'Cannot restore — a shift with this closing_id already exists in the live table.';
+    END IF;
+
+    -- Guard: for cashflow-enabled locations, block restore if cashflow for
+    -- that date is already CLOSED (data would be orphaned outside the cashflow).
+    SELECT COUNT(*) INTO v_cashflow_closed
+    FROM t_cashflow_closing
+    WHERE location_code   = v_location_code
+      AND cashflow_date   = DATE(v_closing_date)
+      AND closing_status  = 'CLOSED';
+
+    IF v_cashflow_closed > 0 THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'Cannot restore — the cashflow for this shift\'s date is already closed. Reopen the cashflow first.';
+    END IF;
+
+    -- ── 1. Restore closing header ──────────────────────────────
+    INSERT INTO t_closing (
+        closing_id, closer_id, cashier_id, location_code, cash, ex_short,
+        closing_status, notes, created_by, updated_by, updation_date,
+        creation_date, closing_date, close_reading_time, cashflow_id
+        -- credit_billing_stopped omitted: defaults to 0
+    )
+    SELECT
+        closing_id, closer_id, cashier_id, location_code, cash, ex_short,
+        closing_status, notes, created_by, p_restored_by, NOW(),
+        creation_date, closing_date, close_reading_time, cashflow_id
+    FROM t_closing_deleted
+    WHERE deleted_record_id = p_deleted_record_id;
+
+    -- ── 2. Restore pump readings ───────────────────────────────
+    IF EXISTS (SELECT 1 FROM t_reading_deleted WHERE closing_id = v_closing_id) THEN
+        INSERT INTO t_reading (
+            reading_id, closing_id, opening_reading, closing_reading, pump_id,
+            price, testing, created_by, updated_by, updation_date, creation_date
+        )
+        SELECT
+            reading_id, closing_id, opening_reading, closing_reading, pump_id,
+            price, testing, created_by, p_restored_by, NOW(), creation_date
+        FROM t_reading_deleted
+        WHERE closing_id = v_closing_id;
+    END IF;
+
+    -- ── 3. Restore cash sales ──────────────────────────────────
+    IF EXISTS (SELECT 1 FROM t_cashsales_deleted WHERE closing_id = v_closing_id) THEN
+        INSERT INTO t_cashsales (
+            cashsales_id, closing_id, Bill_no, product_id, price, price_discount,
+            qty, notes, amount, created_by, updated_by, updation_date,
+            creation_date, bill_id, vehicle_number, odometer_reading
+        )
+        SELECT
+            cashsales_id, closing_id, Bill_no, product_id, price, price_discount,
+            qty, notes, amount, created_by, p_restored_by, NOW(),
+            creation_date, bill_id, vehicle_number, odometer_reading
+        FROM t_cashsales_deleted
+        WHERE closing_id = v_closing_id;
+    END IF;
+
+    -- ── 4. Restore credit sales ────────────────────────────────
+    IF EXISTS (SELECT 1 FROM t_credits_deleted WHERE closing_id = v_closing_id) THEN
+        INSERT INTO t_credits (
+            tcredit_id, closing_id, bill_no, creditlist_id, product_id,
+            price, price_discount, qty, amount, notes, created_by, updated_by,
+            updation_date, creation_date, vehicle_number, indent_number,
+            settlement_date, recon_id, bill_id, odometer_reading
+        )
+        SELECT
+            tcredit_id, closing_id, bill_no, creditlist_id, product_id,
+            price, price_discount, qty, amount, notes, created_by, p_restored_by,
+            NOW(), creation_date, vehicle_number, indent_number,
+            settlement_date, recon_id, bill_id, odometer_reading
+        FROM t_credits_deleted
+        WHERE closing_id = v_closing_id;
+    END IF;
+
+    -- ── 5. Restore expenses ────────────────────────────────────
+    IF EXISTS (SELECT 1 FROM t_expense_deleted WHERE closing_id = v_closing_id) THEN
+        INSERT INTO t_expense (
+            texpense_id, closing_id, expense_id, amount, creditlist_id, notes,
+            created_by, updated_by, updation_date, creation_date
+        )
+        SELECT
+            texpense_id, closing_id, expense_id, amount, creditlist_id, notes,
+            created_by, p_restored_by, NOW(), creation_date
+        FROM t_expense_deleted
+        WHERE closing_id = v_closing_id;
+    END IF;
+
+    -- ── 6. Restore digital sales ───────────────────────────────
+    IF EXISTS (SELECT 1 FROM t_digital_sales_deleted WHERE closing_id = v_closing_id) THEN
+        INSERT INTO t_digital_sales (
+            digital_sales_id, closing_id, vendor_id, amount, transaction_date,
+            notes, created_by, updated_by, creation_date, updation_date
+        )
+        SELECT
+            digital_sales_id, closing_id, vendor_id, amount, transaction_date,
+            notes, created_by, p_restored_by, creation_date, NOW()
+        FROM t_digital_sales_deleted
+        WHERE closing_id = v_closing_id;
+    END IF;
+
+    -- ── 7. Restore attendance ──────────────────────────────────
+    IF EXISTS (SELECT 1 FROM t_attendance_deleted WHERE closing_id = v_closing_id) THEN
+        INSERT INTO t_attendance (
+            tattendance_id, person_id, closing_id, shift_type, in_time, out_time,
+            notes, created_by, updated_by, updation_date, creation_date,
+            in_date, out_date
+        )
+        SELECT
+            tattendance_id, person_id, closing_id, shift_type, in_time, out_time,
+            notes, created_by, p_restored_by, NOW(), creation_date,
+            in_date, out_date
+        FROM t_attendance_deleted
+        WHERE closing_id = v_closing_id;
+    END IF;
+
+    -- ── 8. Restore denominations ───────────────────────────────
+    IF EXISTS (SELECT 1 FROM t_denomination_deleted WHERE closing_id = v_closing_id) THEN
+        INSERT INTO t_denomination (
+            denom_id, denomination, denomcount, closing_id, created_by, updated_by,
+            updation_date, creation_date
+        )
+        SELECT
+            denom_id, denomination, denomcount, closing_id, created_by, p_restored_by,
+            NOW(), creation_date
+        FROM t_denomination_deleted
+        WHERE closing_id = v_closing_id;
+    END IF;
+
+    -- ── 9. Restore 2T oil sales ────────────────────────────────
+    IF EXISTS (SELECT 1 FROM t_2toil_deleted WHERE closing_id = v_closing_id) THEN
+        INSERT INTO t_2toil (
+            oil_id, product_id, closing_id, price, given_qty, returned_qty,
+            created_by, updated_by, updation_date, creation_date
+        )
+        SELECT
+            oil_id, product_id, closing_id, price, given_qty, returned_qty,
+            created_by, p_restored_by, NOW(), creation_date
+        FROM t_2toil_deleted
+        WHERE closing_id = v_closing_id;
+    END IF;
+
+    -- ── 10. Restore credit receipts (Collections tab) ──────────
+    IF EXISTS (SELECT 1 FROM t_receipts_deleted WHERE closing_id = v_closing_id) THEN
+        INSERT INTO t_receipts (
+            treceipt_id, receipt_no, creditlist_id, digital_creditlist_id,
+            receipt_type, amount, notes, location_code, closing_id,
+            created_by, updated_by, creation_date, updation_date, receipt_date,
+            cashflow_date, pending_cashflow_id, recon_match_id,
+            manual_recon_flag, manual_recon_by, manual_recon_date,
+            source_txn_id, source_split_id
+        )
+        SELECT
+            treceipt_id, receipt_no, creditlist_id, digital_creditlist_id,
+            receipt_type, amount, notes, location_code, closing_id,
+            created_by, p_restored_by, creation_date, NOW(), receipt_date,
+            cashflow_date, pending_cashflow_id, recon_match_id,
+            manual_recon_flag, manual_recon_by, manual_recon_date,
+            source_txn_id, source_split_id
+        FROM t_receipts_deleted
+        WHERE closing_id = v_closing_id;
+    END IF;
+
+    -- ── Cleanup recycle bin ────────────────────────────────────
+    DELETE FROM t_reading_deleted      WHERE closing_id = v_closing_id;
+    DELETE FROM t_cashsales_deleted    WHERE closing_id = v_closing_id;
+    DELETE FROM t_credits_deleted      WHERE closing_id = v_closing_id;
+    DELETE FROM t_expense_deleted      WHERE closing_id = v_closing_id;
+    DELETE FROM t_digital_sales_deleted WHERE closing_id = v_closing_id;
+    DELETE FROM t_attendance_deleted   WHERE closing_id = v_closing_id;
+    DELETE FROM t_denomination_deleted WHERE closing_id = v_closing_id;
+    DELETE FROM t_2toil_deleted        WHERE closing_id = v_closing_id;
+    DELETE FROM t_receipts_deleted     WHERE closing_id = v_closing_id;
+    DELETE FROM t_closing_deleted      WHERE deleted_record_id = p_deleted_record_id;
+
+    COMMIT;
+
+END //
+
+DELIMITER ;

--- a/public/javascripts/app-scripts.js
+++ b/public/javascripts/app-scripts.js
@@ -1476,6 +1476,118 @@ function formDigitalSales(digitalSalesId, digitalSalesTag, saleObjRowNum, user) 
     };
 }
 
+// Toggle the digital-vendor cell in a Collections row based on the selected receipt type
+function toggleReceiptVendorCell(selectEl, rowNo) {
+    const vendorCell = document.getElementById('credit-receipts-vendor-cell-' + rowNo);
+    if (!vendorCell) {
+        return;
+    }
+    if (selectEl.value === 'Digital') {
+        vendorCell.style.display = '';
+    } else {
+        vendorCell.style.display = 'none';
+        const vendorField = document.getElementById('credit-receipts-vendor-' + rowNo);
+        if (vendorField) {
+            vendorField.value = '';
+        }
+    }
+}
+
+// Collections tab - add credit receipts to DB via ajax
+function saveCreditReceipts() {
+    return new Promise((resolve, reject) => {
+        const receiptTag = 'credit-receipts-';
+        const receiptRow = receiptTag + 'table-row-';
+        const tabToActivate = 'expenses_tab';
+        const currentTabId = 'new_credit_receipts';
+        const receiptObj = document.getElementById(currentTabId).querySelectorAll('[id^=' + receiptRow + ']:not([type="hidden"])');
+        let newReceipts = [], updateReceipts = [], newHiddenFieldsArr = [];
+        const user = JSON.parse(document.getElementById("user").value);
+        let hasValidationError = false;
+
+        receiptObj.forEach((receiptRowObj) => {
+            if (!receiptRowObj.className.includes('d-md-none')) {
+                const receiptObjRowNum = receiptRowObj.id.replace(receiptRow, '');
+                const typeField = document.getElementById(receiptTag + 'type-' + receiptObjRowNum);
+                const creditPartyField = document.getElementById(receiptTag + 'creditparty-' + receiptObjRowNum);
+                const vendorField = document.getElementById(receiptTag + 'vendor-' + receiptObjRowNum);
+                const amountField = document.getElementById(receiptTag + 'amt-' + receiptObjRowNum);
+                const dateField = document.getElementById(receiptTag + 'receipt-date-' + receiptObjRowNum);
+                const hiddenField = document.getElementById(receiptTag + receiptObjRowNum + '_hiddenId');
+
+                const hasCreditParty = creditPartyField.value;
+                const hasAmount = parseFloat(amountField.value) > 0;
+                const hasDate = dateField.value;
+                const isExistingRecord = hiddenField.value && parseInt(hiddenField.value) > 0;
+
+                if (hasCreditParty || hasAmount || hasDate || isExistingRecord) {
+
+                    if (!hasCreditParty) {
+                        alert('Please select a Credit Party for all Collections entries');
+                        hasValidationError = true;
+                        return;
+                    }
+
+                    if (typeField.value === 'Digital' && !vendorField.value) {
+                        alert('Please select a Digital Vendor for digital Collections entries');
+                        hasValidationError = true;
+                        return;
+                    }
+
+                    if (!hasAmount) {
+                        alert('Please enter an amount greater than 0 for all Collections entries');
+                        hasValidationError = true;
+                        return;
+                    }
+
+                    if (!hasDate) {
+                        alert('Please provide a receipt date for all Collections entries');
+                        hasValidationError = true;
+                        return;
+                    }
+
+                    if (isExistingRecord) {
+                        updateReceipts.push(formCreditReceipts(hiddenField.value, receiptTag, receiptObjRowNum, user));
+                    } else {
+                        newHiddenFieldsArr.push(receiptTag + receiptObjRowNum);
+                        newReceipts.push(formCreditReceipts(undefined, receiptTag, receiptObjRowNum, user));
+                    }
+                }
+            }
+        });
+
+        if (hasValidationError) {
+            resolve(false);
+            return;
+        }
+        postAjaxNew('new-credit-receipts', newReceipts, updateReceipts, tabToActivate, currentTabId, newHiddenFieldsArr, 'treceipt_id')
+            .then((data) => {
+                resolve(data);
+            });
+
+        if (newReceipts.length === 0 && updateReceipts.length === 0) {
+            resolve(true);      // tab click handled in trackMenu()
+        }
+    });
+}
+
+function formCreditReceipts(receiptId, receiptTag, receiptObjRowNum, user) {
+    const typeValue = document.getElementById(receiptTag + 'type-' + receiptObjRowNum).value;
+    return {
+        'treceipt_id': receiptId,
+        'closing_id': document.getElementById('closing_hiddenId').value,
+        'location_code': user.location_code,
+        'receipt_type': typeValue,
+        'creditlist_id': document.getElementById(receiptTag + 'creditparty-' + receiptObjRowNum).value,
+        'digital_creditlist_id': typeValue === 'Digital' ? document.getElementById(receiptTag + 'vendor-' + receiptObjRowNum).value : null,
+        'amount': document.getElementById(receiptTag + 'amt-' + receiptObjRowNum).value,
+        'receipt_date': document.getElementById(receiptTag + 'receipt-date-' + receiptObjRowNum).value,
+        'notes': document.getElementById(receiptTag + 'notes-' + receiptObjRowNum).value,
+        'created_by': user.User_Name,
+        'updated_by': user.User_Name
+    };
+}
+
 
 
 function getCreditType(creditSaleTag, creditObjRowNum) {
@@ -2856,6 +2968,14 @@ function showAddedDigitalSalesRow(prefix) {
 // (see credit-entry-modal.js) since the row stays off-screen until it's opened there.
 function showAddedCreditRow() {
     showAddedRow('credit', calculateCreditTotal);
+    applyCreditBillDateConstraints();
+}
+
+// Wrapper that calls the generic showAddedRow for the Collections table, then
+// re-applies the shared shift-scoped date constraints (receipt-date shares the
+// credit-bill-date class with the Credit tab's bill-date field).
+function showAddedCreditReceiptsRow() {
+    showAddedRow('credit-receipts', calculateCreditReceiptsTotal);
     applyCreditBillDateConstraints();
 }
 

--- a/public/javascripts/draft-edit-scripts.js
+++ b/public/javascripts/draft-edit-scripts.js
@@ -57,6 +57,10 @@ function calculateDigitalSalesTotal() {
     calculateTotal('digital-sales-');
 }
 
+function calculateCreditReceiptsTotal() {
+    calculateTotal('credit-receipts-');
+}
+
 function calculateExpenseTotal() {
     calculateTotal('exp-');
 }
@@ -77,6 +81,13 @@ function calculateDigitalSalesAndTrackMenu(obj) {
      setTimeout(() => {
         trackMenu(obj);
         calculateDigitalSalesTotal();
+    }, 100);
+}
+
+function calculateCreditReceiptsAndTrackMenu(obj) {
+     setTimeout(() => {
+        trackMenu(obj);
+        calculateCreditReceiptsTotal();
     }, 100);
 }
 
@@ -214,6 +225,7 @@ function getSaveFunction(clickedTab) {
             case 'cash_sales_tab':
             case 'credit_sales_tab':
             case 'digital_sales_tab':
+            case 'credit_receipts_tab':
             case 'closing_tab':
             case 'reading_tab':
             case 'sales_2t_tab':
@@ -245,7 +257,10 @@ function getSaveFunction(clickedTab) {
                 break;
             case 'digital_sales_tab':
                 saveFunctionName = 'saveDigitalSales';
-                break;    
+                break;
+            case 'credit_receipts_tab':
+                saveFunctionName = 'saveCreditReceipts';
+                break;
             case 'expenses_tab':
                 saveFunctionName = 'saveExpensesAndDenoms';
                 break;
@@ -302,6 +317,7 @@ function disableOtherTabs(tabName) {
             disableLink(document.getElementById('cash_sales_tab'));
             disableLink(document.getElementById('credit_sales_tab'));
             disableLink(document.getElementById('digital_sales_tab'));
+            disableLink(document.getElementById('credit_receipts_tab'));
             disableLink(document.getElementById('expenses_tab'));
             disableLink(document.getElementById('summary_tab'));
             disableLink(document.getElementById('attendance_tab'));
@@ -313,6 +329,7 @@ function disableOtherTabs(tabName) {
             disableLink(document.getElementById('cash_sales_tab'));
             disableLink(document.getElementById('credit_sales_tab'));
             disableLink(document.getElementById('digital_sales_tab'));
+            disableLink(document.getElementById('credit_receipts_tab'));
             disableLink(document.getElementById('summary_tab'));
             disableLink(document.getElementById('attendance_tab'));
             break;
@@ -331,6 +348,7 @@ function enableOtherTabs(tabName) {
             enableLink(document.getElementById('cash_sales_tab'));
             enableLink(document.getElementById('credit_sales_tab'));
             enableLink(document.getElementById('digital_sales_tab'));
+            enableLink(document.getElementById('credit_receipts_tab'));
             enableLink(document.getElementById('expenses_tab'));
             enableLink(document.getElementById('summary_tab'));
             enableLink(document.getElementById('attendance_tab'));
@@ -342,6 +360,7 @@ function enableOtherTabs(tabName) {
             enableLink(document.getElementById('cash_sales_tab'));
             enableLink(document.getElementById('credit_sales_tab'));
             enableLink(document.getElementById('digital_sales_tab'));
+            enableLink(document.getElementById('credit_receipts_tab'));
             enableLink(document.getElementById('summary_tab'));
             enableLink(document.getElementById('attendance_tab'));
             break;

--- a/views/edit-draft-closing.pug
+++ b/views/edit-draft-closing.pug
@@ -7,6 +7,7 @@ block content
     - var maxCashSalesRowCnt = config.maxCashSalesRowCnt;
     - var maxExpensesRowCnt = config.maxExpensesRowCnt;
     - var maxDigitalSalesRowCnt = config.maxDigitalSalesRowCnt;
+    - var maxCreditReceiptsRowCnt = config.maxCreditReceiptsRowCnt;
     - var currency = config.currency;
     - var denominationValues = config.denominationValues;
     - var denominationValuesJson = config.denominationValuesJson;
@@ -62,6 +63,9 @@ block content
                         a.nav-link#credit_sales_tab(data-toggle="tab" href="#new_credit_sales" onclick=`cashSaleOrCreditUpdateProductTypePrices(this, 'credit-')`) Credit Sales
                     li.nav-item.col-md
                         a.nav-link#digital_sales_tab(data-toggle="tab" href="#new_digital_sales" onclick=`calculateDigitalSalesAndTrackMenu(this)`) Digital Sales
+                    if allowCreditReceiptsInClosing
+                        li.nav-item.col-md
+                            a.nav-link#credit_receipts_tab(data-toggle="tab" href="#new_credit_receipts" onclick=`calculateCreditReceiptsAndTrackMenu(this)`) Collections
                     li.nav-item.col-md
                         a.nav-link#expenses_tab(data-toggle="tab" href="#new_expenses" onclick=`calculateExpensesAndDenoms(this)`) Expenses
                     if bowserValues && bowserValues.length > 0
@@ -88,6 +92,9 @@ block content
                         a.nav-link#credit_sales_tab(data-toggle="tab" href="#new_credit_sales" onclick=`cashSaleOrCreditUpdateProductTypePrices(this, 'credit-')`) Credit Sales
                     li.nav-item.col-md
                         a.nav-link#digital_sales_tab(data-toggle="tab" href="#new_digital_sales" onclick=`calculateDigitalSalesAndTrackMenu(this)`) Digital Sales
+                    if allowCreditReceiptsInClosing
+                        li.nav-item.col-md
+                            a.nav-link#credit_receipts_tab(data-toggle="tab" href="#new_credit_receipts") Collections
                     li.nav-item.col-md
                         a.nav-link#expenses_tab(data-toggle="tab" href="#new_expenses") Expenses
                     if bowserValues && bowserValues.length > 0
@@ -470,8 +477,49 @@ block content
                     div.row(align="center")
                         div.col
                             button.btn.btn-primary(type="button", onClick="trackMenuWithName('expenses_tab')") Next &raquo;
-                                
-                                
+
+                if allowCreditReceiptsInClosing
+                    // ----------------------- Credit receipts (Collections) details ----------------------------
+                    div.tab-pane.fade#new_credit_receipts(class= divDisableClass)
+                        div
+                            div.col-16
+                                div.table-responsive
+                                    table.table#credit-receipts-table
+                                        tbody.w-100
+                                            thead(class="thead-light")
+                                                tr
+                                                    th(scope="col") Type
+                                                    th(scope="col") Credit Party
+                                                    th(scope="col") Digital Vendor
+                                                    th(scope="col") Amount
+                                                    th(scope="col") Receipt Date
+                                                    th(scope="col") Notes
+                                                    if(!freezedRecord)
+                                                        th(scope="col")
+
+                                                - var rowCnt = 0
+                                                while rowCnt < maxCreditReceiptsRowCnt
+                                                    +addCreditReceipts(rowCnt, creditReceiptsData ? creditReceiptsData[rowCnt] : null)
+                                                    - rowCnt++
+                                            tr
+                                                td(colspan=3)
+                                                td Total
+                                                td
+                                                    input.form-control#credit-receipts-total(type='text' name='credit-receipts-total' readonly value='0')
+                                                td
+                                                td
+                        div.row
+                            div.col &nbsp;
+                        div.row
+                            div.col(align="center")
+                                button.btn.btn-info(type="button", onClick="showAddedCreditReceiptsRow()") Add Collection
+
+                        div.row
+                            div.col &nbsp;
+                        div.row(align="center")
+                            div.col
+                                button.btn.btn-primary(type="button", onClick="trackMenuWithName('expenses_tab')") Next &raquo;
+
                 // ----------------------- New expenses & denominations details ----------------------------
                 div.tab-pane.container.fade#new_expenses(class= divDisableClass)
                     div.row
@@ -695,6 +743,31 @@ block content
                                                                 b#val-intercompany-total 0.000
                                         else
                                             div.col-6
+                                    if allowCreditReceiptsInClosing
+                                        div.row
+                                            // Summary: Credit receipts (Collections)
+                                            div.col-6#v-credit-receipts
+                                                h6.sub-header Collections
+                                                div.table-responsive#vis-credit-receipts-table
+                                                    table.table.table-sm
+                                                        thead.thead-light
+                                                            tr
+                                                                th(scope="col") Type
+                                                                th(scope="col") Credit Party
+                                                                th(scope="col") Amount
+                                                                th(scope="col") Receipt Date
+                                                        - var rowCnt = 0
+                                                        - var maxCreditReceiptsRowCnt = config.maxCreditReceiptsRowCnt
+                                                        while rowCnt < maxCreditReceiptsRowCnt
+                                                            +summaryCreditReceiptsData(rowCnt++)
+                                                        tr
+                                                            td(colspan=2)
+                                                            td
+                                                                span
+                                                                    b Total
+                                                            td
+                                                                span
+                                                                    b#val-credit-receipts-total= 0
                                 div.row
                                     if show2TSalesTab
                                         // 2T loose details

--- a/views/mixins/new-closing-mixins.pug
+++ b/views/mixins/new-closing-mixins.pug
@@ -253,6 +253,58 @@ mixin addDigitalSales(digitalSalesRowNo, rowData)
                 button.close(type="button" aria-label="Close" onclick='hideRow(\'' + trId + '\',"remove-digital-sales", calculateDigitalSalesTotal)')
                     span(aria-hidden="true") &times;
 
+//- Collections tab: Dom elements to show a credit receipt (payment collected from a
+//- credit customer during the shift, Cash or Digital). Structurally mirrors
+//- addDigitalSales - plain row, no modal - since receipts don't need product/price fields.
+mixin addCreditReceipts(receiptRowNo, rowData)
+    - var prefix = 'credit-receipts-';
+    - var trId = prefix + 'table-row-'+receiptRowNo;
+    - var trClass = 'd-md-none';
+    if(!rowData)
+        - rowData = {amount:0, receiptDate: '', receiptType: 'Cash', creditPartyId: null, digitalVendorId: null, notes: ''};
+    if(rowData.receiptId && parseInt(rowData.receiptId) > 0)
+        - trClass = ''
+    - var vendorCellStyle = rowData.receiptType === 'Digital' ? '' : 'display:none'
+    tr(class=trClass id=trId)
+        input(type='hidden' id=prefix + receiptRowNo + '_hiddenId' value=rowData.receiptId)
+        td
+            select.form-control(name=prefix + 'type-' + receiptRowNo id=prefix + 'type-' + receiptRowNo required onchange='toggleReceiptVendorCell(this, ' + receiptRowNo + ')')
+                option(value='Cash' selected= rowData.receiptType === 'Cash') Cash
+                option(value='Digital' selected= rowData.receiptType === 'Digital') Digital
+        td
+            - var allReceiptCreditParties = [];
+            if creditCompanyValues
+                each val in creditCompanyValues
+                    if val.card_flag !== 'Y'
+                        - allReceiptCreditParties.push({creditorId: val.creditorId, creditorName: val.creditorName});
+            if suspenseValues
+                each val in suspenseValues
+                    if val.card_flag !== 'Y'
+                        - allReceiptCreditParties.push({creditorId: val.creditorId, creditorName: val.creditorName});
+            - allReceiptCreditParties.sort((a, b) => a.creditorName.localeCompare(b.creditorName));
+            select.form-control(name=prefix + 'creditparty-' + receiptRowNo id=prefix + 'creditparty-' + receiptRowNo required)
+                option(value='') Select Credit Party
+                each party in allReceiptCreditParties
+                    option(value=`${party.creditorId}` selected= rowData.creditPartyId === party.creditorId)= party.creditorName
+        td(id=prefix + 'vendor-cell-' + receiptRowNo style=vendorCellStyle)
+            select.form-control(name=prefix + 'vendor-' + receiptRowNo id=prefix + 'vendor-' + receiptRowNo)
+                option(value='') Select Digital Vendor
+                if creditCompanyValues
+                    each vendor in creditCompanyValues
+                        if vendor.card_flag === 'Y'
+                            option(value=`${vendor.creditorId}` selected= vendor.creditorId === rowData.digitalVendorId)= vendor.creditorName
+        td
+            input.form-control(type='number' name=prefix + 'amount-' + receiptRowNo id=prefix + 'amt-' + receiptRowNo min=0.01 step=0.01 required value=rowData.amount onchange='calculateCreditReceiptsTotal()' oninput='validity.valid||(value="")')
+        td
+            - var defaultReceiptDate = rowData.receiptDate || (typeof closingData !== 'undefined' ? closingData.closingDate : currentDate)
+            input.form-control.credit-bill-date(type='date' name=prefix + 'receipt-date-' + receiptRowNo id=prefix + 'receipt-date-' + receiptRowNo required value=defaultReceiptDate data-closing-date=(typeof closingData !== 'undefined' ? closingData.closingDate : currentDate))
+        td
+            textarea.form-control(name=prefix + 'notes-' + receiptRowNo id=prefix + 'notes-' + receiptRowNo style="height:36px")= rowData.notes
+        if(!freezedRecord)
+            td
+                button.close(type="button" aria-label="Close" onclick='hideRow(\'' + trId + '\',"remove-credit-receipt", calculateCreditReceiptsTotal)')
+                    span(aria-hidden="true") &times;
+
 //- Add new page: used by addCredits & addCashSales - a separate fn will populate product rates
 mixin optionsForProductRates(cashOrCreditSalePrefix)
     if productValues

--- a/views/mixins/summary-mixins.pug
+++ b/views/mixins/summary-mixins.pug
@@ -171,7 +171,21 @@ mixin summaryDigitalSalesData(digitalSaleRowNo)
             span(id='val-' + prefix + 'transaction-date-' + digitalSaleRowNo)
         td
             span(id='val-' + prefix + 'notes-' + digitalSaleRowNo)
-            
+
+//- Collections tab: Summary on credit receipts data
+mixin summaryCreditReceiptsData(receiptRowNo)
+    - var prefix = 'credit-receipts-';
+    - var trClass = 'd-md-none';
+    tr(class=trClass id='vis-' + prefix + 'table-row-' + receiptRowNo)
+        td
+            span(id='valText-' + prefix + 'type-' + receiptRowNo)
+        td
+            span(id='valText-' + prefix + 'creditparty-' + receiptRowNo)
+        td
+            span(id='val-' + prefix + 'amt-' + receiptRowNo)
+        td
+            span(id='val-' + prefix + 'receipt-date-' + receiptRowNo)
+
 //- Add new page: Summary on expenses data
 mixin showExpensesData(rowNo, val)
     - var trClass = 'd-md-none';

--- a/views/new-closing.pug
+++ b/views/new-closing.pug
@@ -8,6 +8,7 @@ block content
     - var maxCashSalesRowCnt = config.maxCashSalesRowCnt;
     - var maxExpensesRowCnt = config.maxExpensesRowCnt;
     - var maxDigitalSalesRowCnt = config.maxDigitalSalesRowCnt;
+    - var maxCreditReceiptsRowCnt = config.maxCreditReceiptsRowCnt;
     - var currency = config.currency;
     - var denominationValues = config.denominationValues;
     - var denominationValuesJson = config.denominationValuesJson;
@@ -31,8 +32,11 @@ block content
                     a.nav-link#cash_sales_tab(data-toggle="tab" href="#new_cash_sales" onclick=`cashSaleOrCreditUpdateProductTypePrices(this, 'cash-sale-')`) Lube Sales
                 li.nav-item.col-md
                     a.nav-link#credit_sales_tab(data-toggle="tab" href="#new_credit_sales" onclick=`cashSaleOrCreditUpdateProductTypePrices(this, 'credit-')`) Credit Sales
-                li.nav-item.col-md                    
+                li.nav-item.col-md
                     a.nav-link#digital_sales_tab(data-toggle="tab" href="#new_digital_sales" onclick=`calculateDigitalSalesAndTrackMenu(this)`) Digital Sales
+                if allowCreditReceiptsInClosing
+                    li.nav-item.col-md
+                        a.nav-link#credit_receipts_tab(data-toggle="tab" href="#new_credit_receipts" onclick=`calculateCreditReceiptsAndTrackMenu(this)`) Collections
                 li.nav-item.col-md
                     a.nav-link#expenses_tab(data-toggle="tab" href="#new_expenses" onclick=`trackMenu(this)`) Expenses
                 if bowserValues && bowserValues.length > 0
@@ -416,6 +420,46 @@ block content
                         div.col
                             button.btn.btn-primary(type="button", onClick="trackMenuWithName('expenses_tab')") Next &raquo;
 
+                if allowCreditReceiptsInClosing
+                    div.tab-pane.fade#new_credit_receipts
+                        div
+                            div.col-16
+                                div.table-responsive
+                                    table.table#credit-receipts-table
+                                        tbody.w-100
+                                            thead(class="thead-light")
+                                                tr
+                                                    th(scope="col") Type
+                                                    th(scope="col") Credit Party
+                                                    th(scope="col") Digital Vendor
+                                                    th(scope="col") Amount
+                                                    th(scope="col") Receipt Date
+                                                    th(scope="col") Notes
+                                                    th(scope="col")
+
+                                                - var rowCnt = 0
+                                                while rowCnt < maxCreditReceiptsRowCnt
+                                                    +addCreditReceipts(rowCnt++)
+                                            tr
+                                                td(colspan=3)
+                                                td Total
+                                                td
+                                                    input.form-control#credit-receipts-total(type='text' name='credit-receipts-total' readonly value='0')
+                                                td
+                                                td
+
+                        div.row
+                            div.col &nbsp;
+                        div.row
+                            div.col(align="center")
+                                button.btn.btn-info(type="button", onClick="showAddedCreditReceiptsRow()") Add Collection
+
+                        div.row
+                            div.col &nbsp;
+                        div.row(align="center")
+                            div.col
+                                button.btn.btn-primary(type="button", onClick="trackMenuWithName('expenses_tab')") Next &raquo;
+
                 // ----------------------- New expenses & denominations details ----------------------------
                 div.tab-pane.container.fade#new_expenses
                     div.row
@@ -623,6 +667,31 @@ block content
                                                             b#val-intercompany-total 0.000
                                     else
                                         div.col-6
+                                if allowCreditReceiptsInClosing
+                                    div.row
+                                        // Summary: Credit receipts (Collections)
+                                        div.col-6#v-credit-receipts
+                                            h6.sub-header Collections
+                                            div.table-responsive#vis-credit-receipts-table
+                                                table.table.table-sm
+                                                    thead.thead-light
+                                                        tr
+                                                            th(scope="col") Type
+                                                            th(scope="col") Credit Party
+                                                            th(scope="col") Amount
+                                                            th(scope="col") Receipt Date
+                                                    - var rowCnt = 0
+                                                    - var maxCreditReceiptsRowCnt = config.maxCreditReceiptsRowCnt
+                                                    while rowCnt < maxCreditReceiptsRowCnt
+                                                        +summaryCreditReceiptsData(rowCnt++)
+                                                    tr
+                                                        td(colspan=2)
+                                                        td
+                                                            span
+                                                                b Total
+                                                        td
+                                                            span
+                                                                b#val-credit-receipts-total= 0
                                 div.row
                                     if show2TSalesTab
                                         // 2T loose details


### PR DESCRIPTION
## Summary
- New "Collections" tab in shift closing (new-closing.pug / edit-draft-closing.pug) so cashiers can log a credit receipt (Cash or Digital) against a credit customer directly during their shift, instead of only via the standalone admin Credit Receipts page
- Gated behind `ALLOW_CREDIT_RECEIPTS_IN_CLOSING` location-config flag (default `N`) — built for Balaa Fuels, invisible everywhere else until enabled
- `t_receipts` gains a `closing_id` column; `delete_closing`/`restore_closing` procedures updated so deleting/restoring a draft shift correctly archives/restores receipts entered this way (SQL already run against dev by user)
- Admin Credit Receipts page now hides edit/delete for receipts owned by a shift (`closing_id IS NOT NULL`)

(Replaces #843 — that one was based on an older PetroMath_dev_new tip and hit a non-real conflict against PR #842's merge; this branch is cherry-picked cleanly onto the current tip.)

Note: the "Excess/Shortage" cash-reconciliation figure is computed by a DB-only stored function (`calculate_exshortage`) not tracked in this repo — wiring Cash-type receipts into that calculation is a separate follow-up once its current definition is available.

## Test plan
- [ ] Enable `ALLOW_CREDIT_RECEIPTS_IN_CLOSING=Y` for a test location
- [ ] New shift: Collections tab appears, add Cash + Digital rows, save, confirm persistence across tabs
- [ ] Reopen as draft: rows reload correctly, still editable
- [ ] Summary tab shows Collections total
- [ ] Delete draft shift: receipt rows archived to `t_receipts_deleted` and removed
- [ ] Restore deleted shift: receipt rows restored
- [ ] `/creditreceipts` admin page: shift-owned rows show read-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)