### PR TITLE
Revert Company Select2 in credit sale modal

### DIFF
--- a/public/javascripts/credit-entry-modal.js
+++ b/public/javascripts/credit-entry-modal.js
@@ -75,25 +75,6 @@ function initVehicleSelect2ForModal(rowNo) {
     });
 }
 
-// Same lazy-init reasoning as the vehicle dropdown above, applied to the credit
-// party dropdown so Company is also type-to-search rather than a long scrolling list.
-function initCreditPartySelect2ForModal(rowNo) {
-    var select = document.getElementById('credit-creditparty-' + rowNo);
-    if (!select || typeof $ === 'undefined') return;
-    var $select = $(select);
-    if ($select.hasClass('select2-hidden-accessible')) {
-        $select.select2('destroy');
-    }
-    $select.select2({
-        placeholder: 'Search company...',
-        allowClear: true,
-        width: '100%',
-        minimumInputLength: 0,
-        theme: 'default',
-        dropdownParent: $('#creditEntryModal')
-    });
-}
-
 function findNextAvailableCreditRow() {
     var table = document.getElementById('credit-table');
     if (!table) return null;
@@ -134,7 +115,6 @@ function openCreditRowModal(rowNo, isNew) {
     moveCreditVehicleWrapToSlot(rowNo);
     moveCreditOffMeterToSlot(rowNo);
     initVehicleSelect2ForModal(rowNo);
-    initCreditPartySelect2ForModal(rowNo);
 }
 
 function saveCreditRowModal() {

--- a/views/mixins/new-closing-mixins.pug
+++ b/views/mixins/new-closing-mixins.pug
@@ -380,7 +380,7 @@ mixin addCredits(creditRowNo, rowData)
                     if val.card_flag !== 'Y'
                         - allCreditParties.push({creditorId: val.creditorId, creditorName: val.creditorName});
             - allCreditParties.sort((a, b) => a.creditorName.localeCompare(b.creditorName));
-            select.form-control.select2-creditparty(name=prefix + 'creditparty-' + creditRowNo id=prefix + 'creditparty-' + creditRowNo, onChange='updateCreditAndLoadVehicles(this, \'' + prefix + '\', ' + creditRowNo + ')')
+            select.form-control(name=prefix + 'creditparty-' + creditRowNo id=prefix + 'creditparty-' + creditRowNo, onChange='updateCreditAndLoadVehicles(this, \'' + prefix + '\', ' + creditRowNo + ')')
                 option(value='') Select Credit Party
                 each party in allCreditParties
                     option(value=`${party.creditorId}` selected= rowData.creditListId === party.creditorId)= party.creditorName


### PR DESCRIPTION
## Summary
Reverts the Company-Select2 portion of #857 (Odometer placeholder removal stays). Root cause: Select2 on Company, combined with `updateCreditAndLoadVehicles()` directly manipulating the Vehicle `<select>`'s DOM while its own Select2 instance is live, caused selecting a company to close the entire Add/Edit Credit Sale modal. Company is back to a plain `<select>`; Vehicle's existing, unaffected Select2 search is untouched.

## Test plan
- [ ] Open Add Credit Sale, select a Company, confirm the modal stays open
- [ ] Confirm Vehicle search still works as before