### PR TITLE
Fix Collections tab crash on draft shifts with existing receipts

### DIFF
--- a/dao/txn-read-dao.js
+++ b/dao/txn-read-dao.js
@@ -520,6 +520,11 @@ getMostRecentClosingDate: async (locationCode) => {
     },
     getReceiptsByClosingId: (closingId) => {
     return CashReceipts.findAll({
+        // receipt_date_fmt is declared on the model but is not a real column on
+        // t_receipts (existing queries against this model always scope attributes
+        // to avoid it) - must list attributes explicitly here too.
+        attributes: ['treceipt_id', 'receipt_type', 'creditlist_id', 'digital_creditlist_id',
+            'amount', 'receipt_date', 'notes', 'closing_id'],
         where: {'closing_id': closingId}
     });
     }


### PR DESCRIPTION
Fixes ER_BAD_FIELD_ERROR (Unknown column receipt_date_fmt) when opening a draft closing that already has a Collections-tab receipt. See commit message for root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)