### PR TITLE
Credit sale modal: remove Odometer placeholder, make Company searchable

### DIFF
--- a/public/javascripts/credit-entry-modal.js
+++ b/public/javascripts/credit-entry-modal.js
@@ -75,6 +75,25 @@ function initVehicleSelect2ForModal(rowNo) {
     });
 }
 
+// Same lazy-init reasoning as the vehicle dropdown above, applied to the credit
+// party dropdown so Company is also type-to-search rather than a long scrolling list.
+function initCreditPartySelect2ForModal(rowNo) {
+    var select = document.getElementById('credit-creditparty-' + rowNo);
+    if (!select || typeof $ === 'undefined') return;
+    var $select = $(select);
+    if ($select.hasClass('select2-hidden-accessible')) {
+        $select.select2('destroy');
+    }
+    $select.select2({
+        placeholder: 'Search company...',
+        allowClear: true,
+        width: '100%',
+        minimumInputLength: 0,
+        theme: 'default',
+        dropdownParent: $('#creditEntryModal')
+    });
+}
+
 function findNextAvailableCreditRow() {
     var table = document.getElementById('credit-table');
     if (!table) return null;
@@ -115,6 +134,7 @@ function openCreditRowModal(rowNo, isNew) {
     moveCreditVehicleWrapToSlot(rowNo);
     moveCreditOffMeterToSlot(rowNo);
     initVehicleSelect2ForModal(rowNo);
+    initCreditPartySelect2ForModal(rowNo);
 }
 
 function saveCreditRowModal() {

--- a/views/mixins/new-closing-mixins.pug
+++ b/views/mixins/new-closing-mixins.pug
@@ -380,7 +380,7 @@ mixin addCredits(creditRowNo, rowData)
                     if val.card_flag !== 'Y'
                         - allCreditParties.push({creditorId: val.creditorId, creditorName: val.creditorName});
             - allCreditParties.sort((a, b) => a.creditorName.localeCompare(b.creditorName));
-            select.form-control(name=prefix + 'creditparty-' + creditRowNo id=prefix + 'creditparty-' + creditRowNo, onChange='updateCreditAndLoadVehicles(this, \'' + prefix + '\', ' + creditRowNo + ')')
+            select.form-control.select2-creditparty(name=prefix + 'creditparty-' + creditRowNo id=prefix + 'creditparty-' + creditRowNo, onChange='updateCreditAndLoadVehicles(this, \'' + prefix + '\', ' + creditRowNo + ')')
                 option(value='') Select Credit Party
                 each party in allCreditParties
                     option(value=`${party.creditorId}` selected= rowData.creditListId === party.creditorId)= party.creditorName
@@ -397,7 +397,7 @@ mixin addCredits(creditRowNo, rowData)
                     button.btn.btn-primary.btn-sm.flex-shrink-0(id=prefix + 'add-vehicle-btn-' + creditRowNo type='button' title='Add new vehicle' style=(rowData.creditListId ? '' : 'display:none') onclick='openAddVehicleModal(\'' + prefix + '\', ' + creditRowNo + ')')
                         | +
         td
-            input.form-control(type='number' name=prefix + 'odometer-' + creditRowNo id=prefix + 'odometer-' + creditRowNo min=0 oninput='validity.valid||(value="")' value=rowData.odometerReading step=0.01 placeholder='Odometer Reading')
+            input.form-control(type='number' name=prefix + 'odometer-' + creditRowNo id=prefix + 'odometer-' + creditRowNo min=0 oninput='validity.valid||(value="")' value=rowData.odometerReading step=0.01)
         td
             input.form-control(type='number' name=prefix + 'price-' + creditRowNo id=prefix + 'price-' + creditRowNo min=0 oninput='validity.valid||(value="")' value=rowData.price onchange='calculateCashOrCreditSale(\'' + prefix + '\', ' + creditRowNo + ')' step=0.01 readonly)
         td


### PR DESCRIPTION
## Summary
- Odometer field no longer shows the "Odometer Reading" placeholder text.
- Company (credit party) dropdown is now Select2-enabled in the credit-sale Add/Edit modal, matching the existing Vehicle Number field's search-as-you-type behavior.

## Test plan
- [ ] Open the credit-sale Add/Edit modal, confirm Odometer field starts blank with no placeholder
- [ ] Confirm typing in Company filters the dropdown