### PR TITLE
Fix Collections tab column misalignment and summary date display

### DIFF
--- a/public/javascripts/app-scripts.js
+++ b/public/javascripts/app-scripts.js
@@ -849,7 +849,10 @@ function populateSummary(obj) {
                     } else {
                         labels[j].textContent = '';
                     }
-                } else {   
+                } else if (getValueFromLabelId.includes('credit-receipts-receipt-date-')) {
+                    const dateElement = document.getElementById(getValueFromLabelId);
+                    labels[j].textContent = formatDateDDMonYYYY(dateElement ? dateElement.value : '');
+                } else {
                     labels[j].textContent = document.getElementById(getValueFromLabelId) ? document.getElementById(getValueFromLabelId).value : "";
                 }
 
@@ -1476,20 +1479,28 @@ function formDigitalSales(digitalSalesId, digitalSalesTag, saleObjRowNum, user) 
     };
 }
 
-// Toggle the digital-vendor cell in a Collections row based on the selected receipt type
+// Format a yyyy-mm-dd date string as DD-MON-YYYY (project date display standard)
+function formatDateDDMonYYYY(isoDateStr) {
+    if (!isoDateStr) return '';
+    const d = new Date(isoDateStr + 'T00:00:00');
+    const day = String(d.getDate()).padStart(2, '0');
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    return `${day}-${months[d.getMonth()]}-${d.getFullYear()}`;
+}
+
+// Toggle the digital-vendor dropdown in a Collections row based on the selected receipt
+// type. Toggles the <select> itself (not its <td>) - hiding a td collapses the column
+// for that row and misaligns every cell after it with the header row.
 function toggleReceiptVendorCell(selectEl, rowNo) {
-    const vendorCell = document.getElementById('credit-receipts-vendor-cell-' + rowNo);
-    if (!vendorCell) {
+    const vendorField = document.getElementById('credit-receipts-vendor-' + rowNo);
+    if (!vendorField) {
         return;
     }
     if (selectEl.value === 'Digital') {
-        vendorCell.style.display = '';
+        vendorField.style.display = '';
     } else {
-        vendorCell.style.display = 'none';
-        const vendorField = document.getElementById('credit-receipts-vendor-' + rowNo);
-        if (vendorField) {
-            vendorField.value = '';
-        }
+        vendorField.style.display = 'none';
+        vendorField.value = '';
     }
 }
 

--- a/views/edit-draft-closing.pug
+++ b/views/edit-draft-closing.pug
@@ -752,10 +752,10 @@ block content
                                                     table.table.table-sm
                                                         thead.thead-light
                                                             tr
+                                                                th(scope="col") Receipt Date
                                                                 th(scope="col") Type
                                                                 th(scope="col") Credit Party
                                                                 th(scope="col") Amount
-                                                                th(scope="col") Receipt Date
                                                         - var rowCnt = 0
                                                         - var maxCreditReceiptsRowCnt = config.maxCreditReceiptsRowCnt
                                                         while rowCnt < maxCreditReceiptsRowCnt

--- a/views/mixins/new-closing-mixins.pug
+++ b/views/mixins/new-closing-mixins.pug
@@ -286,8 +286,8 @@ mixin addCreditReceipts(receiptRowNo, rowData)
                 option(value='') Select Credit Party
                 each party in allReceiptCreditParties
                     option(value=`${party.creditorId}` selected= rowData.creditPartyId === party.creditorId)= party.creditorName
-        td(id=prefix + 'vendor-cell-' + receiptRowNo style=vendorCellStyle)
-            select.form-control(name=prefix + 'vendor-' + receiptRowNo id=prefix + 'vendor-' + receiptRowNo)
+        td
+            select.form-control(name=prefix + 'vendor-' + receiptRowNo id=prefix + 'vendor-' + receiptRowNo style=vendorCellStyle)
                 option(value='') Select Digital Vendor
                 if creditCompanyValues
                     each vendor in creditCompanyValues

--- a/views/mixins/summary-mixins.pug
+++ b/views/mixins/summary-mixins.pug
@@ -178,13 +178,13 @@ mixin summaryCreditReceiptsData(receiptRowNo)
     - var trClass = 'd-md-none';
     tr(class=trClass id='vis-' + prefix + 'table-row-' + receiptRowNo)
         td
+            span(id='val-' + prefix + 'receipt-date-' + receiptRowNo)
+        td
             span(id='valText-' + prefix + 'type-' + receiptRowNo)
         td
             span(id='valText-' + prefix + 'creditparty-' + receiptRowNo)
         td
             span(id='val-' + prefix + 'amt-' + receiptRowNo)
-        td
-            span(id='val-' + prefix + 'receipt-date-' + receiptRowNo)
 
 //- Add new page: Summary on expenses data
 mixin showExpensesData(rowNo, val)

--- a/views/new-closing.pug
+++ b/views/new-closing.pug
@@ -676,10 +676,10 @@ block content
                                                 table.table.table-sm
                                                     thead.thead-light
                                                         tr
+                                                            th(scope="col") Receipt Date
                                                             th(scope="col") Type
                                                             th(scope="col") Credit Party
                                                             th(scope="col") Amount
-                                                            th(scope="col") Receipt Date
                                                     - var rowCnt = 0
                                                     - var maxCreditReceiptsRowCnt = config.maxCreditReceiptsRowCnt
                                                     while rowCnt < maxCreditReceiptsRowCnt


### PR DESCRIPTION
Fixes column misalignment on Cash-type rows (hidden td was collapsing the column instead of just the dropdown) and reorders/formats the Summary tab's Receipt Date column per the DD-MON-YYYY display standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)