### PR TITLE
Backfill two migration files already applied to dev/beta DB

### DIFF
--- a/db/migrations/add-cash-receipts-to-exshortage.sql
+++ b/db/migrations/add-cash-receipts-to-exshortage.sql
@@ -1,0 +1,135 @@
+-- ============================================================
+-- calculate_exshortage: account for Cash-type credit receipts
+-- entered from the shift-closing Collections tab
+--
+-- When a cashier collects a Cash-type receipt (a credit customer
+-- settling their outstanding balance in cash) and correctly counts
+-- it into their end-of-shift denominations, that cash was already
+-- flowing into `denomamt` (added) with nothing on the subtracted
+-- side to explain it - showing up as unexplained excess. This adds
+-- a new term, symmetric to amt/twotoilamt/cashasaleamt/
+-- closingcashgiven (all "explained cash" - subtracted), summing
+-- Cash-type t_receipts rows for the closing.
+--
+-- Digital-type receipts are intentionally excluded - same as
+-- Digital Sales, they have no live cash-reconciliation impact.
+--
+-- Backward compatible: COALESCE(...,0) means any closing with no
+-- Collections-tab receipts (i.e. every closing today, and every
+-- location that hasn't enabled ALLOW_CREDIT_RECEIPTS_IN_CLOSING)
+-- computes byte-for-byte the same result as before.
+--
+-- Full re-declaration, structurally identical to the existing
+-- function with one added SELECT INTO block and one added term in
+-- the final SET. Safe to re-run: uses DROP FUNCTION IF EXISTS.
+-- ============================================================
+
+DELIMITER $$
+
+DROP FUNCTION IF EXISTS CALCULATE_EXSHORTAGE$$
+
+CREATE FUNCTION `CALCULATE_EXSHORTAGE`(p_closing_id INT) RETURNS decimal(10,2)
+BEGIN
+    DECLARE amt                   DECIMAL(10,2);
+    DECLARE creditamt             DECIMAL(10,2);
+    DECLARE cashasaleamt          DECIMAL(10,2);
+    DECLARE pumpdiscountamt       DECIMAL(10,2);
+    DECLARE digitalsaleamt        DECIMAL(10,2);
+    DECLARE twotoilamt            DECIMAL(10,2);
+    DECLARE expenseamt            DECIMAL(10,2);
+    DECLARE denomamt              DECIMAL(10,2);
+    DECLARE closingcashgiven      DECIMAL(10,2);
+    DECLARE intercompanyamt       DECIMAL(10,2);
+    DECLARE creditreceiptcashamt  DECIMAL(10,2);
+    DECLARE ex_short_amt          DECIMAL(10,2);
+
+
+    SELECT COALESCE(SUM((closing_reading - opening_reading - testing) * price), 0)
+    INTO amt
+    FROM t_reading
+    WHERE closing_id = p_closing_id;
+
+
+    SELECT COALESCE(SUM(tc.price * tc.qty), 0) INTO creditamt
+    FROM t_credits tc
+    INNER JOIN m_product mp ON tc.product_id = mp.product_id
+    INNER JOIN (
+        SELECT DISTINCT mp2.product_code
+        FROM t_reading tr
+        INNER JOIN m_pump mp2 ON tr.pump_id = mp2.pump_id
+        WHERE tr.closing_id = p_closing_id
+    ) pump_products ON mp.product_name = pump_products.product_code
+    WHERE tc.closing_id = p_closing_id
+    AND COALESCE(tc.off_meter_sale, 0) = 0;
+
+
+    SELECT COALESCE(SUM((cs.price - cs.price_discount) * cs.qty), 0) INTO cashasaleamt
+    FROM t_cashsales cs
+    INNER JOIN m_product mp ON cs.product_id = mp.product_id
+    WHERE cs.closing_id = p_closing_id
+      AND mp.product_name NOT IN (
+          SELECT DISTINCT mp2.product_code
+          FROM t_reading tr
+          INNER JOIN m_pump mp2 ON tr.pump_id = mp2.pump_id
+          WHERE tr.closing_id = p_closing_id
+      );
+
+
+    SELECT COALESCE(SUM(cs.price_discount * cs.qty), 0) INTO pumpdiscountamt
+    FROM t_cashsales cs
+    INNER JOIN m_product mp ON cs.product_id = mp.product_id
+    WHERE cs.closing_id = p_closing_id
+      AND mp.product_name IN (
+          SELECT DISTINCT mp2.product_code
+          FROM t_reading tr
+          INNER JOIN m_pump mp2 ON tr.pump_id = mp2.pump_id
+          WHERE tr.closing_id = p_closing_id
+      );
+
+    SELECT COALESCE(SUM(price * (given_qty - returned_qty)), 0) INTO twotoilamt
+    FROM t_2toil WHERE closing_id = p_closing_id;
+
+    SELECT COALESCE(SUM(amount), 0) INTO expenseamt
+    FROM t_expense WHERE closing_id = p_closing_id;
+
+    SELECT COALESCE(SUM(IF(denomination = '0', 1, denomination) * denomcount), 0) INTO denomamt
+    FROM t_denomination WHERE closing_id = p_closing_id;
+
+    SELECT COALESCE(cash, 0) INTO closingcashgiven
+    FROM t_closing WHERE closing_id = p_closing_id;
+
+    SELECT COALESCE(SUM(amount), 0) INTO digitalsaleamt
+    FROM t_digital_sales WHERE closing_id = p_closing_id;
+
+
+
+    SELECT COALESCE(SUM(
+        tci.quantity * (
+            SELECT AVG(tr.price)
+            FROM t_reading tr
+            JOIN m_pump mp ON tr.pump_id = mp.pump_id
+            JOIN m_product mp2 ON mp.product_code = mp2.product_name
+            WHERE tr.closing_id = p_closing_id
+              AND mp2.product_id = tci.product_id
+        )
+    ), 0) INTO intercompanyamt
+    FROM t_closing_intercompany tci
+    WHERE tci.closing_id = p_closing_id;
+
+    -- Cash-type Collections-tab receipts: already-collected cash, explained
+    -- the same way amt/twotoilamt/cashasaleamt/closingcashgiven are.
+    SELECT COALESCE(SUM(amount), 0) INTO creditreceiptcashamt
+    FROM t_receipts
+    WHERE closing_id = p_closing_id
+      AND receipt_type = 'Cash';
+
+    SET ex_short_amt = COALESCE(expenseamt, 0) + COALESCE(denomamt, 0) + COALESCE(creditamt, 0)
+                     + COALESCE(digitalsaleamt, 0) + COALESCE(pumpdiscountamt, 0)
+                     + COALESCE(intercompanyamt, 0)
+                     - COALESCE(amt, 0) - COALESCE(twotoilamt, 0) - COALESCE(cashasaleamt, 0)
+                     - COALESCE(closingcashgiven, 0) - COALESCE(creditreceiptcashamt, 0);
+
+    RETURN ex_short_amt;
+END$$
+
+DELIMITER ;

--- a/db/migrations/add-cashflow-guard-to-delete-closing.sql
+++ b/db/migrations/add-cashflow-guard-to-delete-closing.sql
@@ -1,0 +1,301 @@
+-- ============================================================
+-- delete_closing: block deletion if a Collections-tab receipt on
+-- this shift is claimed by a cashflow
+--
+-- Reopening a CLOSED shift now releases any cashflow claim on its
+-- receipts (see reopenShift in dao/txn-write-dao.js). But a receipt
+-- can also get swept into a cashflow/day-close while its shift is
+-- still DRAFT and was never closed at all - generate_cashflow's
+-- cursor only checks the receipt's own receipt_date, not the
+-- originating shift's status. For that path there's no reopen event
+-- to trigger a release, so deleting such a shift directly must be
+-- blocked outright (matching the existing active-bills guard) rather
+-- than silently orphaning the t_cashflow_transaction row generated
+-- from it.
+--
+-- Full re-declaration of delete_closing (based on
+-- add-receipts-to-delete-closing.sql) with one added guard, placed
+-- alongside the existing bills check. Safe to re-run: uses
+-- DROP PROCEDURE IF EXISTS.
+-- ============================================================
+
+DELIMITER //
+
+DROP PROCEDURE IF EXISTS delete_closing //
+
+CREATE PROCEDURE delete_closing (
+    IN p_closing_id  INT,
+    IN p_deleted_by  VARCHAR(45)
+)
+BEGIN
+    DECLARE v_has_credit_bills    INT DEFAULT 0;
+    DECLARE v_has_cash_bills      INT DEFAULT 0;
+    DECLARE v_total_bills         INT DEFAULT 0;
+    DECLARE v_has_claimed_receipts INT DEFAULT 0;
+    DECLARE v_error_message       VARCHAR(500);
+    DECLARE v_has_child_data      INT DEFAULT 0;
+    DECLARE v_deleted_by          VARCHAR(45);
+    DECLARE v_deletion_reason     TEXT DEFAULT NULL;
+
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    SET v_deleted_by = IFNULL(p_deleted_by, 'system');
+
+    START TRANSACTION;
+
+    -- Check if there are any credits with bills for this closing
+    SELECT COUNT(*) INTO v_has_credit_bills
+    FROM t_credits tc
+    INNER JOIN t_bills tb ON tc.bill_id = tb.bill_id
+    WHERE tc.closing_id = p_closing_id
+      AND tc.bill_id IS NOT NULL
+      AND tb.bill_status != 'CANCELLED';
+
+    -- Check if there are any cash sales with bills for this closing
+    SELECT COUNT(*) INTO v_has_cash_bills
+    FROM t_cashsales tcs
+    INNER JOIN t_bills tb ON tcs.bill_id = tb.bill_id
+    WHERE tcs.closing_id = p_closing_id
+      AND tcs.bill_id IS NOT NULL
+      AND tb.bill_status != 'CANCELLED';
+
+    SET v_total_bills = v_has_credit_bills + v_has_cash_bills;
+
+    -- If bills exist, raise an error and prevent deletion
+    IF v_total_bills > 0 THEN
+        SET v_error_message = CONCAT('Cannot delete closing_id ', p_closing_id,
+                                     '. Found ', v_total_bills,
+                                     ' record(s) with active bills (',
+                                     v_has_credit_bills, ' credit, ',
+                                     v_has_cash_bills, ' cash). ',
+                                     'Please remove or cancel the bills first.');
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = v_error_message;
+    END IF;
+
+    -- If this shift has a Collections-tab receipt already claimed by a
+    -- cashflow/day-close, block deletion outright.
+    SELECT COUNT(*) INTO v_has_claimed_receipts
+    FROM t_receipts
+    WHERE closing_id = p_closing_id
+      AND (cashflow_date IS NOT NULL OR pending_cashflow_id IS NOT NULL);
+
+    IF v_has_claimed_receipts > 0 THEN
+        SET v_error_message = CONCAT('Cannot delete closing_id ', p_closing_id,
+                                     '. Found ', v_has_claimed_receipts,
+                                     ' Collections receipt(s) already claimed by a cashflow/day close. ',
+                                     'Resolve the cashflow first before deleting this shift.');
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = v_error_message;
+    END IF;
+
+    -- ============================================================
+    -- SMART RECYCLE BIN: Check if shift has any child data
+    -- ============================================================
+    SELECT (
+        (SELECT COUNT(*) FROM t_reading      WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_cashsales    WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_credits      WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_expense      WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_digital_sales WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_attendance   WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_denomination WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_2toil        WHERE closing_id = p_closing_id) +
+        (SELECT COUNT(*) FROM t_receipts     WHERE closing_id = p_closing_id)
+    ) INTO v_has_child_data;
+
+    -- ============================================================
+    -- Only move to recycle bin if there's actual child data
+    -- ============================================================
+    IF v_has_child_data > 0 THEN
+
+        -- 1. Move closing record to deleted table
+        INSERT INTO t_closing_deleted (
+            closing_id, closer_id, cashier_id, location_code, cash, ex_short,
+            closing_status, notes, created_by, updated_by, updation_date,
+            creation_date, closing_date, close_reading_time, cashflow_id,
+            deleted_by, deleted_at, deletion_reason
+        )
+        SELECT
+            closing_id, closer_id, cashier_id, location_code, cash, ex_short,
+            closing_status, notes, created_by, updated_by, updation_date,
+            creation_date, closing_date, close_reading_time, cashflow_id,
+            v_deleted_by, NOW(), v_deletion_reason
+        FROM t_closing
+        WHERE closing_id = p_closing_id;
+
+        -- 2. Move pump readings
+        IF EXISTS (SELECT 1 FROM t_reading WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_reading_deleted (
+                reading_id, closing_id, opening_reading, closing_reading, pump_id,
+                price, testing, created_by, updated_by, updation_date, creation_date,
+                deleted_by, deleted_at
+            )
+            SELECT
+                reading_id, closing_id, opening_reading, closing_reading, pump_id,
+                price, testing, created_by, updated_by, updation_date, creation_date,
+                v_deleted_by, NOW()
+            FROM t_reading
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 3. Move cash sales
+        IF EXISTS (SELECT 1 FROM t_cashsales WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_cashsales_deleted (
+                cashsales_id, closing_id, Bill_no, product_id, price, price_discount,
+                qty, notes, amount, created_by, updated_by, updation_date,
+                creation_date, bill_id, vehicle_number, odometer_reading,
+                deleted_by, deleted_at
+            )
+            SELECT
+                cashsales_id, closing_id, Bill_no, product_id, price, price_discount,
+                qty, notes, amount, created_by, updated_by, updation_date,
+                creation_date, bill_id, vehicle_number, odometer_reading,
+                v_deleted_by, NOW()
+            FROM t_cashsales
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 4. Move credit sales
+        IF EXISTS (SELECT 1 FROM t_credits WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_credits_deleted (
+                tcredit_id, closing_id, bill_no, creditlist_id, product_id,
+                price, price_discount, qty, amount, notes, created_by, updated_by,
+                updation_date, creation_date, vehicle_number, indent_number,
+                settlement_date, recon_id, bill_id, odometer_reading,
+                deleted_by, deleted_at
+            )
+            SELECT
+                tcredit_id, closing_id, bill_no, creditlist_id, product_id,
+                price, price_discount, qty, amount, notes, created_by, updated_by,
+                updation_date, creation_date, vehicle_number, indent_number,
+                settlement_date, recon_id, bill_id, odometer_reading,
+                v_deleted_by, NOW()
+            FROM t_credits
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 5. Move expenses
+        IF EXISTS (SELECT 1 FROM t_expense WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_expense_deleted (
+                texpense_id, closing_id, expense_id, amount, creditlist_id, notes,
+                created_by, updated_by, updation_date, creation_date,
+                deleted_by, deleted_at
+            )
+            SELECT
+                texpense_id, closing_id, expense_id, amount, creditlist_id, notes,
+                created_by, updated_by, updation_date, creation_date,
+                v_deleted_by, NOW()
+            FROM t_expense
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 6. Move digital sales
+        IF EXISTS (SELECT 1 FROM t_digital_sales WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_digital_sales_deleted (
+                digital_sales_id, closing_id, vendor_id, amount, transaction_date,
+                notes, created_by, updated_by, creation_date, updation_date,
+                deleted_by, deleted_at
+            )
+            SELECT
+                digital_sales_id, closing_id, vendor_id, amount, transaction_date,
+                notes, created_by, updated_by, creation_date, updation_date,
+                v_deleted_by, NOW()
+            FROM t_digital_sales
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 7. Move attendance
+        IF EXISTS (SELECT 1 FROM t_attendance WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_attendance_deleted (
+                tattendance_id, person_id, closing_id, shift_type, in_time, out_time,
+                notes, created_by, updated_by, updation_date, creation_date,
+                in_date, out_date,
+                deleted_by, deleted_at
+            )
+            SELECT
+                tattendance_id, person_id, closing_id, shift_type, in_time, out_time,
+                notes, created_by, updated_by, updation_date, creation_date,
+                in_date, out_date,
+                v_deleted_by, NOW()
+            FROM t_attendance
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 8. Move denominations
+        IF EXISTS (SELECT 1 FROM t_denomination WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_denomination_deleted (
+                denom_id, denomination, denomcount, closing_id, created_by, updated_by,
+                updation_date, creation_date,
+                deleted_by, deleted_at
+            )
+            SELECT
+                denom_id, denomination, denomcount, closing_id, created_by, updated_by,
+                updation_date, creation_date,
+                v_deleted_by, NOW()
+            FROM t_denomination
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 9. Move 2T oil sales
+        IF EXISTS (SELECT 1 FROM t_2toil WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_2toil_deleted (
+                oil_id, product_id, closing_id, price, given_qty, returned_qty,
+                created_by, updated_by, updation_date, creation_date,
+                deleted_by, deleted_at
+            )
+            SELECT
+                oil_id, product_id, closing_id, price, given_qty, returned_qty,
+                created_by, updated_by, updation_date, creation_date,
+                v_deleted_by, NOW()
+            FROM t_2toil
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+        -- 10. Move credit receipts (Collections tab)
+        IF EXISTS (SELECT 1 FROM t_receipts WHERE closing_id = p_closing_id) THEN
+            INSERT INTO t_receipts_deleted (
+                treceipt_id, receipt_no, creditlist_id, digital_creditlist_id,
+                receipt_type, amount, notes, location_code, closing_id,
+                created_by, updated_by, creation_date, updation_date, receipt_date,
+                cashflow_date, pending_cashflow_id, recon_match_id,
+                manual_recon_flag, manual_recon_by, manual_recon_date,
+                source_txn_id, source_split_id,
+                deleted_by, deleted_at
+            )
+            SELECT
+                treceipt_id, receipt_no, creditlist_id, digital_creditlist_id,
+                receipt_type, amount, notes, location_code, closing_id,
+                created_by, updated_by, creation_date, updation_date, receipt_date,
+                cashflow_date, pending_cashflow_id, recon_match_id,
+                manual_recon_flag, manual_recon_by, manual_recon_date,
+                source_txn_id, source_split_id,
+                v_deleted_by, NOW()
+            FROM t_receipts
+            WHERE closing_id = p_closing_id;
+        END IF;
+
+    END IF;
+    -- If v_has_child_data = 0, skip recycle bin (just an empty header — hard delete)
+
+    -- ============================================================
+    -- Delete from original tables (either way)
+    -- ============================================================
+    DELETE FROM t_2toil          WHERE closing_id = p_closing_id;
+    DELETE FROM t_credits        WHERE closing_id = p_closing_id;
+    DELETE FROM t_digital_sales  WHERE closing_id = p_closing_id;
+    DELETE FROM t_denomination   WHERE closing_id = p_closing_id;
+    DELETE FROM t_expense        WHERE closing_id = p_closing_id;
+    DELETE FROM t_cashsales      WHERE closing_id = p_closing_id;
+    DELETE FROM t_reading        WHERE closing_id = p_closing_id;
+    DELETE FROM t_attendance     WHERE closing_id = p_closing_id;
+    DELETE FROM t_receipts       WHERE closing_id = p_closing_id;
+    DELETE FROM t_closing        WHERE closing_id = p_closing_id;
+
+    COMMIT;
+
+END //
+
+DELIMITER ;


### PR DESCRIPTION
## Summary
Pure repo-hygiene fix: `add-cash-receipts-to-exshortage.sql` and `add-cashflow-guard-to-delete-closing.sql` landed on `master` via the cherry-picked prod-promotion PR #852, but the files themselves were never added back to this branch — even though the actual stored-procedure changes were already applied to the dev/beta DB at the time. No DB change here, just syncing the file tree.

After this merges, `master` and `PetroMath_dev_new` differ only by the credit-modal UI change (still in testing).

## Test plan
- [x] Diffed both files against master's copy — byte-identical
- N/A — no DB/app behavior change, files only